### PR TITLE
Apply agent system_prompt (style) to BYOA-hosted agents

### DIFF
--- a/server/src/agents/computer/daemon.ts
+++ b/server/src/agents/computer/daemon.ts
@@ -300,6 +300,7 @@ interface AgentInfo {
   id: string
   name: string
   role: string | null
+  systemPrompt: string | null
   engine: EngineId | null
   model: string | null
   fastModel: string | null
@@ -963,7 +964,7 @@ class AgentRunner {
   }
 
   async start(): Promise<void> {
-    await this.adapter.seedHome(this.home, { id: this.agent.id, name: this.agent.name, role: this.agent.role })
+    await this.adapter.seedHome(this.home, { id: this.agent.id, name: this.agent.name, role: this.agent.role, systemPrompt: this.agent.systemPrompt })
     await writeShim(this.binDir)
     await this.loadSessionId()
     void this.streamLoop()
@@ -1000,6 +1001,7 @@ class AgentRunner {
     return this.adapter.id === engine
       && this.agent.name === agent.name
       && this.agent.role === agent.role
+      && this.agent.systemPrompt === agent.systemPrompt
       && this.agent.model === agent.model
       && this.agent.fastModel === agent.fastModel
   }

--- a/server/src/agents/computer/engine.ts
+++ b/server/src/agents/computer/engine.ts
@@ -93,6 +93,7 @@ export interface EnginePersona {
   id: string
   name: string
   role: string | null
+  systemPrompt: string | null
 }
 
 export interface EngineRunArgs {
@@ -529,6 +530,7 @@ function extraArgs(envVar: string): string[] {
 const PERSONA_HEADER = (p: EnginePersona): string =>
   `# ${p.name}${p.role ? ` — ${p.role}` : ''}\n\n` +
   `You are **${p.name}**, a member of a team that collaborates in Cumora (a team chat).\n` +
+  (p.systemPrompt?.trim() ? `\n## Your style\n${p.systemPrompt.trim()}\n\n` : '\n') +
   `This directory is your private home and your working directory — it persists\n` +
   `across wakes and is yours alone. Its layout:\n` +
   `- \`CLAUDE.md\` (this file) — always loaded each wake; keep it short.\n` +
@@ -884,8 +886,11 @@ class ClaudeAdapter implements EngineAdapter {
   async seedHome(home: string, persona: EnginePersona): Promise<void> {
     await ensureCommonHome(home)
     await mkdir(join(home, '.claude', 'skills'), { recursive: true })
-    const claudeMd = join(home, 'CLAUDE.md')
-    if (!(await exists(claudeMd))) await writeFile(claudeMd, PERSONA_HEADER(persona), 'utf8')
+    // Always (re)written from the DB's name/role/systemPrompt — this file is
+    // system-owned, not agent-editable, so it's safe to overwrite on every
+    // start()/restart (including the restart configMatches() triggers when
+    // the operator edits the agent's persona in Cumora).
+    await writeFile(join(home, 'CLAUDE.md'), PERSONA_HEADER(persona), 'utf8')
     // settings.json lets bash (hence the cumora shim) run without prompts in
     // this isolated home. Only written if absent so the user can customize.
     const settings = join(home, '.claude', 'settings.json')
@@ -1369,8 +1374,8 @@ class CodexAdapter implements EngineAdapter {
 
   async seedHome(home: string, persona: EnginePersona): Promise<void> {
     await ensureCommonHome(home)
-    const agentsMd = join(home, 'AGENTS.md')
-    if (!(await exists(agentsMd))) await writeFile(agentsMd, PERSONA_HEADER(persona), 'utf8')
+    // See ClaudeAdapter.seedHome: system-owned, safe to overwrite every start.
+    await writeFile(join(home, 'AGENTS.md'), PERSONA_HEADER(persona), 'utf8')
   }
 
   run(args: EngineRunArgs): Promise<EngineRunResult> {

--- a/server/src/agents/computer/registry.ts
+++ b/server/src/agents/computer/registry.ts
@@ -355,10 +355,10 @@ export async function mintAgentRuntimeToken(args: {
  *  upgrade in the underlying CLI (e.g. claude 4.7 → 4.8) silently changes
  *  agent behavior on every user's machine unless we pin here. */
 export async function listAgentsForComputer(computerId: string): Promise<
-  Array<{ id: string; name: string; role: string | null; engine: EngineId | null; model: string | null; fastModel: string | null }>
+  Array<{ id: string; name: string; role: string | null; systemPrompt: string | null; engine: EngineId | null; model: string | null; fastModel: string | null }>
 > {
-  const { rows } = await pool.query<{ id: string; name: string; role: string | null; engine: EngineId | null; model: string | null; fastModel: string | null }>(
-    `SELECT id, name, role, engine, model, fast_model AS "fastModel" FROM participants
+  const { rows } = await pool.query<{ id: string; name: string; role: string | null; systemPrompt: string | null; engine: EngineId | null; model: string | null; fastModel: string | null }>(
+    `SELECT id, name, role, system_prompt AS "systemPrompt", engine, model, fast_model AS "fastModel" FROM participants
       WHERE computer_id = $1 AND kind = 'agent' AND departed_at IS NULL
       ORDER BY name ASC`,
     [computerId],


### PR DESCRIPTION
## Summary
- The BYOA (local computer) daemon's agent-sync query never selected `participants.system_prompt`, so locally-paired agents silently ignored the "Style (system prompt)" text set in the UI — only the managed cloud-pod path (`personas.ts`) actually applied it.
- `configMatches()` didn't compare the field either, so editing an agent's style wouldn't even trigger the daemon's automatic runner restart.
- `seedHome()` only wrote `CLAUDE.md`/`AGENTS.md` once ever per agent home, so a restart alone wouldn't refresh it.

This threads `systemPrompt` through `listAgentsForComputer` → `AgentInfo` → `EnginePersona`, renders it as a `## Your style` section in the persona header, includes it in `configMatches()`, and makes `seedHome()` regenerate `CLAUDE.md`/`AGENTS.md` on every `start()` (safe — these files are system-generated, not agent-edited) so a style edit takes effect via the daemon's existing config-change restart.

## Test plan
- [x] `tsc --noEmit` passes
- [x] Verified locally with a paired BYOA computer: edited an agent's style in the UI, confirmed the daemon logged a config-change restart and the agent's `CLAUDE.md` picked up the new `## Your style` section