### PR TITLE
fix(electron): load the notification window over app://, not file://

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -567,7 +567,12 @@ const NOTIF_MARGIN_TOP = 24
 
 function notificationUrl() {
   if (isDev) return `${DEV_URL}/#notifications`
-  return `file://${path.join(__dirname, '..', 'dist', 'index.html')}#notifications`
+  // Same `app://` scheme the main window loads (see the header comment): over
+  // `file://` the bundle's absolute `/assets/…` imports resolve outside the asar
+  // and 404, so the renderer never boots — meaning `notification:ready` never
+  // fires, every push queues in pendingPushes forever, and a packaged build
+  // shows no toasts and plays no chime at all.
+  return 'app://cumora/index.html#notifications'
 }
 
 function positionNotificationWindow() {

--- a/server/src/__tests__/electron-renderer-url.test.ts
+++ b/server/src/__tests__/electron-renderer-url.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Guard: every packaged renderer entry point must load over `app://`.
+ *
+ * electron/main.cjs's header explains at length why `file://` cannot work for
+ * the packaged renderer — the Vite bundle's absolute `/assets/…` imports
+ * resolve outside the asar and 404, so nothing mounts. The main window was
+ * moved to `app://cumora/index.html` for exactly that reason; the notification
+ * window was left behind on `file://` and was therefore dead in every packaged
+ * build (no toast ever rendered, so `notification:ready` never fired and pushes
+ * queued forever).
+ *
+ * electron/ has no runtime test harness — it needs a real Electron process — so
+ * this is a source-level guard in the same shape as guard-big-brain.test.ts:
+ * pin the invariant against the live file, and self-test the matcher so the
+ * guard can't quietly become a no-op.
+ *
+ * Run: node --import tsx --test server/src/__tests__/electron-renderer-url.test.ts
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
+const MAIN_CJS = join(REPO_ROOT, 'electron', 'main.cjs')
+
+/** The `loadURL(...)` / `return ...` targets a packaged build would use.
+ *  We deliberately ignore anything guarded by `isDev`, which legitimately
+ *  points at the Vite dev server over http. */
+function packagedRendererUrls(source: string): string[] {
+  const out: string[] = []
+  for (const raw of source.split('\n')) {
+    const line = raw.trim()
+    if (line.startsWith('//') || line.startsWith('*')) continue
+    if (line.includes('isDev')) continue
+    // Any string literal that names an index.html we hand to a BrowserWindow.
+    if (!/index\.html/.test(line)) continue
+    if (!/loadURL|return\s/.test(line)) continue
+    out.push(line)
+  }
+  return out
+}
+
+test('no packaged renderer entry point loads over file://', () => {
+  const urls = packagedRendererUrls(readFileSync(MAIN_CJS, 'utf8'))
+  assert.ok(urls.length > 0, 'found no renderer entry points — the matcher has drifted')
+  const offenders = urls.filter((l) => l.includes('file://'))
+  assert.deepEqual(
+    offenders, [],
+    '\nA packaged renderer would load over file://, where the bundle\'s absolute\n' +
+    '/assets/… imports resolve outside the asar and 404 — the renderer never mounts:\n' +
+    offenders.map((l) => `  ${l}`).join('\n'),
+  )
+})
+
+test('every packaged renderer entry point uses the app:// scheme', () => {
+  const urls = packagedRendererUrls(readFileSync(MAIN_CJS, 'utf8'))
+  for (const line of urls) {
+    assert.match(line, /app:\/\/cumora\//, `not served over app://cumora/: ${line}`)
+  }
+})
+
+test('the notification window is one of the entry points this guard covers', () => {
+  // Cheap anchor: if the notification loader stops matching, the guard above
+  // would pass vacuously for it.
+  const urls = packagedRendererUrls(readFileSync(MAIN_CJS, 'utf8'))
+  assert.ok(
+    urls.some((l) => l.includes('#notifications')),
+    'the notification window URL is no longer covered by this guard',
+  )
+})
+
+// --- the matcher actually catches a regression (so the guard isn't a no-op) ---
+
+test('the matcher flags a file:// notification URL', () => {
+  // Built by concatenation so the `$`+`{` placeholder stays inert sample data.
+  const bad = '  return `file://' + '$' + "{path.join(__dirname, '..', 'dist', 'index.html')}#notifications`"
+  const found = packagedRendererUrls(bad)
+  assert.equal(found.length, 1)
+  assert.ok(found[0].includes('file://'))
+})
+
+test('the matcher ignores the isDev branch', () => {
+  const dev = '  if (isDev) return `' + '$' + '{DEV_URL}/index.html#notifications`'
+  assert.deepEqual(packagedRendererUrls(dev), [])
+})


### PR DESCRIPTION
## The bug

`electron/main.cjs` opens with a 28-line comment explaining why the packaged renderer cannot load over `file://`:

> Production packaging would otherwise load index.html over `file://`, where ANY absolute path (`/logo.png`, `/assets/index-XYZ.js`, the favicons in `<link>`, …) resolves to `file:///foo` — outside the asar — and 404s.

That is why `app://` is registered as a privileged scheme, served out of `dist/`, and why the main window loads `app://cumora/index.html` (`main.cjs:1151`). `vite.config.ts` sets no `base`, so the emitted bundle really does use absolute `/assets/…` paths.

`notificationUrl()` was left behind on `file://`:

```js
function notificationUrl() {
  if (isDev) return `${DEV_URL}/#notifications`
  return `file://${path.join(__dirname, '..', 'dist', 'index.html')}#notifications`
}
```

In a packaged build the notification renderer therefore never boots. The cascade:

- `notification:ready` never fires, so every push accumulates in `pendingPushes` forever
- no toast is ever shown, and since the panel never paints, `notification:painted` never fires either — so the chime never plays
- `notification:set-interactive(false)` never arrives, so the window is never torn down

**Net effect: desktop notifications are entirely dead in shipped builds — and only in shipped builds.** In dev both windows load from the Vite dev server, so it never reproduces while developing. The only trace is the `did-fail-load` console line at `main.cjs:957`.

## The fix

Point it at the same `app://` URL the main window already uses.

This also puts both renderers on one origin — which is what `CUMORA_CORS_ORIGINS` already allowlists (`main.cjs:1148` notes it must stay in sync). Worth noting the old `file://` origin would have been CORS-blocked on any `/api` call even if the bundle had loaded, so this removes a second latent failure rather than introducing one.

## Tests

`electron/` has no runtime test harness — it needs a real Electron process — so the regression guard is a source-level one, in the same shape as the existing `guard-big-brain.test.ts` (which scans live source and self-tests its own rules so the guard can't become a no-op).

`server/src/__tests__/electron-renderer-url.test.ts` pins that no packaged renderer entry point loads over `file://`, that each uses `app://cumora/`, and — the anchor that keeps the guard honest — that the notification URL is actually still covered by the matcher. Two further cases prove the matcher flags a `file://` notification URL and ignores the legitimate `isDev` branch.

Verified red-before / green-after: reverting `notificationUrl()` to the old body fails cases 1 and 2.

## Checks

`npm run lint`, `npm run typecheck`, `npm run server:typecheck` pass. This test needs no Postgres/Redis/`OPENAI_API_KEY` — it only reads source — so it runs green in a bare sandbox too; the suite's failure set is otherwise identical to baseline.

I could not launch a packaged macOS build in my environment to watch a real toast appear, so the runtime claim rests on the repo's own documented reasoning for the `app://` migration plus the `did-fail-load` path — worth a maintainer smoke-test on a packaged build before merge.
