### PR TITLE
 chore: migrate deprecated Biome recommended configuration

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -36,9 +36,9 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "a11y": {
-        "recommended": false
+        "preset": "none"
       },
       "style": {
         "noNonNullAssertion": "off",


### PR DESCRIPTION
## Summary

Update the Biome configuration to use the current rule preset syntax.

- Replace `rules.recommended: true` with `rules.preset: "recommended"`
- Replace `a11y.recommended: false` with `a11y.preset: "none"`
- Preserve the existing lint behavior while removing the Biome deprecation warning

## Why

Biome 2.5 reports that the `recommended` configuration field is deprecated and will be removed in the
next major version. This migration keeps the configuration forward-compatible and removes the warning
from local and CI lint output.

before：
<img width="1019" height="428" alt="image" src="https://github.com/user-attachments/assets/5663b53c-596f-41cd-ab0c-68ddf5d43926" />

after：
<img width="1033" height="164" alt="image" src="https://github.com/user-attachments/assets/f7f5b6a0-39a2-483c-a748-f4e4f21f48f4" />


## Testing

- `npm run lint`
- `npm run typecheck`
- `npm run server:typecheck`
- `npm run guard:big-brain`
- `npm run guard:llm-tracked`
- `npm test`

Unit test result: 573 passed, 0 failed, 1 skipped.