### PR TITLE
fix(ws): make WsClient.connect() re-entrant so boot opens one socket, not five

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1483,8 +1483,27 @@ class WsClient {
   private listeners = new Set<Listener>()
   private reconnectDelay = 500
   private intentionalClose = false
+  /** In-flight `connect()` de-dupe. The `this.ws` guard below cannot catch a
+   *  second caller: `this.ws` is not assigned until AFTER the ticket fetch
+   *  awaits, and boot fires five connects in the same tick
+   *  (bootMessagesStream / bootParticipants / bootConversations /
+   *  bootWhispers / bootComputers, each behind its own module-local `wsBound`
+   *  flag, so none of them suppresses another). Every socket they opened fanned
+   *  into this same `listeners` set, and since `message.delta` is applied by
+   *  ACCUMULATING onto the body, the streaming bubble rendered each chunk five
+   *  times while an agent typed. Concurrent callers ride the first attempt; the
+   *  memo clears once it settles, so a later connect still gets a fresh socket. */
+  private connecting: Promise<void> | null = null
 
-  async connect() {
+  connect(): Promise<void> {
+    const existing = this.connecting
+    if (existing) return existing
+    const p = this.connectImpl().finally(() => { this.connecting = null })
+    this.connecting = p
+    return p
+  }
+
+  private async connectImpl() {
     if (this.ws && (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING)) return
     const token = getAuthToken()
     if (!token) return  // not signed in → don't even try
@@ -1509,19 +1528,27 @@ class WsClient {
       return
     }
     const url = `${wsOrigin()}/ws?t=${encodeURIComponent(ticket)}`
-    this.ws = new WebSocket(url)
-    this.ws.onopen = () => { this.reconnectDelay = 500 }
-    this.ws.onmessage = (ev) => {
+    const sock = new WebSocket(url)
+    this.ws = sock
+    sock.onopen = () => { this.reconnectDelay = 500 }
+    sock.onmessage = (ev) => {
       try {
         const data = JSON.parse(ev.data) as WsEvent
         this.listeners.forEach((l) => { l(data) })
       } catch { /* ignore */ }
     }
-    this.ws.onclose = () => {
+    sock.onclose = () => {
+      // Only the socket that is still CURRENT may clear the field. `reconnect()`
+      // closes the old socket and opens its replacement immediately, but the
+      // close event lands a tick later — nulling `this.ws` then would orphan a
+      // LIVE socket (`isOpen()`/`send()` start reporting closed while typing
+      // frames are silently dropped) and schedule a second one on top of it,
+      // putting us back to two sockets sharing one listener set.
+      if (this.ws !== sock) return
       this.ws = null
       if (!this.intentionalClose) this.scheduleReconnect()
     }
-    this.ws.onerror = () => { /* onclose follows */ }
+    sock.onerror = () => { /* onclose follows */ }
   }
 
   private scheduleReconnect() {


### PR DESCRIPTION
## The bug

`connect()` checks its single-socket guard on `this.ws` — but `this.ws` is only assigned **after** the ticket fetch awaits:

```ts
async connect() {
  if (this.ws && (this.ws.readyState === OPEN || this.ws.readyState === CONNECTING)) return
  ...
  const r = await fetch(`${API}/auth/ws-ticket`, …)   // this.ws is still null here
  ...
  this.ws = new WebSocket(url)
}
```

`AuthedApp`'s mount effect calls five boots back-to-back in one synchronous tick (`App.tsx:116-120`), and each calls `ws.connect()` exactly once. Crucially, **each store has its own module-local `wsBound` flag**, so none of them suppresses another:

```
src/stores/messages.ts:798       let wsBound = false  (messages.ts:782)
src/stores/participants.ts:135   let wsBound = false  (participants.ts:130)
src/stores/conversations.ts:216  let wsBound = false  (conversations.ts:211)
src/stores/whispers.ts:79        let wsBound = false  (whispers.ts:74)
src/stores/computers.ts:67       let wsBound = false  (computers.ts:62)
```

All five pass the guard while `this.ws` is null, each fetches its own single-use ticket, each constructs a WebSocket. `this.ws` keeps the last; **the other four stay open**, and all five `onmessage` handlers fan into the same shared `listeners` set.

`applyEvent` for `message.delta` is an accumulator, not idempotent — `const body = (cur?.body ?? '') + e.delta`. So every streaming agent reply rendered **each chunk five times** ("HelloHelloHelloHelloHello there there there…") until the reply completed and the final message replaced it, which is why it looks like a rendering glitch rather than a connection bug. Each `hello` frame also drove five concurrent `reloadConversation` + `conversations.reload()` + `participants.refresh()` storms, and the server carried five WS sessions per client.

## The fix

**1. Memoize the in-flight attempt** so concurrent callers ride the first one. This is the coalescing idiom already used in this codebase — `orchestrator.ts`'s `ensurePod`/`ensurePodImpl` + `inFlight` map, and `LinkPreview.tsx`'s `inflight` map. The memo clears once the attempt settles, so a later connect still gets a fresh socket.

**2. Make `onclose` socket-identity-aware.** `reconnect()` closes the old socket and opens its replacement immediately, but the close event lands a tick later. Without the identity check, that late event nulls out the reference to a **healthy live** socket — `isOpen()` starts reporting false and `send()` silently drops typing frames — and schedules another socket on top, putting us back to two sockets sharing one listener set. This also removes the pre-existing race where `reconnect()` clears `intentionalClose` synchronously before the async `onclose` reads it.

## Measurement

There is no frontend test harness in this repo (`CONTRIBUTING.md`: "There are no frontend unit tests yet"; `npm test` globs only `server/src/__tests__` and `workers/`), so this PR ships no automated test — stated as a limitation, not an oversight.

What I did instead: replicated `connect()`'s exact shape with a stubbed ticket fetch and WebSocket, and fired the same five same-tick connects:

```
OLD: sockets opened = 5
OLD: later reconnect still opens = 1
NEW: sockets opened = 1
NEW: later reconnect still opens = 1
```

The second line of each pair is the one that matters for safety: the memo must not wedge `connect()` shut after the first attempt settles.

## What deliberately does not change

- **`reconnect()` is untouched.** Its synchronous `intentionalClose = false` is no longer racy once the identity guard is in place — the old socket's late `onclose` returns at the identity check and never reaches the `intentionalClose` test. Deferring the flag instead would be a second way of saying the same thing, and the identity guard also covers the unrelated "an orphaned socket closes later" case.
- **`reconnect()` does not clear `connecting`.** Clearing it would let a second socket open while the first attempt is still fetching its ticket — exactly the bug being fixed. "Force a fresh ticket" is already satisfied by an in-flight fresh ticket.
- **Callers that chain on the resolution.** The only one is `yjsClient.ts`'s `void ws.connect().then(() => subscribe())`; `subscribe()` is already a no-op unless `ws.isOpen()`, so riding the first attempt changes nothing about its behavior.

## Checks

`npm run lint` and `npm run typecheck` pass.
