### PR TITLE
fix(auth): accept a verified non-primary GitHub email (#2)

### DIFF
--- a/server/src/__tests__/oauth-github-email.test.ts
+++ b/server/src/__tests__/oauth-github-email.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Regression test for GitHub sign-in's email-selection logic.
+ *
+ * fetchProfile('github', ...) hits /user + /user/emails and picks a verified
+ * address. A GitHub account can have its primary email unverified while a
+ * secondary address is verified — that must still succeed and use the
+ * verified secondary, not refuse outright (issue #2).
+ *
+ * Run: node --import tsx --test server/src/__tests__/oauth-github-email.test.ts
+ */
+import { test, afterEach, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { fetchProfile } from '../oauth.js'
+import { pool } from '../db/pool.js'
+
+const SAVED_FETCH = globalThis.fetch
+
+interface GitHubEmail { email: string; primary: boolean; verified: boolean }
+
+function mockGitHub(user: { id: number; login: string; name?: string | null; avatar_url?: string }, emails: GitHubEmail[]) {
+  globalThis.fetch = (async (url: string | URL | Request) => {
+    const href = typeof url === 'string' ? url : url instanceof URL ? url.href : url.url
+    if (href === 'https://api.github.com/user') {
+      return new Response(JSON.stringify(user), { status: 200 })
+    }
+    if (href === 'https://api.github.com/user/emails') {
+      return new Response(JSON.stringify(emails), { status: 200 })
+    }
+    throw new Error(`unexpected fetch: ${href}`)
+  }) as typeof fetch
+}
+
+afterEach(() => {
+  globalThis.fetch = SAVED_FETCH
+})
+
+after(async () => {
+  // oauth.ts imports both db/pool.js and redis.js, which open connections
+  // at module load. Tear them down here so the test process can exit
+  // instead of hanging on dangling handles.
+  try { await pool.end() } catch { /* ignore */ }
+  try {
+    const { redis, sub } = await import('../redis.js')
+    redis.disconnect()
+    sub.disconnect()
+  } catch { /* ignore */ }
+})
+
+test('fetchProfile(github): uses the primary email when it is verified', async () => {
+  mockGitHub(
+    { id: 1, login: 'octocat', name: 'The Octocat' },
+    [{ email: 'primary@example.com', primary: true, verified: true }],
+  )
+  const profile = await fetchProfile('github', 'fake-token')
+  assert.equal(profile.email, 'primary@example.com')
+})
+
+test('fetchProfile(github): falls back to a verified non-primary email when the primary is unverified', async () => {
+  mockGitHub(
+    { id: 2, login: 'alanthssss', name: null },
+    [
+      { email: 'unverified-primary@example.com', primary: true, verified: false },
+      { email: 'verified-secondary@example.com', primary: false, verified: true },
+    ],
+  )
+  const profile = await fetchProfile('github', 'fake-token')
+  assert.equal(profile.email, 'verified-secondary@example.com')
+  assert.equal(profile.displayName, 'alanthssss')
+})
+
+test('fetchProfile(github): still refuses when no email is verified at all', async () => {
+  mockGitHub(
+    { id: 3, login: 'nobody' },
+    [{ email: 'unverified@example.com', primary: true, verified: false }],
+  )
+  await assert.rejects(
+    () => fetchProfile('github', 'fake-token'),
+    /github account has no verified email/,
+  )
+})

--- a/server/src/api/router.ts
+++ b/server/src/api/router.ts
@@ -685,13 +685,19 @@ api.get('/auth/callback/:provider', safe(async (req, res) => {
   if (!code || !state) {
     res.redirect(errorUrl(null, 'missing_code_or_state')); return
   }
-  const claimed = await consumeState(state)
-  if (!claimed || claimed.provider !== provider) {
-    res.redirect(errorUrl(null, 'bad_state')); return
-  }
   const ip = req.socket.remoteAddress ?? null
   const ua = (req.headers['user-agent'] as string | undefined) ?? null
+  // `claimed` is read in the catch block below, so it has to be declared
+  // outside the try — consumeState() itself can throw (e.g. a Redis
+  // hiccup) and previously did so *before* this try started, escaping to
+  // the router's generic unhandled-error page instead of the same
+  // graceful #error= redirect every other failure in this flow gets.
+  let claimed: Awaited<ReturnType<typeof consumeState>> = null
   try {
+    claimed = await consumeState(state)
+    if (!claimed || claimed.provider !== provider) {
+      res.redirect(errorUrl(null, 'bad_state')); return
+    }
     const url = await handleCallback({
       provider, code, returnUrl: claimed.returnUrl, ip, userAgent: ua,
       inviteToken: claimed.inviteToken,
@@ -701,7 +707,7 @@ api.get('/auth/callback/:provider', safe(async (req, res) => {
     const msg = e instanceof Error ? e.message : String(e)
     console.warn(`[auth] ${provider} callback failed:`, msg)
     await audit({ kind: 'login_failed', ip, userAgent: ua, detail: { provider, error: msg } })
-    res.redirect(errorUrl(claimed.returnUrl, msg.slice(0, 120)))
+    res.redirect(errorUrl(claimed?.returnUrl ?? null, msg.slice(0, 120)))
   }
 }))
 

--- a/server/src/oauth.ts
+++ b/server/src/oauth.ts
@@ -186,7 +186,7 @@ interface GoogleProfile { sub: string; email?: string; email_verified?: boolean;
 interface GitHubProfile { id: number; login: string; name?: string | null; email?: string | null; avatar_url?: string }
 interface GitHubEmail   { email: string; primary: boolean; verified: boolean }
 
-async function fetchProfile(p: Provider, accessToken: string): Promise<NormalizedProfile> {
+export async function fetchProfile(p: Provider, accessToken: string): Promise<NormalizedProfile> {
   const cfg = providerConfig(p)
   if (p === 'google') {
     const r = await fetch(cfg.userInfoUrl, { headers: { authorization: `Bearer ${accessToken}` } })
@@ -201,8 +201,11 @@ async function fetchProfile(p: Provider, accessToken: string): Promise<Normalize
     }
   }
   // GitHub: /user doesn't expose email when the user hides it. Hit /user/emails
-  // and pick `primary && verified`. Otherwise refuse — we need a real address
-  // for the user record + cross-provider auto-binding.
+  // and prefer `primary && verified`. A GitHub account can have its primary
+  // email unverified while a secondary address is verified (e.g. mid-way
+  // through changing their primary) — "verified" is what attests ownership
+  // for auto-linking, "primary" is just GitHub's own default-address pick,
+  // so fall back to any verified email rather than refusing outright.
   const [userR, emailsR] = await Promise.all([
     fetch(cfg.userInfoUrl, { headers: { authorization: `Bearer ${accessToken}`, accept: 'application/json', 'user-agent': 'cumora' } }),
     fetch('https://api.github.com/user/emails', { headers: { authorization: `Bearer ${accessToken}`, accept: 'application/json', 'user-agent': 'cumora' } }),
@@ -211,11 +214,11 @@ async function fetchProfile(p: Provider, accessToken: string): Promise<Normalize
   if (!emailsR.ok) throw new Error(`github emails ${emailsR.status}`)
   const u = await userR.json() as GitHubProfile
   const emails = await emailsR.json() as GitHubEmail[]
-  const primary = emails.find((e) => e.primary && e.verified)
-  if (!primary) throw new Error('github account has no verified primary email')
+  const verified = emails.find((e) => e.primary && e.verified) ?? emails.find((e) => e.verified)
+  if (!verified) throw new Error('github account has no verified email')
   return {
     providerId: String(u.id),
-    email: primary.email.toLowerCase(),
+    email: verified.email.toLowerCase(),
     displayName: (u.name && u.name.trim()) || u.login,
     avatarUrl: u.avatar_url ?? null,
   }


### PR DESCRIPTION
Fixes #2.

## The GitHub half — confirmed root cause + fix

`fetchProfile('github', ...)` required the *primary* email to be verified:

```ts
const primary = emails.find((e) => e.primary && e.verified)
if (!primary) throw new Error('github account has no verified primary email')
```

That's exactly the error string in the screenshots on #2. But a GitHub account can have its primary email unverified while a *different* address on the same account is verified — common mid-way through changing your primary. `verified` is what actually attests ownership for the auto-link logic (see the comment a few lines up: "we just verified the provider attests to the email's ownership"); `primary` is only GitHub's own default-address pick, not a security property. So this refused sign-in entirely for a case it didn't need to.

Fix: prefer `primary && verified`, fall back to any `verified` email otherwise.

```ts
const verified = emails.find((e) => e.primary && e.verified) ?? emails.find((e) => e.verified)
if (!verified) throw new Error('github account has no verified email')
```

Added `server/src/__tests__/oauth-github-email.test.ts` — three cases: primary-verified (unchanged behavior), primary-unverified-but-secondary-verified (the actual bug, now passes), and no-email-verified-at-all (still correctly refused).

## The Google half — hardened, not confirmed fixed

Every failure in this flow is supposed to redirect gracefully to `#error=...` (`errorUrl(...)` in `oauth.ts`) — that's what the GitHub screenshot shows. The Google screenshot shows something different: a raw, generic "Error: Server Error / ... try again in 30 seconds" page, which doesn't match anything in this app's own error handling.

One real (if unconfirmed) gap I found while in here: `consumeState(state)` was called *before* the callback route's try/catch, so if it throws — e.g. a Redis hiccup on the `getdel` call — that exception skips the graceful-redirect path entirely and falls through to the router's generic unhandled-error handler instead. Moved it inside the try so every failure in this flow gets the same `#error=` treatment.

I'm flagging this honestly as a plausible contributor, not a confirmed fix — diagnosing the actual Google failure needs server-side logs I don't have access to. Worth checking `[api] unhandled` log lines around the time of that report if this doesn't fully resolve it.

## Testing

- `node --import tsx --test server/src/__tests__/oauth-github-email.test.ts` — 3/3 pass
- Mutation check: reverted just the fallback line, kept the test → the second case fails with the exact old error message; restored → green
- Full suite: `npm test` — 577 tests, 0 failures (ran against local Postgres 16/pgvector + Redis 7, same images as `.github/workflows/pr.yml`)
- `tsc --noEmit` on `server/` — clean
