### PR TITLE
fix(byoa): don't truncate large CLI output in the `cumora` shim

### DIFF
--- a/server/src/__tests__/agent-computer-shim-output.test.ts
+++ b/server/src/__tests__/agent-computer-shim-output.test.ts
@@ -1,0 +1,106 @@
+/**
+ * The BYOA `cumora` shim must hand the engine the WHOLE CLI result.
+ *
+ * stdout on a pipe is asynchronous in Node, so `process.exit()` on the line
+ * after `process.stdout.write()` discards whatever is still buffered. The engine
+ * always runs the shim with stdout piped, so this silently truncated every large
+ * result at the pipe buffer — with exit code 0 and empty stderr, which is why
+ * nothing ever surfaced it.
+ *
+ * These run the REAL shim text against a REAL pipe, since that is the only place
+ * the bug exists.
+ *
+ * Run: node --import tsx --test server/src/__tests__/agent-computer-shim-output.test.ts
+ */
+import { spawn } from 'node:child_process'
+import { createServer, type Server } from 'node:http'
+import { mkdtemp, writeFile, chmod, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { CUMORA_SHIM } from '../agents/computer/daemon.js'
+
+const cleanup: Array<() => Promise<void> | void> = []
+
+afterEach(async () => {
+  for (const fn of cleanup.splice(0)) await fn()
+})
+
+/** A stand-in for /runtime/cli that returns a payload of the requested size. */
+async function serveCli(payload: string, exitCode = 0): Promise<string> {
+  const server: Server = createServer((_req, res) => {
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end(JSON.stringify({ text: payload, exitCode, ok: exitCode === 0, sideEffects: [] }))
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  cleanup.push(() => new Promise<void>((resolve) => { server.close(() => resolve()) }))
+  const addr = server.address()
+  if (!addr || typeof addr === 'string') throw new Error('no port')
+  return `http://127.0.0.1:${addr.port}`
+}
+
+/** Write the real shim to disk and run it with stdout on a PIPE — the way the
+ *  engine's bash tool always invokes it. */
+async function runShim(url: string): Promise<{ stdoutBytes: number; exitCode: number; stderr: string }> {
+  const dir = await mkdtemp(join(tmpdir(), 'cumora-shim-'))
+  cleanup.push(() => rm(dir, { recursive: true, force: true }))
+  const shim = join(dir, 'cumora.js')
+  await writeFile(shim, CUMORA_SHIM, 'utf8')
+  await chmod(shim, 0o755)
+
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [shim, 'inbox'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        CUMORA_AGENT_RUNTIME_URL: url,
+        CUMORA_AGENT_RUNTIME_TOKEN: 'test-token',
+        CUMORA_AGENT_RUNTIME_TOKEN_FILE: '',
+      },
+    })
+    let stdoutBytes = 0
+    let stderr = ''
+    child.stdout.on('data', (b: Buffer) => { stdoutBytes += b.length })
+    child.stderr.on('data', (b: Buffer) => { stderr += b.toString('utf8') })
+    child.on('close', (code) => resolve({ stdoutBytes, exitCode: code ?? -1, stderr }))
+  })
+}
+
+test('the shim writes the whole CLI payload before exiting', async () => {
+  // 1MB cannot fit any pipe buffer, so this is deterministic — there is no size
+  // at which the old write-then-exit accidentally passed.
+  const payload = 'x'.repeat(1_000_000)
+  const url = await serveCli(payload)
+  const r = await runShim(url)
+  assert.equal(
+    r.stdoutBytes, payload.length + 1,
+    'stdout must carry the full text plus its trailing newline, not just the pipe buffer',
+  )
+  assert.equal(r.exitCode, 0)
+  assert.equal(r.stderr, '')
+})
+
+test('a small payload still round-trips unchanged', async () => {
+  const payload = 'no unread messages'
+  const url = await serveCli(payload)
+  const r = await runShim(url)
+  assert.equal(r.stdoutBytes, payload.length + 1)
+  assert.equal(r.exitCode, 0)
+})
+
+test('the CLI exit code still propagates, with a large payload', async () => {
+  // The exit code must survive being moved into the write callback.
+  const payload = 'y'.repeat(300_000)
+  const url = await serveCli(payload, 2)
+  const r = await runShim(url)
+  assert.equal(r.stdoutBytes, payload.length + 1)
+  assert.equal(r.exitCode, 2, 'a non-zero CLI exit code must still reach the engine')
+})
+
+test('an empty payload exits without writing', async () => {
+  const url = await serveCli('', 1)
+  const r = await runShim(url)
+  assert.equal(r.stdoutBytes, 0)
+  assert.equal(r.exitCode, 1)
+})

