### PR TITLE
fix(computer): resolveSpawn must prefer real .cmd over nvm-windows extensionless shim (#5)

### DIFF
--- a/server/src/__tests__/agents-computer-engine.test.ts
+++ b/server/src/__tests__/agents-computer-engine.test.ts
@@ -9,8 +9,9 @@ import { join } from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
 import { afterEach, test } from 'node:test'
 import assert from 'node:assert/strict'
-import { getAdapter } from '../agents/computer/engine.js'
+import { getAdapter, resolveSpawn } from '../agents/computer/engine.js'
 
+const IS_WIN = process.platform === 'win32'
 const tempDirs: string[] = []
 
 afterEach(async () => {
@@ -88,4 +89,30 @@ test('persistent Claude startup failure keeps stderr for first send', async () =
   assert.equal(logs[0], 'Claude Code error: subscription expired')
   assert.equal(logs.length, 2)
   assert.match(logs[1] ?? '', /\[session\] engine process died .*exit 1/)
-})
+  })
+
+  // Regression: nvm-windows on Windows ships an extensionless POSIX shell-shim
+  // (`#!/bin/sh` wrapper) alongside the real `.cmd`. The OLD resolveSpawn iterated
+  // `['', ...PATHEXT]` → matched the shim first → returned `shell:false` → Node
+  // could not exec the shim and every BYOA turn died with ENOENT.
+  // See https://github.com/yetone/cumora/issues/5
+  test('resolveSpawn prefers .cmd over extensionless shim on Windows', { skip: !IS_WIN }, async () => {
+    const root = await mkdtemp(join(tmpdir(), 'cumora-resolve-'))
+    tempDirs.push(root)
+    const binDir = join(root, 'bin')
+    await mkdir(binDir)
+    // Both files exist — mirrors the standard nvm-windows layout.
+    await writeFile(join(binDir, 'claude'), '#!/bin/sh\nexit 0\n', 'utf8')
+    await writeFile(join(binDir, 'claude.cmd'), '@echo off\nexit /b 0\n', 'utf8')
+    process.env.PATH = `${binDir};${process.env.PATH ?? ''}`
+    const r = resolveSpawn('claude')
+    // NTFS is case-insensitive, and Windows resolves `claude.cmd` as `claude.CMD`
+    // — compare with a normalized basename so the test passes regardless of FS.
+    assert.equal(
+      r.command.toLowerCase().endsWith('claude.cmd'),
+      true,
+      `must pick the .cmd, not the shim — got ${r.command}`,
+    )
+    assert.equal(r.shell, true, '.cmd must run via the shell')
+    assert.equal(r.wantsStdinPrompt, true, '.cmd needs the big prompt via stdin')
+  })

--- a/server/src/agents/computer/engine.ts
+++ b/server/src/agents/computer/engine.ts
@@ -48,21 +48,39 @@ const CODEX_LOG_RAW = process.env.CUMORA_CODEX_VERBOSE === '1'
  *    code 1". Resolve the real file on PATH and run a `.cmd`/`.bat` via
  *    shell:true. When the shell is needed,
  *    a big multi-line prompt must travel via STDIN, not argv (the shell can't carry
- *    it) → `wantsStdinPrompt`. */
-function resolveSpawn(bin: string): { command: string; shell: boolean; wantsStdinPrompt: boolean } {
+ *    it) → `wantsStdinPrompt`.
+ *
+ *  Windows + nvm-windows gotcha: global npm CLIs are shipped as an extensionless
+ *  POSIX shell-shim (`#!/bin/sh` wrapper) ALONGSIDE the real `.cmd`. The old loop
+ *  iterated `['', ...PATHEXT]`, hit the shim first, classified it as non-batch,
+ *  and returned `shell:false` → every Claude/Codex turn died with ENOENT.
+ *  Fix: prefer a real `.exe`/`.cmd`/`.bat` hit; only fall back to the shim with
+ *  `shell:true` when nothing else is on PATH. */
+// Exported for tests; the nvm-windows extensionless-shim regression (issue #5)
+// needs a stable handle to the resolver without going through spawn().
+export function resolveSpawn(bin: string): { command: string; shell: boolean; wantsStdinPrompt: boolean } {
   if (!IS_WIN) return { command: bin, shell: false, wantsStdinPrompt: false }
   const exts = (process.env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD').split(';').map((e) => e.trim()).filter(Boolean)
   for (const dir of (process.env.PATH ?? '').split(PATH_DELIMITER)) {
     if (!dir) continue
-    for (const ext of ['', ...exts]) {
+    for (const ext of exts) {
       const candidate = join(dir, bin + ext)
       if (existsSync(candidate)) {
         const isBatch = /\.(cmd|bat)$/i.test(candidate)
-        return { command: candidate, shell: isBatch, wantsStdinPrompt: isBatch }
+        return { command: candidate, shell: true, wantsStdinPrompt: isBatch }
       }
     }
   }
-  // Not found on PATH — let the shell resolve it, and feed the prompt via stdin.
+  // Last resort: only an extensionless shim (nvm-windows) is on PATH. The shim
+  // itself is a `#!/bin/sh` wrapper and cannot be exec'd without a shell → force
+  // shell:true so Node routes the call through cmd.exe, which can find the
+  // .cmd via PATHEXT after the shim.
+  for (const dir of (process.env.PATH ?? '').split(PATH_DELIMITER)) {
+    if (!dir) continue
+    const shim = join(dir, bin)
+    if (existsSync(shim)) return { command: shim, shell: true, wantsStdinPrompt: true }
+  }
+  // Not found on PATH at all — let the shell resolve it, and feed the prompt via stdin.
   return { command: bin, shell: true, wantsStdinPrompt: true }
 }
 


### PR DESCRIPTION
Closes yetone/cumora#5

## What

Fixes yetone/cumora#5 — on Windows + nvm-windows, every BYOA turn dies with `spawn C:\nvm4w\nodejs\claude ENOENT` and `cumora agent computer --doctor` reports all 6 probes failing.