### PR TITLE
fix(documents): don't treat intraword underscores as emphasis

### DIFF
--- a/server/src/__tests__/document-markdown.test.ts
+++ b/server/src/__tests__/document-markdown.test.ts
@@ -183,3 +183,56 @@ test('a pipe line without a separator stays a paragraph and does not hang', () =
   assert.deepEqual(nodes[0], { type: 'paragraph', content: [{ type: 'text', text: '| not a table |' }] })
   assert.deepEqual(nodes[1], { type: 'paragraph', content: [{ type: 'text', text: 'plain text' }] })
 })
+
+// ── intraword underscores ────────────────────────────────────────────────────
+// CommonMark allows intraword emphasis with `*` but not with `_`. Getting this
+// wrong doesn't just add a stray italic: the underscores are consumed as
+// delimiters and permanently lost from the stored document.
+
+test('parseInlineMarkdown keeps snake_case identifiers intact', () => {
+  assert.deepEqual(parseInlineMarkdown('call user_id and order_id now'), [
+    { type: 'text', text: 'call user_id and order_id now' },
+  ])
+})
+
+test('parseInlineMarkdown keeps underscores inside a URL intact', () => {
+  assert.deepEqual(parseInlineMarkdown('see https://x.com/a_b_c now'), [
+    { type: 'text', text: 'see https://x.com/a_b_c now' },
+  ])
+})
+
+test('parseInlineMarkdown does not treat intraword __ as bold', () => {
+  assert.deepEqual(parseInlineMarkdown('foo__bar__baz'), [
+    { type: 'text', text: 'foo__bar__baz' },
+  ])
+})
+
+test('parseInlineMarkdown still italicizes a word-boundary _span_', () => {
+  assert.deepEqual(parseInlineMarkdown('_leading italic_ ok'), [
+    { type: 'text', text: 'leading italic', marks: [{ type: 'italic' }] },
+    { type: 'text', text: ' ok' },
+  ])
+})
+
+test('parseInlineMarkdown still bolds a word-boundary __span__', () => {
+  assert.deepEqual(parseInlineMarkdown('__bold__ here'), [
+    { type: 'text', text: 'bold', marks: [{ type: 'bold' }] },
+    { type: 'text', text: ' here' },
+  ])
+})
+
+test('parseInlineMarkdown still allows intraword emphasis with *', () => {
+  // Only `_` is restricted — `*` intraword emphasis stays legal.
+  assert.deepEqual(parseInlineMarkdown('foo*bar*baz'), [
+    { type: 'text', text: 'foo' },
+    { type: 'text', text: 'bar', marks: [{ type: 'italic' }] },
+    { type: 'text', text: 'baz' },
+  ])
+})
+
+test('parseInlineMarkdown italicizes _a_b_ across an inner underscore', () => {
+  // The inner `_` is intraword so it cannot close; the trailing one does.
+  assert.deepEqual(parseInlineMarkdown('_a_b_'), [
+    { type: 'text', text: 'a_b', marks: [{ type: 'italic' }] },
+  ])
+})

--- a/server/src/documents/markdown.ts
+++ b/server/src/documents/markdown.ts
@@ -61,6 +61,42 @@ function findClosing(text: string, marker: string, from: number): number {
   return idx
 }
 
+// CommonMark allows intraword emphasis with `*` but NOT with `_`, because
+// underscores are load-bearing inside ordinary words: snake_case identifiers and
+// underscore-bearing URLs. Treating them as delimiters doesn't just add a stray
+// italic — it CONSUMES the underscores, so `user_id and order_id` is stored as
+// "user" + italic("id and order") + "id" and the characters are gone for good.
+const WORD_CHAR_RE = /[\p{L}\p{N}]/u
+
+function isWordChar(ch: string | undefined): boolean {
+  return ch !== undefined && WORD_CHAR_RE.test(ch)
+}
+
+/** Can a delimiter run starting at `i` OPEN an emphasis span? Only `_` is
+ *  restricted, and only inside a word — we look back past the whole run of
+ *  underscores so `foo__bar` is judged by the `o`, not by a sibling `_`. */
+function canOpenEmphasis(text: string, i: number): boolean {
+  if (text[i] !== '_') return true
+  let j = i - 1
+  while (j >= 0 && text[j] === '_') j -= 1
+  return !isWordChar(text[j])
+}
+
+/** Index of the delimiter that actually CLOSES an emphasis span, or -1.
+ *  A `_` run sitting inside a word can't close, so keep looking — that's what
+ *  lets `_a_b_` still italicize `a_b` the way CommonMark does. */
+function findEmphasisClose(text: string, marker: string, from: number): number {
+  if (marker[0] !== '_') return findClosing(text, marker, from)
+  let idx = text.indexOf(marker, from)
+  while (idx >= 0) {
+    let j = idx + marker.length
+    while (text[j] === '_') j += 1
+    if (!isWordChar(text[j])) return idx
+    idx = text.indexOf(marker, idx + marker.length)
+  }
+  return -1
+}
+
 function findLinkClose(text: string, openBracket: number): { closeParen: number; label: string; href: string } | null {
   const closeBracket = text.indexOf(']', openBracket + 1)
   if (closeBracket < 0 || text[closeBracket + 1] !== '(') return null
@@ -87,9 +123,9 @@ export function parseInlineMarkdown(text: string, marks?: ProseMirrorJsonMark[])
         continue
       }
     }
