### PR TITLE
feat(computer): add Grok Build as a BYOA engine

### DIFF
--- a/agent-cli/src/cli.ts
+++ b/agent-cli/src/cli.ts
@@ -21,7 +21,7 @@ async function main(): Promise<void> {
     'Usage:\n' +
     '  npx cumora@latest agent computer --pair <code> [--server <url>]   pair this machine\n' +
     '  npx cumora@latest agent computer [--server <url>]                 start the daemon\n\n' +
-    'Needs `claude` (Claude Code) or `codex` on PATH. Get a pairing code from\n' +
+    'Needs `claude` (Claude Code), `codex`, or `grok` (Grok Build) on PATH. Get a pairing code from\n' +
     'Cumora → You → Computers → Add a computer.\n',
   )
   process.exit(argv.length ? 1 : 0)

--- a/docs/BYOA.md
+++ b/docs/BYOA.md
@@ -1,4 +1,4 @@
-# BYOA — Bring Your Own Agent (local Claude Code / Codex as the engine)
+# BYOA — Bring Your Own Agent (local Claude Code / Codex / Grok Build as the engine)
 
 Every Cumora agent has a "brain" and a host. The managed path is
 server-side: `runAgentTurn` in `server/src/agents/turn.ts` runs a
@@ -6,9 +6,9 @@ multi-hop loop against the OpenAI Responses API, with the agent's body in
 a per-agent Kubernetes pod (the `agent-computer` image).
 
 **BYOA** lets a user supply the brain instead: a long-running daemon on
-the user's own machine (laptop **or** VPS) drives a local **Claude Code**
-or **Codex CLI** as the reasoning engine, on the user's own
-subscription — the server never holds the user's provider credentials.
+the user's own machine (laptop **or** VPS) drives a local **Claude Code**,
+**Codex CLI**, or **Grok Build** (`grok`) as the reasoning engine, on the
+user's own subscription — the server never holds the user's provider credentials.
 One daemon hosts **many independent agents** — each with its own isolated
 home directory, memory, skills, and notes. In Cumora these still appear
 as ordinary `kind='agent'` participants; only their engine differs.
@@ -38,7 +38,7 @@ managed cloud agents and local agents into the same picture.
   user to set up; it's always online.
 - **Your computers** — machines you pair (your Mac, a VPS). Each runs the
   `cumora agent computer` daemon with a local engine (Claude Code /
-  Codex). Agents you place here are BYOA agents.
+  Codex / Grok Build). Agents you place here are BYOA agents.
 
 ```
 Computers
@@ -151,7 +151,8 @@ different token".
    roster. The invariant scaffold (CLI usage, the shared
    `GLANCE_YIELD_RULES`, memory rules, privacy boundary) is delivered
    once per session out-of-band — `--append-system-prompt-file` for
-   Claude, `developerInstructions` for Codex — so per-turn tokens stay
+   Claude, `developerInstructions` for Codex, `_meta.rules` for Grok ACP —
+   so per-turn tokens stay
    small and the engine's **native auto-compaction** keeps up.
 6. The engine reads its home (`CLAUDE.md` / `AGENTS.md`, skills,
    `memory/`), reasons, and acts through bash: every `cumora …` call
@@ -160,7 +161,9 @@ different token".
 7. **Same-turn steering.** A DM / @mention / human message arriving
    mid-turn is injected into the live session at the next safe stream
    boundary; plain group activity gets a content-free nudge (default
-   on). See COORDINATION.md 3c.
+   on). See COORDINATION.md 3c. Grok Build's ACP `session/prompt` is
+   one-in-flight, so mid-turn inject is a no-op there and the ping
+   coalesces onto the next wake.
 8. Turn ends → run finished, status back. Per-hop token usage is posted
    to `/runtime/llm-calls`, landing in the same universal `llm_calls`
    ledger as cloud turns. Engine failures surface as a
@@ -258,7 +261,7 @@ credentials are keyed to that dir — so the daemon sets `cwd` to the
 agent's home and does **not** relocate config. Per-agent: project memory,
 skills, settings, notes, workspace. Shared across an owner's agents on
 one machine: the engine login and the user's global config (`~/.claude` /
-`~/.codex`). Agents are independent in the dimensions that matter; they
+`~/.codex` / `~/.grok`). Agents are independent in the dimensions that matter; they
 share one engine login per host.
 
 ---
@@ -372,7 +375,7 @@ npx cumora@latest agent computer --pair <code> [--server <url>]
 
 ## Boundaries
 
-- **Cost / rate limits are the operator's** (their Claude Code / Codex
+- **Cost / rate limits are the operator's** (their Claude Code / Codex / Grok Build
   subscription) — a stated BYOA benefit. The daemon's semaphores, spawn
   pacing, and cooldowns exist to stay inside those limits gracefully
   (COORDINATION.md 2-4).

--- a/server/src/__tests__/agents-computer-engine.test.ts
+++ b/server/src/__tests__/agents-computer-engine.test.ts
@@ -3,12 +3,12 @@
  *
  * Run: node --import tsx --test server/src/__tests__/agents-computer-engine.test.ts
  */
-import { mkdtemp, mkdir, writeFile, chmod, rm } from 'node:fs/promises'
+import assert from 'node:assert/strict'
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { setTimeout as delay } from 'node:timers/promises'
 import { afterEach, test } from 'node:test'
-import assert from 'node:assert/strict'
+import { setTimeout as delay } from 'node:timers/promises'
 import { getAdapter, resolveSpawn } from '../agents/computer/engine.js'
 
 const IS_WIN = process.platform === 'win32'
@@ -90,6 +90,44 @@ test('persistent Claude startup failure keeps stderr for first send', async () =
   assert.equal(logs.length, 2)
   assert.match(logs[1] ?? '', /\[session\] engine process died .*exit 1/)
   })
+
+test('grok adapter seeds AGENTS.md and reports sessionId from stream-json', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'cumora-engine-grok-'))
+  tempDirs.push(root)
+  const binDir = join(root, 'bin')
+  const home = join(root, 'home')
+  await mkdir(binDir)
+  await mkdir(home)
+  const fakeGrok = join(binDir, 'grok')
+  await writeFile(
+    fakeGrok,
+    '#!/bin/sh\n' +
+    'echo \'{"type":"system","subtype":"init","session_id":"sess-grok-1","model":"grok-4.6"}\'\n' +
+    'echo \'{"type":"result","subtype":"success","session_id":"sess-grok-1","usage":{"input_tokens":3,"output_tokens":1},"result":"OK"}\'\n' +
+    'exit 0\n',
+    'utf8',
+  )
+  await chmod(fakeGrok, 0o755)
+
+  const adapter = getAdapter('grok')
+  await adapter.seedHome(home, { id: 'iris', name: 'Iris', role: 'Designer' })
+  const agentsMd = await readFile(join(home, 'AGENTS.md'), 'utf8')
+  assert.match(agentsMd, /Iris/)
+
+  const result = await adapter.run({
+    home,
+    prompt: 'wake',
+    env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ''}` },
+    model: null,
+    fastModel: null,
+    onLog: () => { /* unused */ },
+    signal: new AbortController().signal,
+  })
+
+  assert.equal(result.exitCode, 0)
+  assert.equal(result.sessionId, 'sess-grok-1')
+  assert.equal(result.model, 'grok-4.6')
+})
 
   // Regression: nvm-windows on Windows ships an extensionless POSIX shell-shim
   // (`#!/bin/sh` wrapper) alongside the real `.cmd`. The OLD resolveSpawn iterated

