### PR TITLE
chore: add a unified dependency setup command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,9 +16,13 @@ running locally.
 createdb -h localhost cumora
 export OPENAI_API_KEY=sk-...        # the only hard-required env var
 
-npm install
+npm run setup                     # root + Email Worker dependencies
 npm run dev:all                     # Vite renderer on :5180 + API server on :5181
 ```
+
+Use `npm run setup` rather than a root-only `npm install`: the root test
+command also runs `workers/email-gate` tests, whose dependencies live in the
+Worker's separate `package.json`.
 
 Open http://localhost:5180 for the web app, or `npm run electron:dev` for the
 desktop shell. The database schema is created idempotently on boot and seeded

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You need Postgres and Redis (Homebrew services are fine):
 createdb -h localhost cumora
 export OPENAI_API_KEY=sk-...
 
-npm install
+npm run setup          # install root + Email Worker dependencies
 npm run dev:all       # Vite renderer on :5180 + API server on :5181
 ```
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "email": "yetoneful@gmail.com"
   },
   "scripts": {
+    "setup": "npm install && npm install --prefix workers/email-gate",
     "dev": "vite --port 5180 --strictPort",
     "dev:all": "concurrently -k -n web,api -c blue,magenta \"npm:dev\" \"npm:server:dev\"",
     "build": "tsc -b && vite build",


### PR DESCRIPTION
## Summary
Closes #16 

Add a root-level `npm run setup` command that installs both the main project
dependencies and the Email Worker dependencies.

- Add `npm run setup` to `package.json`
- Update `README.md` to use the unified setup command
- Update `CONTRIBUTING.md` to explain why the separate Worker dependencies are required

## Why

The root test command runs both server and Worker tests:

```bash
npm test
```
However, a root-only npm install does not install dependencies from workers/email-gate/package.json. As a result, new contributors can encounter:

```
Error: Cannot find module 'postal-mime'
```
<img width="1160" height="301" alt="image" src="https://github.com/user-attachments/assets/a4d644f0-33e6-4ae0-a1fe-1c0ca7bd1c13" />


The new setup command installs both dependency sets:

```
npm run setup
```

This makes the documented local setup consistent with the dependencies required by the test suite.

<img width="1159" height="301" alt="image" src="https://github.com/user-attachments/assets/bdaaef79-693f-42b1-8a69-0241bcfa7834" />


## Testing

- npm run setup
- npm run lint
- npm run typecheck
- npm run server:typecheck
- npm run guard:big-brain
- npm run guard:llm-tracked
- npm test

Test result: 573 passed, 0 failed, 1 skipped.