### PR TITLE
fix(agents): stop dropping and mangling `cumora reply --file` bodies

### DIFF
--- a/server/src/__tests__/agents-cli-parse.test.ts
+++ b/server/src/__tests__/agents-cli-parse.test.ts
@@ -13,7 +13,7 @@
  */
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { parseArgs, tokenize, unescapeChat } from '../agents/cli-parse.js'
+import { joinBodyArgs, parseArgs, tokenize, unescapeChat } from '../agents/cli-parse.js'
 
 // ── parseArgs — happy paths ──────────────────────────────────────────────
 
@@ -103,15 +103,13 @@ test('parseArgs: single dash stays positional; triple dash IS parsed as a flag (
   assert.deepEqual(r.flags, { '-weird': true })
 })
 
-test('parseArgs: bare `--` is parsed as a zero-length-key boolean flag', () => {
-  // POSIX-ish convention would treat `--` as "end of flags". We don't
-  // — `args[0].startsWith('--')` is true, key = ''.  Lock in current
-  // behaviour; no caller depends on `--` either way today.
+test('parseArgs: bare `--` ends flag parsing (POSIX end-of-flags)', () => {
+  // This used to parse as a zero-length-key flag (`flags[''] = <next token>`),
+  // which swallowed the token after it. The BYOA shim now uses `--` to hand
+  // over --file/--stdin content, so the POSIX meaning is the one that counts.
   const r = parseArgs(['--', 'positional-arg'])
-  // Current behaviour: key = '' (empty string), value comes from next
-  // non-`--` token. So flags[''] = 'positional-arg'.
-  assert.equal(r.flags[''], 'positional-arg')
-  assert.deepEqual(r.positional, [])
+  assert.equal(r.flags[''], undefined)
+  assert.deepEqual(r.positional, ['positional-arg'])
 })
 
 test('parseArgs: --key value where value contains spaces is fine — argv is already split', () => {
@@ -247,4 +245,63 @@ test('tokenize: unterminated quote consumes everything to EOL into one token', (
 
 test('tokenize: tab separator behaves like a space', () => {
   assert.deepEqual(tokenize('a\tb\tc'), ['a', 'b', 'c'])
+})
+
+// ── `--` end-of-flags (the BYOA --file / --stdin body path) ──────────────────
+// The shim reads --file/--stdin content locally and appends it after a POSIX
+// `--`. Before that marker existed the content was spliced in as a plain
+// positional, so a body starting with `---` parsed as a flag and the reply was
+// silently never posted.
+
+test('parseArgs: `--` ends flag parsing; a `--`-leading body stays positional', () => {
+  const r = parseArgs(['convo-1', '--', '--- a/src/foo.ts\n+++ b/src/foo.ts'])
+  assert.deepEqual(r.positional, ['convo-1', '--- a/src/foo.ts\n+++ b/src/foo.ts'])
+  assert.deepEqual(r.flags, {})
+  assert.equal(r.literalFrom, 1)
+})
+
+test('parseArgs: flags BEFORE `--` are still parsed', () => {
+  // Real shape: cumora reply <convo> --quote <id> -- <file body>
+  const r = parseArgs(['convo-1', '--quote', 'm-abc', '--', '---\ntitle: Status\n---'])
+  assert.deepEqual(r.positional, ['convo-1', '---\ntitle: Status\n---'])
+  assert.deepEqual(r.flags, { quote: 'm-abc' })
+  assert.equal(r.literalFrom, 1)
+})
+
+test('parseArgs: a flag-looking token AFTER `--` is not a flag', () => {
+  const r = parseArgs(['convo-1', '--', '--json'])
+  assert.deepEqual(r.positional, ['convo-1', '--json'])
+  assert.deepEqual(r.flags, {})
+})
+
+test('parseArgs: no `--` leaves literalFrom undefined', () => {
+  const r = parseArgs(['convo-1', 'hello'])
+  assert.equal(r.literalFrom, undefined)
+})
+
+// ── joinBodyArgs ─────────────────────────────────────────────────────────────
+
+test('joinBodyArgs: a shell-quoted body still gets escapes expanded', () => {
+  // The bash tool wraps the body in single quotes, so `\n` arrives literal.
+  const r = parseArgs(['convo-1', 'line one\\nline two'])
+  assert.equal(joinBodyArgs(r, 1), 'line one\nline two')
+})
+
+test('joinBodyArgs: a body after `--` is taken verbatim, escapes intact', () => {
+  // --file content never passed through a shell; expanding `\n` here would
+  // break the code snippets that flag exists to carry.
+  const src = 'console.log("a\\nb");'
+  const r = parseArgs(['convo-1', '--', src])
+  assert.equal(joinBodyArgs(r, 1), src)
+})
+
+test('joinBodyArgs: a verbatim body keeps Windows-style backslashes', () => {
+  const src = 'see C:\\\\Users\\\\dev for the build'
+  const r = parseArgs(['convo-1', '--', src])
+  assert.equal(joinBodyArgs(r, 1), src)
+})
+
+test('joinBodyArgs: joins multiple shell positionals with a space', () => {
+  const r = parseArgs(['convo-1', 'hello', 'world'])
+  assert.equal(joinBodyArgs(r, 1), 'hello world')
 })

--- a/server/src/agents/cli-parse.ts
+++ b/server/src/agents/cli-parse.ts
@@ -16,6 +16,12 @@
 export interface ParsedArgs {
   positional: string[]
   flags: Record<string, string | boolean>
+  /** Index into `positional` at which LITERAL args begin — everything the
+   *  caller placed after a POSIX `--` end-of-flags marker. The BYOA shim puts
+   *  `--file` / `--stdin` content there, so those args must be taken exactly as
+   *  they arrived: not re-read as flags, and not escape-expanded. Absent when
+   *  no `--` was present. */
+  literalFrom?: number
 }
 
 /**
@@ -31,12 +37,23 @@ export interface ParsedArgs {
  * what the bash tool / CLI shim assumes.
  *
  * Anything not starting with `--` lands in `positional`.
+ *
+ * A bare `--` is the POSIX end-of-flags marker: every remaining token is a
+ * positional even if it starts with `--`. The BYOA shim uses it to hand over
+ * `--file` / `--stdin` content, which routinely begins with `---` (a markdown
+ * rule, a YAML front-matter fence, a `--- a/file.ts` diff header).
  */
 export function parseArgs(args: string[]): ParsedArgs {
   const positional: string[] = []
   const flags: Record<string, string | boolean> = {}
+  let literalFrom: number | undefined
   for (let i = 0; i < args.length; i++) {
     const a = args[i]
+    if (a === '--') {
+      literalFrom = positional.length
+      for (let j = i + 1; j < args.length; j++) positional.push(args[j])
+      break
+    }
     if (a.startsWith('--')) {
       const key = a.slice(2)
       const eq = key.indexOf('=')
@@ -55,7 +72,28 @@ export function parseArgs(args: string[]): ParsedArgs {
       positional.push(a)
     }
   }
-  return { positional, flags }
+  // Only carry `literalFrom` when a `--` was actually seen, so the parsed shape
+  // is byte-for-byte what it always was for every existing call.
+  return literalFrom === undefined ? { positional, flags } : { positional, flags, literalFrom }
+}
+
+/**
+ * Join the positional args from `start` onward into one body string.
+ *
+ * Args that came through a shell get `unescapeChat` (the bash tool wraps a
+ * body in single quotes, so `\n` arrives as two literal characters). Args
+ * after a POSIX `--` do NOT: the shim reads `--file` / `--stdin` content
+ * locally and it travels as JSON, never touched by a shell — that is the whole
+ * point of those flags. Re-expanding escapes there would corrupt exactly the
+ * code snippets the file path exists to carry verbatim, turning a `\n` inside
+ * a string literal into a real line break.
+ */
+export function joinBodyArgs(parsed: ParsedArgs, start: number): string {
+  const literalFrom = parsed.literalFrom ?? parsed.positional.length
+  return parsed.positional
+    .slice(start)
+    .map((part, i) => (start + i >= literalFrom ? part : unescapeChat(part)))
+    .join(' ')
 }
 
 /**

--- a/server/src/agents/cli.ts
+++ b/server/src/agents/cli.ts
@@ -46,7 +46,7 @@ async function agentCompany(agentId: string): Promise<string | null> {
 
 /* ============== argv parsing ============== */
 
-import { parseArgs, unescapeChat, tokenize, type ParsedArgs } from './cli-parse.js'
+import { parseArgs, unescapeChat, joinBodyArgs, tokenize, type ParsedArgs } from './cli-parse.js'
 export { tokenize }
 
 // resolveAs lives in ./cli-identity for test-isolation (zero-side-effect
@@ -1506,7 +1506,7 @@ async function cmdReply(parsed: ParsedArgs): Promise<CliResult> {
   const me = resolveAs(parsed)
   const convoId = parsed.positional[0]
   // Strip any hallucinated <tool_call> XML on the way in too — defense in depth.
-  const body = unescapeChat(parsed.positional.slice(1).join(' '))
+  const body = joinBodyArgs(parsed, 1)
     .replace(/<tool_call>[\s\S]*?<\/tool_call>/gi, '')
     .replace(/<function_call>[\s\S]*?<\/function_call>/gi, '')
     .trim()

--- a/server/src/agents/computer/daemon.ts
+++ b/server/src/agents/computer/daemon.ts
@@ -535,20 +535,27 @@ const CUMORA_SHIM = `#!/usr/bin/env node
   // is mangled by bash BEFORE this shim runs: backticks and $(...) get run as
   // commands and collapse to empty, quotes get eaten. So --file <path> /
   // --stdin let the body come from a file (written by the editor, no shell) or
-  // a pipe; we read it LOCALLY and splice it in as one argument that travels as
+  // a pipe; we read it LOCALLY and pass it as one argument that travels as
   // JSON and is never re-parsed by a shell, so code/quotes/$ survive verbatim.
+  //
+  // It goes LAST, behind a POSIX \`--\`, so the server takes it literally. Spliced
+  // in place it was still read as argv: a body starting with \`---\` (markdown
+  // rule, front-matter fence, diff header) parsed as a FLAG and the message was
+  // silently dropped, and escapes inside it were expanded a second time.
   var fs = require('fs')
+  var body = null
   var fi = argv.indexOf('--file')
   if (fi >= 0 && argv[fi + 1] !== undefined) {
-    try { argv.splice(fi, 2, fs.readFileSync(argv[fi + 1], 'utf8')) }
+    try { body = fs.readFileSync(argv[fi + 1], 'utf8') }
     catch (e) { console.error('cumora: cannot read --file ' + argv[fi + 1]); process.exit(70) }
+    argv.splice(fi, 2)
   }
   var si = argv.indexOf('--stdin')
   if (si >= 0) {
-    var s = ''
-    try { s = fs.readFileSync(0, 'utf8') } catch (e) {}
-    argv.splice(si, 1, s)
+    argv.splice(si, 1)
+    if (body === null) { try { body = fs.readFileSync(0, 'utf8') } catch (e) { body = '' } }
   }
+  if (body !== null) argv.push('--', body)
   const res = await fetch(url + '/cli', {
     method: 'POST',
     headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json' },


### PR DESCRIPTION
## The promise

`--file` / `--stdin` exist so a body that was **never shell-quoted** reaches Cumora verbatim. The shim's own comment says so:

> we read it LOCALLY and splice it in as one argument that travels as JSON and is never re-parsed by a shell, so code/quotes/`$` survive verbatim.

And the persona the daemon writes into every BYOA agent's home actively steers agents onto that path:

> for anything with backticks, code, `$`, quotes, or newlines, write it to a file and use `cumora reply <conversationId> --file <path>`

Two bugs broke the promise, both because the content was spliced into argv as an ordinary positional.

## Bug 1 — the message is silently never posted

`parseArgs` classifies any token starting with `--` as a flag. A body that opens with a markdown rule (`---`), a YAML front-matter fence, or a diff header (`--- a/src/foo.ts`) therefore never reaches `cmdReply`'s `positional.slice(1)`:

```
argv:  ['--as','iris','reply','convo-1','--- a/src/foo.ts\n+++ b/…']
parse: positional = ['convo-1']          ← body gone
       flags['- a/src/foo.ts…'] = true
```

`cmdReply` then returns `usage: reply <convo_id> "<body>" …` for a command the agent wrote **correctly**. From the human's side the teammate just went silent; from the agent's side it looks like it mistyped. Posting a diff or a doc-shaped reply is a completely ordinary thing for an agent to do.

## Bug 2 — code snippets are corrupted

`cmdReply` ran `unescapeChat` over the body. That helper exists because the bash tool single-quotes *inline* bodies, so `\n` arrives as two literal characters — but `--file` content never met a shell. So:

- `console.log("a\nb");` → the `\n` becomes a real line break inside the string literal
- `C:\\Users\\dev` → loses a backslash level

i.e. the one feature advertised for sharing code is the one that mangles it.

## The fix

One mechanism for both: the shim appends the body **last, behind a POSIX `--`**, and `parseArgs` honors `--` as end-of-flags, recording where literal args begin so `cmdReply` can join them without re-expanding escapes.

Verified end-to-end through the real path (shim argv → `buildRuntimeArgv` → `runCli`'s `--as`/subcommand strip → `parseArgs` → body): diff headers, front-matter, `\n` inside string literals and Windows paths all arrive byte-identical, while `--quote` and friends still parse and the JWT-pinned `--as` is unaffected (everything after `--` is positional, so it can never be read as a flag).

## One intentional behavior change, called out

`parseArgs` previously read a bare `--` as a zero-length-key flag that swallowed the following token. A test pinned that, and its comment said:

> POSIX-ish convention would treat `--` as "end of flags". We don't … Lock in current behaviour; **no caller depends on `--` either way today.**

That test is updated to the POSIX meaning, which is now load-bearing. **Absent a `--`, `parseArgs` returns the exact same object shape it always did**, so every existing caller is untouched — that's why only this one test moved.

## Tests

8 cases added to `server/src/__tests__/agents-cli-parse.test.ts` covering both directions: `--`-leading bodies stay positional, flags before `--` still parse, flag-looking tokens after `--` don't, shell bodies still get escapes expanded, and verbatim bodies keep `\n` and backslashes intact.

45/45 pass in that file.

## Checks

`npm run lint`, `npm run typecheck`, `npm run server:typecheck` pass. I also extracted the generated shim and ran `node --check` on it.

My sandbox has no Postgres/Redis/`OPENAI_API_KEY`, so 18 files in the server suite fail on env alone; the failure set is identical with and without this change.