--- a/server/src/__tests__/agents-computer-engine.test.ts
+++ b/server/src/__tests__/agents-computer-engine.test.ts
@@ -110,7 +110,7 @@ test('grok adapter seeds AGENTS.md and reports sessionId from stream-json', asyn
   await chmod(fakeGrok, 0o755)
 
   const adapter = getAdapter('grok')
-  await adapter.seedHome(home, { id: 'iris', name: 'Iris', role: 'Designer' })
+  await adapter.seedHome(home, { id: 'iris', name: 'Iris', role: 'Designer', systemPrompt: null })
   const agentsMd = await readFile(join(home, 'AGENTS.md'), 'utf8')
   assert.match(agentsMd, /Iris/)
 

--- a/server/src/agents/computer/daemon.ts
+++ b/server/src/agents/computer/daemon.ts
@@ -499,6 +499,9 @@ function authFailureHint(engine: EngineId, detail: string): string {
   if (engine === 'claude') {
     return 'Open Claude Code on that computer and sign in, refresh quota, or add credits, then wake the agent again.'
   }
+  if (engine === 'grok') {
+    return 'Open Grok Build on that computer and run `grok login`, or set XAI_API_KEY, then wake the agent again.'
+  }
   return 'Open Codex on that computer and refresh its login or quota, then wake the agent again.'
 }
 
@@ -509,6 +512,7 @@ function missingEngineMessage(): string {
     'Install and sign in to at least one of:',
     '  - Claude Code: install the `claude` CLI, then run `claude` once to sign in',
     '  - Codex: install the `codex` CLI, then run `codex` once to sign in',
+    '  - Grok Build: install the `grok` CLI, then run `grok login` once',
     '',
     'After that, rerun:',
     '  npx cumora@latest agent computer --pair <code>',
@@ -520,7 +524,7 @@ function helpText(): string {
     'cumora agent computer — run your Cumora agents on THIS machine (BYOA)',
     '',
     'The daemon talks to a Cumora server over HTTP and drives a local agent',
-    'engine (Claude Code or Codex). Pair once, then it runs in the background.',
+    'engine (Claude Code, Codex, or Grok Build). Pair once, then it runs in the background.',
     '',
     'Usage:',
     '  npx cumora@latest agent computer --pair <code> [--server <url>] [--engine <id>]',
@@ -695,8 +699,16 @@ async function doPair(code: string, serverUrl: string, preferredEngine?: string)
  *    - Auto-flush on every WINDOW_MS tick AND when buffer hits FLUSH_AT.
  *    - flush() can be awaited at "natural pauses" (turn end) to push the tail
  *      promptly without waiting for the timer. */
+type ByoaSource = 'byoa-claude' | 'byoa-codex' | 'byoa-grok'
+
+function byoaSourceOf(id: EngineId): ByoaSource {
+  if (id === 'claude') return 'byoa-claude'
+  if (id === 'codex') return 'byoa-codex'
+  return 'byoa-grok'
+}
+
 interface PendingHop {
-  source: 'byoa-claude' | 'byoa-codex'
+  source: ByoaSource
   purpose: 'agent-turn' | 'inbox-triage' | 'compaction' | 'completion-verify' | 'steer-summary' | 'agenda' | 'synthetic-wake-gate'
   runId: string | null
   conversationId: string | null
@@ -746,7 +758,7 @@ class HopReporter {
     // Codex + Claude batches might intermix (the same reporter is used across
     // session lifetimes), so split by source — the server endpoint takes one
     // source per call (the row's `source` column is set from it).
-    const byHourceSource = new Map<'byoa-claude' | 'byoa-codex', PendingHop[]>()
+    const byHourceSource = new Map<ByoaSource, PendingHop[]>()
     for (const h of batch) {
       const arr = byHourceSource.get(h.source) ?? []
       arr.push(h); byHourceSource.set(h.source, arr)
@@ -871,7 +883,7 @@ class AgentRunner {
       if (typeof report.toolUses === 'number') extras.toolUses = report.toolUses
       if (typeof report.textChars === 'number') extras.textChars = report.textChars
       this.reporter.push({
-        source: this.adapter.id === 'claude' ? 'byoa-claude' : 'byoa-codex',
+        source: byoaSourceOf(this.adapter.id),
         purpose,
         runId: this.currentRunId,
         conversationId: this.lastWakeConvo,
@@ -1248,9 +1260,10 @@ class AgentRunner {
   }
 
   /** Triage model id for pricing (the local cerebellum: claude→haiku,
-   *  codex→gpt-5.4-mini), honoring a CUMORA_TRIAGE_MODEL override. */
+   *  grok→grok-4.5, codex→gpt-5.4-mini), honoring a CUMORA_TRIAGE_MODEL override. */
   private triageModel(): string {
-    return process.env.CUMORA_TRIAGE_MODEL || (this.adapter.id === 'claude' ? 'haiku' : 'gpt-5.4-mini')
+    return process.env.CUMORA_TRIAGE_MODEL
+      || (this.adapter.id === 'claude' ? 'haiku' : this.adapter.id === 'grok' ? 'grok-4.5' : 'gpt-5.4-mini')
   }
 
   /** Post one local-triage record to the cost ledger. Best-effort. `usage` is the

--- a/server/src/agents/computer/engine.ts
+++ b/server/src/agents/computer/engine.ts
@@ -2,7 +2,7 @@
  * EngineAdapter — the pluggable "brain" for a BYOA agent.
  *
  * A BYOA agent's reasoning loop is delegated to a local CLI engine running
- * on the user's machine: Claude Code or Codex. The daemon (daemon.ts) hands
+ * on the user's machine: Claude Code, Codex, or Grok Build. The daemon (daemon.ts) hands
  * each wake to an adapter, which spawns the engine headlessly in the agent's
  * isolated home directory. The engine reads its persona + memory + skills
  * from that home natively (CLAUDE.md / AGENTS.md, .claude/skills, …) and acts
@@ -14,14 +14,14 @@
  * NOTE on engine flags: the exact non-interactive / permission flags differ
  * across engine versions. We pick sensible defaults for an isolated,
  * user-owned runner and let the user override via env
- * (CUMORA_CLAUDE_ARGS / CUMORA_CODEX_ARGS, space-split). Correctness of the
+ * (CUMORA_CLAUDE_ARGS / CUMORA_CODEX_ARGS / CUMORA_GROK_ARGS, space-split). Correctness of the
  * loop does not depend on the structured output — the agent acts via the
  * `cumora` tool regardless of how we parse stdout.
  */
 import { spawn, execFileSync, type ChildProcess } from 'node:child_process'
 import { mkdir, writeFile, access, mkdtemp } from 'node:fs/promises'
 import { existsSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { homedir, tmpdir } from 'node:os'
 import { join, delimiter as PATH_DELIMITER } from 'node:path'
 import { stripLoneSurrogates } from '../text-safety.js'
 
@@ -84,10 +84,10 @@ export function resolveSpawn(bin: string): { command: string; shell: boolean; wa
   return { command: bin, shell: true, wantsStdinPrompt: true }
 }
 
-export type EngineId = 'claude' | 'codex'
+export type EngineId = 'claude' | 'codex' | 'grok'
 
 /** The pairable engine ids, in the daemon's default detection order. */
-export const ENGINE_IDS: EngineId[] = ['claude', 'codex']
+export const ENGINE_IDS: EngineId[] = ['claude', 'codex', 'grok']
 
 export interface EnginePersona {
   id: string
@@ -1404,9 +1404,423 @@ class CodexAdapter implements EngineAdapter {
   }
 }
 
+/** Official Grok Build install lives at ~/.grok/bin even when that dir is
+ *  not on the daemon's PATH (launchd / login-shell mismatch). PATH wins. */
+function resolveGrokBin(env: NodeJS.ProcessEnv = process.env): string | null {
+  for (const dir of (env.PATH ?? '').split(PATH_DELIMITER)) {
+    if (!dir) continue
+    const candidate = join(dir, IS_WIN ? 'grok.exe' : 'grok')
+    if (existsSync(candidate)) return candidate
+    if (IS_WIN && existsSync(join(dir, 'grok'))) return join(dir, 'grok')
+  }
+  const homeBin = join(homedir(), '.grok', 'bin', IS_WIN ? 'grok.exe' : 'grok')
+  return existsSync(homeBin) ? homeBin : null
+}
+
+type AcpMsg = {
+  jsonrpc?: string
+  id?: number
+  method?: string
+  result?: { sessionId?: unknown }
+  error?: { message?: unknown }
+  params?: Record<string, unknown>
+}
+
+/** Persistent Grok Build session over ACP stdio (`grok agent --always-approve stdio`).
+ *  Handshake: initialize → session/new|load → session/prompt per wake.
+ *  Mid-turn steer is not in the ACP surface Grok exposes — steer() is a no-op
+ *  and the daemon's next-wake coalescing carries the ping instead. */
+class GrokSession implements EngineSession {
+  private readonly child: ChildProcess
+  private readonly onLog: (line: string) => void
+  private readonly onHopUsage?: (r: EngineHopReport) => void
+  private outBuf = ''
+  private sid: string | null
+  private exited = false
+  private exitCode = 0
+  private reqId = 0
+  private initializeId: number | null = null
+  private sessionReqId: number | null = null
+  private sessionWasLoad = false
+  private readonly sessionNewParams: Record<string, unknown>
+  private ready = false
+  private pending: { resolve: (r: EngineRunResult) => void; id: number; startedAt: number } | null = null
+  private queuedPrompt: string | null = null
+  private steerWarned = false
+  private readonly model: string | null
+  readonly carriesStandingPrompt: boolean
+
+  constructor(bin: string, spawnArgs: string[], home: string, env: NodeJS.ProcessEnv, opts: EngineSessionArgs) {
+    this.onLog = opts.onLog
+    this.onHopUsage = opts.onHopUsage
+    this.sid = opts.resumeSessionId ?? null
+    this.model = opts.model ?? null
+    this.carriesStandingPrompt = !!opts.standingPrompt
+    const meta: Record<string, unknown> = { yoloMode: true }
+    if (opts.standingPrompt) meta.rules = opts.standingPrompt
+    this.sessionNewParams = { cwd: home, mcpServers: [], _meta: meta }
+    this.sessionWasLoad = !!opts.resumeSessionId
+    const grokEnv: NodeJS.ProcessEnv = { ...env, GROK_DISABLE_AUTOUPDATER: env.GROK_DISABLE_AUTOUPDATER ?? '1' }
+    this.child = spawn(bin, spawnArgs, { cwd: home, env: grokEnv, stdio: ['pipe', 'pipe', 'pipe'], shell: false })
+    this.child.stdout?.on('data', (b: Buffer) => this.onStdout(b))
+    this.child.stderr?.on('data', (b: Buffer) => {
+      for (const raw of b.toString('utf8').split('\n')) {
+        const l = cleanLine(raw)
+        if (l) this.onLog(l)
+      }
+    })
+    this.child.on('error', (err) => this.die(1, err.message))
+    this.child.on('close', (code, sig) => this.die(code ?? (sig ? 128 : 1), sig ? `terminated by ${sig}` : `exited with code ${code}`))
+    queueMicrotask(() => {
+      this.initializeId = this.req('initialize', {
+        protocolVersion: 1,
+        clientInfo: { name: 'cumora-daemon', version: '1.0.0' },
+        clientCapabilities: { fs: { readTextFile: false, writeTextFile: false } },
+      })
+    })
+  }
+
+  get alive(): boolean { return !this.exited && this.child.stdin?.writable === true }
+  get sessionId(): string | null { return this.sid }
+
+  send(prompt: string): Promise<EngineRunResult> {
+    if (this.pending) return Promise.resolve({ exitCode: 1, error: 'engine session busy — a turn is already in flight', sessionId: this.sid })
+    if (!this.alive) return Promise.resolve({ exitCode: this.exitCode || 1, error: 'engine session is not alive (process gone)', sessionId: this.sid })
+    return new Promise<EngineRunResult>((resolve) => {
+      this.pending = { resolve, id: 0, startedAt: Date.now() }
+      if (this.ready && this.sid) this.startPrompt(prompt)
+      else this.queuedPrompt = prompt
+    })
+  }
+
+  steer(_text: string): void {
+    // ACP session/prompt is one-in-flight. A mid-turn inject would cancel the
+    // running turn. The daemon coalesces the ping onto the next wake instead.
+    if (!this.steerWarned) {
+      this.steerWarned = true
+      this.onLog('[grok] same-turn steer is not supported on ACP stdio — the ping rides the next wake')
+    }
+  }
+
+  stop(): void {
+    this.exited = true
+    try { this.child.stdin?.end() } catch { /* ignore */ }
+    try { this.child.kill('SIGTERM') } catch { /* ignore */ }
+  }
+
+  private nextId(): number { this.reqId += 1; return this.reqId }
+  private req(method: string, params: Record<string, unknown>): number {
+    const id = this.nextId()
+    try { this.child.stdin?.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n') } catch { /* die() */ }
+    return id
+  }
+
+  private startPrompt(prompt: string): void {
+    if (!this.sid || !this.pending) return
+    const id = this.req('session/prompt', {
+      sessionId: this.sid,
+      prompt: [{ type: 'text', text: stripLoneSurrogates(prompt) }],
+    })
+    this.pending.id = id
+  }
+
+  private onStdout(buf: Buffer): void {
+    this.outBuf += buf.toString('utf8')
+    let nl: number
+    while ((nl = this.outBuf.indexOf('\n')) >= 0) {
+      const line = this.outBuf.slice(0, nl)
+      this.outBuf = this.outBuf.slice(nl + 1)
+      const t = line.trim()
+      if (!t.startsWith('{')) { const c = cleanLine(line); if (c) this.onLog(c); continue }
+      let msg: AcpMsg | null = null
+      try { msg = JSON.parse(t) as AcpMsg } catch { msg = null }
+      if (!msg) { const c = cleanLine(line); if (c) this.onLog(c); continue }
+      this.handle(msg)
+    }
+  }
+
+  private handle(msg: AcpMsg): void {
+    if (msg.id !== undefined && msg.id === this.initializeId) {
+      this.initializeId = null
+      if (msg.error) { this.failPending(String(msg.error.message || 'grok initialize failed')); return }
+      if (this.sessionWasLoad && this.sid) {
+        this.sessionReqId = this.req('session/load', { sessionId: this.sid, ...this.sessionNewParams })
+      } else {
+        this.sessionReqId = this.req('session/new', this.sessionNewParams)
+      }
+      return
+    }
+    if (msg.error && msg.id !== undefined && msg.id === this.sessionReqId) {
+      if (this.sessionWasLoad) {
+        this.onLog(`[grok] session/load failed (${String(msg.error.message || '')}) — starting a fresh session`)
+        this.sessionWasLoad = false
+        this.sid = null
+        this.sessionReqId = this.req('session/new', this.sessionNewParams)
+        return
+      }
+      this.failPending(String(msg.error.message || 'grok session start failed'))
+      return
+    }
+    if (msg.id !== undefined && msg.id === this.sessionReqId && msg.result) {
+      const sid = typeof msg.result.sessionId === 'string' ? msg.result.sessionId : this.sid
+      this.sessionReqId = null
+      if (typeof sid === 'string' && sid) this.sid = sid
+      this.ready = true
+      if (this.queuedPrompt && this.pending) {
+        const p = this.queuedPrompt
+        this.queuedPrompt = null
+        this.startPrompt(p)
+      }
+      return
+    }
+    if (msg.method === 'session/update') {
+      const update = (msg.params?.update ?? msg.params?.sessionUpdate) as Record<string, unknown> | undefined
+      const kind = typeof update?.sessionUpdate === 'string' ? update.sessionUpdate
+        : typeof update?.sessionUpdate === 'undefined' && typeof (msg.params as { sessionUpdate?: unknown } | undefined)?.sessionUpdate === 'string'
+          ? String((msg.params as { sessionUpdate?: unknown }).sessionUpdate)
+          : null
+      const u = (update ?? msg.params ?? {}) as Record<string, unknown>
+      const k = kind ?? (typeof u.sessionUpdate === 'string' ? u.sessionUpdate : null)
+      if (k === 'tool_call' && typeof u.title === 'string') this.onLog(`[grok] tool ${u.title}`)
+      else if (k === 'agent_message_chunk') {
+        const content = u.content as { text?: unknown } | undefined
+        if (typeof content?.text === 'string' && content.text.trim()) {
+          this.onLog(`[grok] » ${content.text.replace(/\s+/g, ' ').slice(0, 200)}`)
+        }
+      }
+      return
+    }
+    if (this.pending && msg.id !== undefined && msg.id === this.pending.id) {
+      if (msg.error) { this.failPending(String(msg.error.message || 'grok prompt failed')); return }
+      const usage = extractAcpUsage(msg.result)
+      if (this.onHopUsage) {
+        try {
+          this.onHopUsage({
+            model: this.model || 'grok',
+            usage: usage ?? {},
+            latencyMs: Date.now() - this.pending.startedAt,
+            hopIndex: 1,
+          })
+        } catch { /* never break the stream */ }
+      }
+      const p = this.pending
+      this.pending = null
+      p.resolve({ exitCode: 0, sessionId: this.sid, usage, model: this.model })
+      return
+    }
+    if (msg.error && msg.id !== undefined) {
+      this.failPending(String(msg.error.message || 'grok acp request failed'))
+    }
+  }
+
+  private failPending(error: string): void {
+    if (this.pending) {
+      const p = this.pending
+      this.pending = null
+      p.resolve({ exitCode: 1, error, sessionId: this.sid })
+    } else {
+      this.onLog(`[grok] ${error}`)
+    }
+  }
+
+  private die(code: number, why: string): void {
+    const alreadyDown = this.exited
+    this.exited = true
+    this.exitCode = code
+    if (!alreadyDown) {
+      this.onLog(`[session] engine process died ${this.pending ? 'MID-TURN' : 'while idle'}: ${why} (exit ${code})`)
+    }
+    if (this.pending) {
+      const p = this.pending
+      this.pending = null
+      p.resolve({ exitCode: code, error: why, sessionId: this.sid })
+    }
+  }
+}
+
+function extractAcpUsage(result: unknown): EngineUsage | undefined {
+  if (!result || typeof result !== 'object') return undefined
+  const r = result as Record<string, unknown>
+  const raw = (r.usage ?? (r._meta as Record<string, unknown> | undefined)?.usage) as Record<string, unknown> | undefined
+  if (!raw || typeof raw !== 'object') return undefined
+  const num = (v: unknown): number | undefined => (typeof v === 'number' && Number.isFinite(v) ? v : undefined)
+  const usage: EngineUsage = {
+    input_tokens: num(raw.input_tokens) ?? num(raw.inputTokens),
+    output_tokens: num(raw.output_tokens) ?? num(raw.outputTokens),
+    cache_read_input_tokens: num(raw.cache_read_input_tokens) ?? num(raw.cacheReadInputTokens),
+    cache_creation_input_tokens: num(raw.cache_creation_input_tokens) ?? num(raw.cacheCreationInputTokens),
+  }
+  if (usage.input_tokens == null && usage.output_tokens == null) return undefined
+  return usage
+}
+
+class GrokAdapter implements EngineAdapter {
+  readonly id = 'grok' as const
+  readonly bin = 'grok'
+
+  private command(env?: NodeJS.ProcessEnv): string {
+    return resolveGrokBin(env) ?? this.bin
+  }
+
+  async classify(args: EngineClassifyArgs): Promise<EngineClassifyResult> {
+    const flags = extraArgs('CUMORA_TRIAGE_ARGS')
+    const model = ['--model', args.model || 'grok-4.5']
+    const command = this.command(args.env)
+    const { shell, wantsStdinPrompt } = resolveSpawn(this.bin)
+    const usingJson = flags.length === 0
+    const base = flags.length
+      ? [...flags, '-p']
+      : ['-p', ...model, '--output-format', 'json', '--always-approve', '--no-auto-update']
+    const argv = wantsStdinPrompt ? base : (flags.length ? [...base, args.prompt] : ['-p', args.prompt, ...base.slice(1)])
+    const res = await spawnCapture(command, argv, {
+      cwd: args.cwd,
+      env: { ...args.env, GROK_DISABLE_AUTOUPDATER: args.env.GROK_DISABLE_AUTOUPDATER ?? '1' },
+      signal: args.signal,
+      onLog: args.onLog,
+      shell,
+      stdinText: wantsStdinPrompt ? args.prompt : undefined,
+    })
+    if (res.error || !usingJson) return res
+    try {
+      const obj = JSON.parse(res.text) as { text?: unknown; usage?: EngineUsage }
+      return {
+        text: typeof obj.text === 'string' ? obj.text : res.text,
+        usage: obj.usage && typeof obj.usage === 'object' ? obj.usage : undefined,
+      }
+    } catch {
+      return res
+    }
+  }
+
+  probe(args: EngineProbeArgs): Promise<EngineClassifyResult> {
+    const model = args.tier === 'small' ? ['--model', 'grok-4.5'] : []
+    const command = this.command(args.env)
+    const { shell, wantsStdinPrompt } = resolveSpawn(this.bin)
+    const base = ['-p', ...model, '--output-format', 'json', '--always-approve', '--no-auto-update']
+    const argv = wantsStdinPrompt ? base : ['-p', DOCTOR_PROMPT, ...base.slice(1)]
+    return spawnCapture(command, argv, {
+      cwd: args.cwd,
+      env: { ...args.env, GROK_DISABLE_AUTOUPDATER: args.env.GROK_DISABLE_AUTOUPDATER ?? '1' },
+      signal: args.signal,
+      shell,
+      stdinText: wantsStdinPrompt ? DOCTOR_PROMPT : undefined,
+    })
+  }
+
+  async probeWake(args: EngineWakeProbeArgs): Promise<EngineWakeProbeResult> {
+    // Same gates as startSession: custom args / opt-out / Windows collapse to
+    // one-shot `grok -p`, which probe() already covers.
+    if (extraArgs('CUMORA_GROK_ARGS').length || process.env.CUMORA_GROK_NO_ACP === '1' || IS_WIN) {
+      return { ok: true, detail: '', skipped: true }
+    }
+    const command = this.command(args.env)
+    return new Promise<EngineWakeProbeResult>((resolve) => {
+      let settled = false
+      const finish = (r: EngineWakeProbeResult) => {
+        if (settled) return
+        settled = true
+        try { child.stdin?.end() } catch { /* ignore */ }
+        try { child.kill('SIGTERM') } catch { /* ignore */ }
+        resolve(r)
+      }
+      const child = spawn(command, ['agent', '--always-approve', '--no-leader', 'stdio'], {
+        cwd: args.cwd,
+        env: { ...args.env, GROK_DISABLE_AUTOUPDATER: args.env.GROK_DISABLE_AUTOUPDATER ?? '1' },
+        stdio: ['pipe', 'pipe', 'pipe'],
+        shell: false,
+      })
+      const onAbort = () => finish({ ok: false, detail: 'aborted (timeout)' })
+      if (args.signal.aborted) { onAbort(); return }
+      args.signal.addEventListener('abort', onAbort, { once: true })
+      let buf = ''
+      let stderrTail = ''
+      const initId = 1
+      const sessionId = 2
+      let initialized = false
+      const writeRpc = (msg: object) => {
+        try { child.stdin?.write(JSON.stringify(msg) + '\n') } catch { /* die */ }
+      }
+      writeRpc({
+        jsonrpc: '2.0', id: initId, method: 'initialize',
+        params: { protocolVersion: 1, clientInfo: { name: 'cumora-doctor', version: '1.0.0' }, clientCapabilities: {} },
+      })
+      child.stdout?.on('data', (b: Buffer) => {
+        buf += b.toString('utf8')
+        for (;;) {
+          const nl = buf.indexOf('\n')
+          if (nl < 0) break
+          const line = buf.slice(0, nl).trim()
+          buf = buf.slice(nl + 1)
+          if (!line.startsWith('{')) continue
+          let msg: AcpMsg
+          try { msg = JSON.parse(line) as AcpMsg } catch { continue }
+          if (msg.error?.message) {
+            finish({ ok: false, detail: `acp rejected handshake: ${String(msg.error.message).slice(0, 240)}` })
+            return
+          }
+          if (!initialized && msg.id === initId && msg.result) {
+            initialized = true
+            writeRpc({
+              jsonrpc: '2.0', id: sessionId, method: 'session/new',
+              params: { cwd: args.cwd, mcpServers: [], _meta: { yoloMode: true } },
+            })
+            continue
+          }
+          if (initialized && msg.id === sessionId && msg.result) {
+            finish({ ok: true, detail: '' })
+            return
+          }
+        }
+      })
+      child.stderr?.on('data', (b: Buffer) => {
+        const tail = stderrTail + b.toString('utf8')
+        stderrTail = tail.length > 2000 ? tail.slice(-2000) : tail
+      })
+      child.on('error', (err) => finish({ ok: false, detail: `spawn error: ${err.message}` }))
+      child.on('close', (code, sig) => {
+        if (settled) return
+        const stage = !initialized ? 'before initialize ack' : 'before session/new ack'
+        const exit = sig ? `terminated by ${sig}` : `exit ${code}`
+        finish({ ok: false, detail: `grok agent stdio died ${stage} (${exit}): ${salientError(stderrTail) || 'no stderr'}` })
+      })
+    })
+  }
+
+  async seedHome(home: string, persona: EnginePersona): Promise<void> {
+    await ensureCommonHome(home)
+    const agentsMd = join(home, 'AGENTS.md')
+    if (!(await exists(agentsMd))) await writeFile(agentsMd, PERSONA_HEADER(persona), 'utf8')
+  }
+
+  run(args: EngineRunArgs): Promise<EngineRunResult> {
+    const flags = extraArgs('CUMORA_GROK_ARGS')
+    const model = args.model ? ['--model', args.model] : []
+    const resume = args.resumeSessionId ? ['--resume', args.resumeSessionId] : []
+    const command = this.command(args.env)
+    const { shell, wantsStdinPrompt } = resolveSpawn(this.bin)
+    const base = flags.length
+      ? [...flags, ...resume, '-p']
+      : ['-p', ...resume, ...model, '--output-format', 'streaming-messages-json', '--always-approve', '--no-auto-update']
+    const argv = wantsStdinPrompt ? base : (flags.length ? [...base, args.prompt] : ['-p', args.prompt, ...base.slice(1)])
+    const env: NodeJS.ProcessEnv = { ...args.env, GROK_DISABLE_AUTOUPDATER: args.env.GROK_DISABLE_AUTOUPDATER ?? '1' }
+    return spawnEngine(command, argv, { ...args, env }, { shell, stdinText: wantsStdinPrompt ? args.prompt : undefined })
+  }
+
+  startSession(args: EngineSessionArgs): EngineSession | null {
+    if (extraArgs('CUMORA_GROK_ARGS').length) return null
+    if (process.env.CUMORA_GROK_NO_ACP === '1') return null
+    // JSON-RPC over a Windows .cmd shim is the same trap Codex hits — exec
+    // (`grok -p`) is the safe path there.
+    if (IS_WIN) return null
+    const model = args.model ? ['--model', args.model] : []
+    return new GrokSession(this.command(args.env), ['agent', '--always-approve', '--no-leader', ...model, 'stdio'], args.home, args.env, args)
+  }
+}
+
 const ADAPTERS: Record<EngineId, EngineAdapter> = {
   claude: new ClaudeAdapter(),
   codex: new CodexAdapter(),
+  grok: new GrokAdapter(),
 }
 
 export function getAdapter(id: EngineId): EngineAdapter {
@@ -1416,7 +1830,11 @@ export function getAdapter(id: EngineId): EngineAdapter {
 /** Probe which engines are installed on this machine. */
 export async function detectEngines(): Promise<EngineId[]> {
   const ids = Object.keys(ADAPTERS) as EngineId[]
-  const present = await Promise.all(ids.map(async (id) => ((await binOnPath(ADAPTERS[id].bin)) ? id : null)))
+  const present = await Promise.all(ids.map(async (id) => {
+    if (await binOnPath(ADAPTERS[id].bin)) return id
+    if (id === 'grok' && resolveGrokBin()) return id
+    return null
+  }))
   return present.filter((x): x is EngineId => x !== null)
 }
 
@@ -1460,7 +1878,7 @@ export interface EngineHealth {
   big: BrainHealth | null
   small: BrainHealth | null
   /** Wake-path protocol health (codex app-server JSON-RPC handshake; claude
-   *  persistent-session flag set). Separate signal from big/small because the
+   *  persistent-session flag set; grok ACP stdio handshake). Separate signal from big/small because the
    *  failure modes are different — those are auth/quota; this is protocol/CLI
    *  version compatibility. */
   wake: WakeHealth | null
@@ -1494,7 +1912,7 @@ export async function runEngineDoctor(opts?: {
   const ids = Object.keys(ADAPTERS) as EngineId[]
   return Promise.all(ids.map(async (id): Promise<EngineHealth> => {
     const adapter = ADAPTERS[id]
-    const path = await resolveBinPath(adapter.bin)
+    const path = (await resolveBinPath(adapter.bin)) ?? (id === 'grok' ? resolveGrokBin(env) : null)
     if (!path) return { id, installed: false, path: null, big: null, small: null, wake: null }
     const probeTier = async (tier: 'big' | 'small'): Promise<BrainHealth> => {
       const controller = new AbortController()

--- a/server/src/agents/computer/registry.ts
+++ b/server/src/agents/computer/registry.ts
@@ -20,7 +20,7 @@ import { publish, CH_STATUS } from '../../redis.js'
 import { signAgentToken } from '../runtime/jwt.js'
 
 export type ComputerKind = 'cloud' | 'local' | 'vps'
-export type EngineId = 'managed' | 'claude' | 'codex'
+export type EngineId = 'managed' | 'claude' | 'codex' | 'grok'
 export type ComputerStatus = 'online' | 'offline' | 'busy'
 
 /** How long a paired computer can go without a heartbeat before the sweep
@@ -45,7 +45,7 @@ export async function announceComputerOnline(computerId: string, companyId: stri
 }
 
 /** Engines a paired (non-cloud) computer is allowed to advertise. */
-const PAIRABLE_ENGINES: ReadonlySet<string> = new Set(['claude', 'codex'])
+const PAIRABLE_ENGINES: ReadonlySet<string> = new Set(['claude', 'codex', 'grok'])
 
 export interface ComputerRow {
   id: string
@@ -365,9 +365,10 @@ export async function listAgentsForComputer(computerId: string): Promise<
   )
   const claudeDefault = process.env.CUMORA_DEFAULT_CLAUDE_MODEL?.trim() || null
   const codexDefault = process.env.CUMORA_DEFAULT_CODEX_MODEL?.trim() || null
+  const grokDefault = process.env.CUMORA_DEFAULT_GROK_MODEL?.trim() || null
   return rows.map((r) => {
     if (r.model) return r
-    const dflt = r.engine === 'codex' ? codexDefault : r.engine === 'claude' ? claudeDefault : null
+    const dflt = r.engine === 'codex' ? codexDefault : r.engine === 'claude' ? claudeDefault : r.engine === 'grok' ? grokDefault : null
     return dflt ? { ...r, model: dflt } : r
   })
 }

--- a/server/src/agents/llm-ledger.ts
+++ b/server/src/agents/llm-ledger.ts
@@ -71,7 +71,7 @@ export type LlmCallPurpose =
   | 'agent-image'
 
 export type LlmCallStatus = 'ok' | 'rate_limited' | 'timeout' | 'failed'
-export type LlmCallSource = 'cloud' | 'byoa-claude' | 'byoa-codex'
+export type LlmCallSource = 'cloud' | 'byoa-claude' | 'byoa-codex' | 'byoa-grok'
 
 /** Context bound to a tracked client. Every LLM call it makes carries this
  *  shape into the ledger. `purpose` is mandatory; everything else scopes the

--- a/server/src/agents/observability.ts
+++ b/server/src/agents/observability.ts
@@ -3,7 +3,7 @@ import { pool } from '../db/pool.js'
 import { effectiveCostUsd, priceFor, modelPriceTable, EMPTY_USAGE, type TokenUsage } from './cost.js'
 
 export type AgentRunStatus = 'running' | 'completed' | 'failed' | 'skipped'
-export type TriageSource = 'cloud' | 'byoa-claude' | 'byoa-codex'
+export type TriageSource = 'cloud' | 'byoa-claude' | 'byoa-codex' | 'byoa-grok'
 export type AgentEventLevel = 'debug' | 'info' | 'warn' | 'error'
 
 const MAX_STRING_CHARS = 24_000

--- a/server/src/agents/runtime/server.ts
+++ b/server/src/agents/runtime/server.ts
@@ -413,7 +413,7 @@ runtimeRouter.post('/triage', withAgent(async (c, req, res) => {
 // per turn-completed (Codex) and batches them into one POST per N hops or
 // every ~250ms (whichever first). This endpoint accepts a batch + inserts
 // one llm_calls row per hop with the appropriate source ('byoa-claude' |
-// 'byoa-codex'). Fire-and-forget; a DB hiccup must never break the wake.
+// 'byoa-codex' | 'byoa-grok'). Fire-and-forget; a DB hiccup must never break the wake.
 runtimeRouter.post('/llm-calls', withAgent(async (c, req, res) => {
   const body = req.body as {
     source?: string
@@ -433,7 +433,7 @@ runtimeRouter.post('/llm-calls', withAgent(async (c, req, res) => {
       extras?: Record<string, unknown>
     }>
   } | undefined
-  const source = (body?.source === 'byoa-claude' || body?.source === 'byoa-codex') ? body.source : 'byoa-claude'
+  const source = (body?.source === 'byoa-claude' || body?.source === 'byoa-codex' || body?.source === 'byoa-grok') ? body.source : 'byoa-claude'
   const daemonVersion = typeof body?.daemonVersion === 'string' && body.daemonVersion.trim() ? body.daemonVersion.trim().slice(0, 32) : null
   const hops = Array.isArray(body?.hops) ? body!.hops : []
   if (hops.length === 0) { res.json({ ok: true, inserted: 0 }); return }

--- a/server/src/api/router.ts
+++ b/server/src/api/router.ts
@@ -1098,7 +1098,7 @@ api.post('/computers/pair', safe(async (req, res) => {
   // and any adopted agent are created with. Fall back to Claude if unreported.
   try {
     if ((await companyTier(paired.companyId)) === 'free') {
-      const engine = (engines[0] === 'claude' || engines[0] === 'codex') ? engines[0] : 'claude'
+      const engine = (engines[0] === 'claude' || engines[0] === 'codex' || engines[0] === 'grok') ? engines[0] : 'claude'
       // Adopt only agents that are stranded on the managed Cumora Cloud (or
       // unassigned) onto the just-paired machine — earlier builds' boot backfill
       // wrongly seeded free starters on cloud, where free can't run them. Agents

--- a/src/admin/ObservabilityPage.tsx
+++ b/src/admin/ObservabilityPage.tsx
@@ -167,7 +167,7 @@ const SOURCE_FILTERS: Array<{ key: SourceFilter; label: string }> = [
   { key: 'cloud', label: 'Cloud' },
   { key: 'byoa',  label: 'BYOA' },
 ]
-const isByoaSource = (s: string): boolean => s === 'byoa-claude' || s === 'byoa-codex'
+const isByoaSource = (s: string): boolean => s === 'byoa-claude' || s === 'byoa-codex' || s === 'byoa-grok'
 
 // ─── Component ───────────────────────────────────────────────────────────
 

--- a/src/admin/api.ts
+++ b/src/admin/api.ts
@@ -120,7 +120,7 @@ export type LlmCallPurpose =
   | 'palette' | 'gender' | 'avatar-image' | 'agent-image'
 
 export type LlmCallStatus = 'ok' | 'rate_limited' | 'timeout' | 'failed'
-export type LlmCallSource = 'cloud' | 'byoa-claude' | 'byoa-codex'
+export type LlmCallSource = 'cloud' | 'byoa-claude' | 'byoa-codex' | 'byoa-grok'
 
 export interface LlmSummary {
   sinceDays: number

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -401,7 +401,7 @@ export interface ApiAgentRun {
 }
 
 // ── Triage cost-effectiveness ledger ──
-export type ApiTriageSource = 'cloud' | 'byoa-claude' | 'byoa-codex'
+export type ApiTriageSource = 'cloud' | 'byoa-claude' | 'byoa-codex' | 'byoa-grok'
 
 export interface ApiTriageAgentRow {
   agentId: string

--- a/src/components/AgentEditor.tsx
+++ b/src/components/AgentEditor.tsx
@@ -239,7 +239,7 @@ export function AgentEditor({ agent, onClose }: Props) {
           <Field
             label={isByoa ? 'Big-brain model (大脑)' : 'Model'}
             hint={isByoa
-              ? `Main reasoning model passed to the engine as --model. ${engine === 'codex' ? 'A model name (e.g. gpt-5.5, o3).' : "A Claude alias or full name (e.g. opus, sonnet, claude-sonnet-4-6)."} Blank = engine default.`
+              ? `Main reasoning model passed to the engine as --model. ${engine === 'codex' ? 'A model name (e.g. gpt-5.5, o3).' : engine === 'grok' ? 'A Grok model (e.g. grok-4.6).' : "A Claude alias or full name (e.g. opus, sonnet, claude-sonnet-4-6)."} Blank = engine default.`
               : 'Optional — leave blank to use the system default. Any OpenAI model name works (e.g. gpt-5.5, gpt-5.5-pro, gpt-5.5-mini).'}
           >
             <Input
@@ -257,7 +257,9 @@ export function AgentEditor({ agent, onClose }: Props) {
               label="Small-brain model (小脑)"
               hint={engine === 'codex'
                 ? 'Cheaper model for light auxiliary tasks (e.g. gpt-5.4-mini). Blank = same as big-brain.'
-                : "Cheaper/faster model for light auxiliary tasks — maps to Claude's ANTHROPIC_SMALL_FAST_MODEL. Blank = engine default."}
+                : engine === 'grok'
+                  ? 'Cheaper/faster Grok model for light auxiliary tasks (e.g. grok-4.5). Blank = engine default.'
+                  : "Cheaper/faster model for light auxiliary tasks — maps to Claude's ANTHROPIC_SMALL_FAST_MODEL. Blank = engine default."}
             >
               <Input
                 type="text"
@@ -272,7 +274,7 @@ export function AgentEditor({ agent, onClose }: Props) {
 
           <Field
             label="Runs on"
-            hint="Which computer executes this agent. Cumora Cloud is managed; a computer you've paired runs it on your local Claude Code or Codex."
+            hint="Which computer executes this agent. Cumora Cloud is managed; a computer you've paired runs it on your local Claude Code, Codex, or Grok Build."
           >
             <Select
               ariaLabel="Runs on"
@@ -305,7 +307,7 @@ export function AgentEditor({ agent, onClose }: Props) {
                   options={(selectedComputer.availableEngines.length
                     ? selectedComputer.availableEngines
                     : (['claude'] as EngineId[])
-                  ).map((en) => ({ value: en, label: en === 'claude' ? 'Claude Code' : en === 'codex' ? 'Codex' : en }))}
+                  ).map((en) => ({ value: en, label: en === 'claude' ? 'Claude Code' : en === 'codex' ? 'Codex' : en === 'grok' ? 'Grok Build' : en }))}
                 />
               </div>
             )}

--- a/src/desktop/MeView.tsx
+++ b/src/desktop/MeView.tsx
@@ -695,7 +695,7 @@ function SkypeSoundSection() {
   )
 }
 
-const ENGINE_LABEL: Record<string, string> = { managed: 'Cumora', claude: 'Claude Code', codex: 'Codex' }
+const ENGINE_LABEL: Record<string, string> = { managed: 'Cumora', claude: 'Claude Code', codex: 'Codex', grok: 'Grok Build' }
 const KIND_ICON: Record<string, string> = { cloud: '☁', local: '💻', vps: '🖥' }
 const STATUS_COLOR: Record<string, string> = { online: '#3BB273', busy: '#E6A23C', offline: 'var(--ink-300)' }
 
@@ -709,7 +709,7 @@ function ComputersTab() {
   const [copied, setCopied] = useState(false)
   // Engine for a NEWLY added computer's starter/assigned agents. Claude is the
   // default (no flag → daemon auto-detects); Codex appends `--engine codex`.
-  const [engine, setEngine] = useState<'claude' | 'codex'>('claude')
+  const [engine, setEngine] = useState<'claude' | 'codex' | 'grok'>('claude')
   // Default on: install the always-on service (auto-start/restart/update).
   // --install-service is macOS/Linux only (daemon throws on Windows) → off + hidden there.
   const [asService, setAsService] = useState(!isWindows)
@@ -856,12 +856,12 @@ function ComputersTab() {
               Run this on the machine you want to host agents:
             </div>
             <div className="text-[11.5px] text-ink-500 mb-2.5 italic font-display">
-              Needs <span className="font-mono not-italic">claude</span> or <span className="font-mono not-italic">codex</span> installed. The computer names itself after that machine and appears here once paired. This token stays valid.
+              Needs <span className="font-mono not-italic">claude</span>, <span className="font-mono not-italic">codex</span>, or <span className="font-mono not-italic">grok</span> installed. The computer names itself after that machine and appears here once paired. This token stays valid.
             </div>
             <div className="flex items-center gap-2.5 mb-2.5">
               <span className="text-[12px] text-ink-500">Engine</span>
               <div className="inline-flex rounded-[9px] p-0.5" style={{ background: 'var(--ink-100)' }}>
-                {([['claude', 'Claude Code'], ['codex', 'Codex']] as const).map(([id, label]) => (
+                {([['claude', 'Claude Code'], ['codex', 'Codex'], ['grok', 'Grok Build']] as const).map(([id, label]) => (
                   <button key={id} type="button" onClick={() => setEngine(id)}
                     className="px-3 py-1 rounded-[7px] text-[12px] font-semibold transition-colors duration-150"
                     style={engine === id
@@ -871,7 +871,7 @@ function ComputersTab() {
                   </button>
                 ))}
               </div>
-              <span className="text-[11px] text-ink-400">just the default — this computer can still run agents on either engine</span>
+              <span className="text-[11px] text-ink-400">just the default — this computer can still run agents on any detected engine</span>
             </div>
             {isWindows ? (
               <div className="mb-2.5 text-[12px] text-ink-600">

--- a/src/desktop/Onboarding.tsx
+++ b/src/desktop/Onboarding.tsx
@@ -20,7 +20,7 @@ export function Onboarding() {
   // Claude is the default; picking Codex appends `--engine codex`. We DON'T
   // append `--engine claude` so a Codex-only machine still auto-detects rather
   // than erroring on a Claude it doesn't have.
-  const [engine, setEngine] = useState<'claude' | 'codex'>('claude')
+  const [engine, setEngine] = useState<'claude' | 'codex' | 'grok'>('claude')
   // Default to installing the always-on service: it auto-starts on boot,
   // auto-restarts on crash, and auto-updates — so the user isn't tied to a
   // terminal that must stay open. Appends `--install-service` to the command.
@@ -74,7 +74,7 @@ export function Onboarding() {
               <>
                 <div className="text-[13px] text-ink-600 mb-4">
                   On the machine you want to host your agents, you'll run one command. It needs
-                  <span className="font-mono"> claude</span> or <span className="font-mono">codex</span> installed.
+                  <span className="font-mono"> claude</span>, <span className="font-mono">codex</span>, or <span className="font-mono">grok</span> installed.
                 </div>
                 {err && <div className="text-[12px] text-coral-deep bg-coral-soft rounded-[8px] p-2 mb-3">{err}</div>}
                 <button onClick={getCode} disabled={busy}
@@ -91,7 +91,7 @@ export function Onboarding() {
                 <div className="flex items-center gap-2.5 mb-2.5">
                   <span className="text-[12px] text-ink-500">Engine</span>
                   <div className="inline-flex rounded-[9px] p-0.5" style={{ background: 'var(--ink-100)' }}>
-                    {([['claude', 'Claude Code'], ['codex', 'Codex']] as const).map(([id, label]) => (
+                    {([['claude', 'Claude Code'], ['codex', 'Codex'], ['grok', 'Grok Build']] as const).map(([id, label]) => (
                       <button key={id} type="button" onClick={() => setEngine(id)}
                         className="px-3 py-1 rounded-[7px] text-[12px] font-semibold transition-colors duration-150"
                         style={engine === id
@@ -101,7 +101,7 @@ export function Onboarding() {
                       </button>
                     ))}
                   </div>
-                  <span className="text-[11px] text-ink-400">just the default — this computer can still run agents on either engine</span>
+                  <span className="text-[11px] text-ink-400">just the default — this computer can still run agents on any detected engine</span>
                 </div>
                 {isWindows ? (
                   <div className="mb-2.5 text-[12px] text-ink-600">

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export type Status = 'avail' | 'working' | 'thinking' | 'waiting' | 'resting'
 export type ComputerKind = 'cloud' | 'local' | 'vps'
 export type ComputerStatus = 'online' | 'offline' | 'busy'
 /** Engine an agent's host runs it on. 'managed' = Cumora's server-side loop. */
-export type EngineId = 'managed' | 'claude' | 'codex'
+export type EngineId = 'managed' | 'claude' | 'codex' | 'grok'
 
 export interface Computer {
   id: string


### PR DESCRIPTION
Adds Grok Build (`grok`) as a third pairable BYOA engine next to Claude Code and Codex.

- Detect `grok` on PATH or `~/.grok/bin`
- Persistent session: `grok agent --always-approve --no-leader stdio` (ACP)
- One-shot fallback: `grok -p` when `CUMORA_GROK_ARGS` / `CUMORA_GROK_NO_ACP=1` is set, and on Windows (same JSON-RPC-over-`.cmd` trap as Codex)
- Pairing UI, agent engine picker, `byoa-grok` ledger source, doctor probe
- Optional pin via `CUMORA_DEFAULT_GROK_MODEL` / per-agent `--model`

Grok's ACP `session/prompt` is one-in-flight, so same-turn steer is a no-op; the daemon coalesces the ping onto the next wake.