-    if (text.startsWith('**', i) || text.startsWith('__', i)) {
+    if ((text.startsWith('**', i) || text.startsWith('__', i)) && canOpenEmphasis(text, i)) {
       const marker = text.slice(i, i + 2)
-      const end = findClosing(text, marker, i + 2)
+      const end = findEmphasisClose(text, marker, i + 2)
       if (end > i + 2) {
         out.push(...parseInlineMarkdown(text.slice(i + 2, end), withMark(marks, { type: 'bold' })))
         i = end + 2
@@ -104,9 +140,9 @@ export function parseInlineMarkdown(text: string, marks?: ProseMirrorJsonMark[])
         continue
       }
     }
-    if ((text[i] === '*' || text[i] === '_') && text[i + 1] !== text[i]) {
+    if ((text[i] === '*' || text[i] === '_') && text[i + 1] !== text[i] && canOpenEmphasis(text, i)) {
       const marker = text[i]
-      const end = findClosing(text, marker, i + 1)
+      const end = findEmphasisClose(text, marker, i + 1)
       if (end > i + 1) {
         out.push(...parseInlineMarkdown(text.slice(i + 1, end), withMark(marks, { type: 'italic' })))
         i = end + 1


### PR DESCRIPTION
## The bug

CommonMark allows intraword emphasis with `*` but **not** with `_`, because underscores are load-bearing inside ordinary words. `parseInlineMarkdown` applied no such rule.

The damage isn't a stray italic — the underscores are **consumed as delimiters**, so the characters are gone from the stored document:

```
"call user_id and order_id now"
  → "call user" + italic("id and order") + "id now"

"see https://x.com/a_b_c now"
  → "see https://x.com/a" + italic("b") + "c now"
```

Any `snake_case` identifier pair or underscore-bearing URL an agent writes into a shared doc is silently corrupted. The italic is at least visible; the missing underscores are not, and a broken link isn't something the reader can repair by hand.

This is reachable from every markdown → document path (`markdownToProseMirrorContent`, `markdownToYXml`), which is how agent-authored content lands in docs.

## The fix

Restrict `_`/`__` to word boundaries, with two details that matter:

- **Look past the whole delimiter run** when judging an opener, so `foo__bar__baz` is judged by the `o` and not by a sibling `_`. Checking only the immediately preceding character leaves `foo__bar__baz` half-parsed.
- **Skip closers that sit inside a word** rather than giving up at the first candidate. That is what still lets `_a_b_` italicize `a_b`, matching CommonMark.

`*`/`**` are deliberately untouched — intraword `foo*bar*baz` keeps working.

## Tests

7 cases added to `server/src/__tests__/document-markdown.test.ts`, covering both directions.

Verified they are real regression tests: against the previous parser exactly the corruption cases fail, while the "still emphasizes" cases pass on both old and new code — so the fix removes the corruption without weakening legitimate emphasis.

```
not ok  9 - parseInlineMarkdown keeps snake_case identifiers intact
not ok 10 - parseInlineMarkdown keeps underscores inside a URL intact
not ok 11 - parseInlineMarkdown does not treat intraword __ as bold
not ok 15 - parseInlineMarkdown italicizes _a_b_ across an inner underscore
# tests 15 | pass 11 | fail 4
```

With the fix: 15/15 pass.

## Checks

`npm run lint`, `npm run typecheck`, `npm run server:typecheck` pass.

My sandbox has no Postgres/Redis/`OPENAI_API_KEY`, so 18 files in the server unit suite fail on env alone. I diffed the failure set with and without this change — identical, no regressions.