--- a/server/src/agents/computer/daemon.ts
+++ b/server/src/agents/computer/daemon.ts
@@ -574,7 +574,10 @@ async function saveConfig(cfg: DaemonConfig): Promise<void> {
 // A tiny Node executable named `cumora` that the engine calls via bash. It
 // POSTs argv to the server's /runtime/cli, which runs the full CLI server-
 // side with the agent's identity pinned by the JWT. No curl/jq dependency.
-const CUMORA_SHIM = `#!/usr/bin/env node
+//
+// Exported for tests: the output-truncation regression below is only observable
+// by running the real shim text against a real pipe.
+export const CUMORA_SHIM = `#!/usr/bin/env node
 'use strict'
 ;(async () => {
   const url = process.env.CUMORA_AGENT_RUNTIME_URL
@@ -622,8 +625,18 @@ const CUMORA_SHIM = `#!/usr/bin/env node
     process.exit(70)
   }
   const data = await res.json()
-  if (typeof data.text === 'string' && data.text) process.stdout.write(data.text + '\\n')
-  process.exit(typeof data.exitCode === 'number' ? data.exitCode : 0)
+  const code = typeof data.exitCode === 'number' ? data.exitCode : 0
+  // Exit from the write CALLBACK, not the next statement: stdout on a PIPE is
+  // ASYNC, so process.exit() kills us with the tail still buffered. The engine
+  // always runs this shim with stdout piped, so a big result (cumora messages
+  // --tail 30, cumora inbox --json) silently arrived truncated at the pipe
+  // buffer — 64KB, or 8KB on the socketpair a stdio:'pipe' parent hands us —
+  // with exit 0 and empty stderr, so nothing signalled the loss and --json
+  // output simply failed to parse. Exiting IN the callback also keeps a reader
+  // that closed early (| head) an exit-0 like before, instead of the unhandled
+  // EPIPE crash a bare process.exitCode would produce.
+  if (typeof data.text === 'string' && data.text) process.stdout.write(data.text + '\\n', () => process.exit(code))
+  else process.exit(code)
 })().catch((e) => { console.error('cumora:', (e && e.message) || e); process.exit(70) })
 `
 


### PR DESCRIPTION
## The bug

The BYOA `cumora` shim ended with:

```js
if (typeof data.text === 'string' && data.text) process.stdout.write(data.text + '\n')
process.exit(typeof data.exitCode === 'number' ? data.exitCode : 0)
```

When fd 1 is a pipe, Node's stdout is **asynchronous**, so `process.exit()` tears the process down with the tail of that write still buffered. The engine always runs the shim with stdout piped.

Measured against the real shim with a 1MB payload:

| reader | delivered | exit | stderr |
|---|---|---|---|
| `stdio:'pipe'` child (socketpair) | **8,192 B** | 0 | empty |
| `\| wc -c` (real pipe) | **65,536 B** | 0 | empty |
| `> out.txt` (file) | 1,000,001 B | 0 | empty |

So `cumora messages <convo> --tail 30` or `cumora inbox --json` over the buffer size came back cut, **with exit code 0 and empty stderr**. Nothing signalled the loss: the agent read a truncated inbox or conversation and acted on it as if complete, and `--json` output failed to parse for no visible reason. This is the agent's main sense organ.

## The fix

Exit from the write's completion callback instead of the next statement.

### Why not `process.exitCode`?

That's the more obvious-looking fix and it repairs truncation equally well — but it turns a reader that closes early into a crash. `cumora doc read <id> | head` is a pattern the agent bash tool invites. Measured:

| 1MB payload | today | write callback | `process.exitCode` |
|---|---|---|---|
| `\| wc -c` | 65,536 | 1,000,001 ✅ | 1,000,001 ✅ |
| `\| head -c 10` | exit 0, silent | exit 0, silent ✅ | **exit 0 + `Error: write EPIPE` crash dump** ❌ |

The callback form is the only variant that fixes truncation while leaving every existing exit-code and stderr behavior byte-identical.

## One behavior change worth naming

The shim now waits for a stalled reader instead of dropping data on the floor. `cumora doc read <id> | sleep 60` previously exited immediately (having silently truncated); it now blocks until the reader drains. That's correct behavior for any command and is the point of the fix — but it is a real change. Engines apply their own bash-tool timeouts, and the shim's own network call has no timeout today either, so this introduces no new class of unbounded wait.

## Tests

New `server/src/__tests__/agent-computer-shim-output.test.ts` runs the **real shim text** against a **real pipe** and a local `node:http` stand-in for `/runtime/cli` — the only place this bug exists. `CUMORA_SHIM` is exported for that.

Verified red before / green after:

```
# without the fix
not ok 1 - the shim writes the whole CLI payload before exiting
    8192 !== 1000001
ok   2 - a small payload still round-trips unchanged
not ok 3 - the CLI exit code still propagates, with a large payload
    8192 !== 300001
ok   4 - an empty payload exits without writing
# pass 2 | fail 2
```

1MB cannot fit any pipe buffer, so the failing assertion is deterministic — there's no size at which the old code accidentally passes. The small-payload and empty-payload cases pass on both, which is what shows the suite isn't just failing indiscriminately. Case 3 guards the exit code surviving its move into the callback.

## Scope

BYOA only. The cloud pod's sibling shim (`server/docker/agent-computer-cumora.sh`) uses blocking `printf` and was never affected — its own comment already notes it must not corrupt `--json` output.

## Checks

`npm run lint`, `npm run typecheck`, `npm run server:typecheck` pass. The new tests need no Postgres/Redis/`OPENAI_API_KEY`.
