### PR TITLE
fix(db): reset the migration client's session before it re-enters the pool

### DIFF
--- a/server/src/__tests__/migrate-client-release.test.ts
+++ b/server/src/__tests__/migrate-client-release.test.ts
@@ -1,0 +1,58 @@
+/**
+ * ensureSchema runs its DDL on a client borrowed from the SHARED pool, after
+ * disabling that session's statement_timeout / idle_in_transaction_session_timeout
+ * and setting a 5s lock_timeout. Those are session-scoped, `pg-pool`'s release()
+ * does not reset session state, and node-postgres only sends the pool's timeouts
+ * in the connection's startup packet — so whatever the migration leaves behind
+ * rides that connection for the rest of the process's life.
+ *
+ * Run: node --import tsx --test server/src/__tests__/migrate-client-release.test.ts
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { releaseMigrationClient } from '../db/migrate.js'
+
+function fakeClient(opts: { failReset?: boolean } = {}) {
+  const calls: string[] = []
+  return {
+    calls,
+    query: async (sql: string) => {
+      calls.push(sql)
+      if (opts.failReset) throw new Error('connection terminated unexpectedly')
+      return {}
+    },
+    release: () => { calls.push('<release>') },
+  }
+}
+
+test('the migration client is reset before it re-enters the pool', () => {
+  const c = fakeClient()
+  return releaseMigrationClient(c).then(() => {
+    assert.deepEqual(c.calls, ['RESET ALL', '<release>'])
+  })
+})
+
+test('the reset happens BEFORE release, never after', async () => {
+  // Order is the whole point: a client released first is already back in the
+  // pool and may have been handed to another request by the time RESET lands.
+  const c = fakeClient()
+  await releaseMigrationClient(c)
+  const reset = c.calls.indexOf('RESET ALL')
+  const released = c.calls.indexOf('<release>')
+  assert.notEqual(reset, -1, 'the session was never reset')
+  assert.notEqual(released, -1, 'the client was never released')
+  assert.ok(reset < released, 'reset must precede release')
+})
+
+test('a failed reset still returns the slot to the pool', async () => {
+  // Losing a pool slot forever is worse than a stale session; the pool discards
+  // a broken connection on its own.
+  const c = fakeClient({ failReset: true })
+  await releaseMigrationClient(c)
+  assert.ok(c.calls.includes('<release>'))
+})
+
+test('releaseMigrationClient does not reject when the reset fails', async () => {
+  const c = fakeClient({ failReset: true })
+  await assert.doesNotReject(() => releaseMigrationClient(c))
+})

--- a/server/src/db/migrate.ts
+++ b/server/src/db/migrate.ts
@@ -2101,8 +2101,36 @@ export async function ensureSchema(): Promise<void> {
     // lock). Best-effort + non-fatal — see the helper.
     await buildConcurrentIndexes(client)
   } finally {
-    client.release()
+    await releaseMigrationClient(client)
   }
+}
+
+/** The subset of a pooled client this helper needs — structural so a test can
+ *  hand it a fake without a live Postgres. */
+type MigrationClient = { query(sql: string): Promise<unknown>; release(): void }
+
+/**
+ * Hand the migration client back to the shared pool with its SESSION state wiped.
+ *
+ * ensureSchema deliberately turns OFF this session's `statement_timeout` and
+ * `idle_in_transaction_session_timeout` and sets `lock_timeout = '5s'`. All three
+ * are SESSION-scoped, and this client is an ordinary member of the 20-slot pool:
+ * `pg-pool`'s `release()` does not reset session state, and node-postgres sends
+ * the pool's timeouts only in the connection's STARTUP PACKET, so they are never
+ * re-applied on checkout. Without this reset, one pooled connection spends the
+ * rest of the process's life with the pool's runaway-query guards disabled — the
+ * very protection whose absence once let a single un-indexed query hold all 20
+ * slots and 503 the API (see db/pool.ts) — and with a 5s `lock_timeout` that
+ * aborts ordinary writes with `55P03` instead of waiting. Same "re-enter the pool
+ * with no leftover state" reasoning as the advisory unlock above.
+ *
+ * A failed RESET must never strand the slot, so we release either way; a
+ * genuinely broken connection is discarded by the pool on its own.
+ */
+export async function releaseMigrationClient(client: MigrationClient): Promise<void> {
+  try { await client.query('RESET ALL') }
+  catch { /* connection already unusable — releasing still returns the slot */ }
+  client.release()
 }
 
 /**


### PR DESCRIPTION
## The bug

`ensureSchema` borrows a client from the shared 20-slot pool and, deliberately, disables that session's `statement_timeout` and `idle_in_transaction_session_timeout` and sets `lock_timeout = '5s'`. All three are **session-scoped**. The client is then released back into the pool with no reset.

The leak is permanent for that connection's lifetime, for two independent reasons I verified against the installed dependencies:

- `pg-pool`'s `release()` does not reset session state — `_release` just re-attaches the idle listener and requeues the client (`node_modules/pg-pool/index.js`).
- node-postgres sends the pool's `statement_timeout` / `lock_timeout` / `idle_in_transaction_session_timeout` in the connection's **startup packet** (`node_modules/pg/lib/client.js:525-533`), so they are applied once at connect and never re-applied on checkout.

So after every boot, one of the 20 pooled connections serves ordinary API traffic with the pool's guards inverted:

| GUC | pool intends | after a migration |
|---|---|---|
| `statement_timeout` | 60s | **0 (disabled)** |
| `idle_in_transaction_session_timeout` | 30s | **0 (disabled)** |
| `lock_timeout` | unset | **5s** |

The first row is the one that stings: `db/pool.ts` documents that timeout as the fix for a real incident —

> that is exactly how one un-indexed hot query (idle.ts' `MAX(created_at)` seq-scan) held all 20 slots at ~8s each and 503-ed the entire API

On this connection that protection is off again, so a runaway pins its slot indefinitely. The `lock_timeout` row is nastier to diagnose: ordinary writes that wait more than 5s for a lock abort with `55P03 lock_not_available` instead of waiting, producing sporadic 500s on roughly 1 request in 20 that are near-impossible to reproduce.

Note `pool.ts`'s own comment assumes this can't happen — "Boot migrations and CONCURRENTLY index builds legitimately run longer and disable these **on their own session**". It is not its own session; it's a pooled one.

## The fix

Reset the session in the same breath as handing the slot back. This is the reasoning already applied to the advisory lock a few lines above:

> releasing explicitly lets the conn re-enter the pool with no lock state — cleaner

A failed `RESET` still releases: losing a pool slot forever would be worse than a stale session, and the pool discards a genuinely broken connection on its own.

`RESET ALL` restores each parameter to the value it would have had if no `SET` had been issued — for these three that is the startup-packet value the pool supplied, which is exactly what we want back.

The helper is exported so the behavior can be pinned without a live Postgres, matching how `cli-argv.ts` and `engine.ts`'s `resolveSpawn` are already exposed for tests.

## Tests

New `server/src/__tests__/migrate-client-release.test.ts` (4 cases) driving a fake client.

Checked against three implementations to make sure the cases aren't vacuous:

- **Current code (no reset):** cases 1 and 2 fail.
- **A naive fix (`RESET ALL` with no try/catch):** cases 3 and 4 fail — that version leaks the pool slot forever whenever the reset throws, which is a worse bug than the one being fixed.
- **This patch:** 4/4 pass.

## Checks

`npm run lint`, `npm run typecheck`, `npm run server:typecheck` pass.

My sandbox has no Postgres/Redis/`OPENAI_API_KEY`. Diffing the server suite's failure set against baseline, the only new entry is this new test file, which needs the same env the other 18 env-dependent files need; run with those vars present it is 4/4 green.
