### PR TITLE
fix(electron): paint the dock unread dot into the icon bitmap

### DIFF
--- a/electron/__dockverify.js
+++ b/electron/__dockverify.js
@@ -1,0 +1,41 @@
+const { app, nativeImage } = require('electron')
+const fs = require('fs'), path = require('path')
+
+// Pull the REAL constants + paint function out of the shipped source and run
+// them, so this verifies the actual code rather than a copy of it.
+const src = fs.readFileSync(path.join(__dirname, 'main.cjs'), 'utf8')
+const pick = (re, what) => { const m = src.match(re); if (!m) throw new Error('could not extract ' + what); return m[0] }
+const consts = pick(/const DOCK_ICON_SIZE = \d+\nconst DOCK_UNREAD_DOT = \{[\s\S]*?\n\}/, 'constants')
+const fn = pick(/function paintDockUnreadDot\(buf, width, height\) \{[\s\S]*?\n\}\n(?=\nfunction getDockUnreadIcon)/, 'paintDockUnreadDot')
+const mod = { exports: {} }
+new Function('module', consts + '\n' + fn + '\nmodule.exports = { paintDockUnreadDot, DOCK_ICON_SIZE, DOCK_UNREAD_DOT }')(mod)
+const { paintDockUnreadDot, DOCK_ICON_SIZE, DOCK_UNREAD_DOT } = mod.exports
+
+app.whenReady().then(() => {
+  const ICON = path.join(__dirname, '..', 'build', 'icon.png')
+  const base = nativeImage.createFromPath(ICON)
+  const { width, height } = base.getSize()
+  console.log('base icon:', width + 'x' + height, 'isEmpty:', base.isEmpty())
+
+  const buf = base.toBitmap()
+  const s = Math.min(width, height) / DOCK_ICON_SIZE
+  const cx = Math.round(DOCK_UNREAD_DOT.cx * s), cy = Math.round(DOCK_UNREAD_DOT.cy * s)
+  const at = (b, x, y) => { const i = (y * width + x) * 4; return { B: b[i], G: b[i+1], R: b[i+2], A: b[i+3] } }
+  const before = at(buf, cx, cy)
+
+  paintDockUnreadDot(buf, width, height)
+  const after = at(buf, cx, cy)
+  const img = nativeImage.createFromBitmap(buf, { width, height })
+
+  console.log('dot centre before:', JSON.stringify(before))
+  console.log('dot centre after :', JSON.stringify(after), '(want R=255 G=59 B=48 A=255)')
+  console.log('result isEmpty   :', img.isEmpty(), 'size:', JSON.stringify(img.getSize()))
+  // a pixel far from the dot must be untouched
+  const farBefore = at(base.toBitmap(), 10, 10), farAfter = at(buf, 10, 10)
+  console.log('far pixel unchanged:', JSON.stringify(farBefore) === JSON.stringify(farAfter))
+  // premultiplied invariant: every channel <= alpha
+  let bad = 0
+  for (let i = 0; i < buf.length; i += 4) if (buf[i] > buf[i+3] || buf[i+1] > buf[i+3] || buf[i+2] > buf[i+3]) bad++
+  console.log('premultiplied violations:', bad)
+  app.exit(0)
+})

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -600,17 +600,75 @@ function getDockCleanIcon() {
   return dockCleanIcon
 }
 
+/** Paint the unread dot straight into an app-icon bitmap, in place.
+ *
+ *  Same raw-bitmap route as the tray below, for the same reason its comment
+ *  gives: `nativeImage.createFromDataURL` only decodes raster formats Chromium
+ *  knows (PNG/JPEG/WebP/GIF), so the SVG this used to build produced an EMPTY
+ *  image — `isEmpty()` true at 0x0. That tripped the `!img.isEmpty()` guard in
+ *  setDockUnreadDot, which skipped `setIcon` entirely, so the dock never showed
+ *  any unread indicator while the tray (already on bitmaps) did.
+ *
+ *  Buffer layout is BGRA with PREMULTIPLIED alpha (Chromium's N32). Blending
+ *  `c*a + dst*(1-a)` on all four channels preserves that invariant, since a
+ *  premultiplied channel never exceeds its alpha.
+ *
+ *  Dot geometry stays in the existing 1024-unit design space and is scaled to
+ *  whatever the icon's real pixel size is, so DOCK_UNREAD_DOT keeps its
+ *  meaning. */
+function paintDockUnreadDot(buf, width, height) {
+  const s = Math.min(width, height) / DOCK_ICON_SIZE
+  const dot = DOCK_UNREAD_DOT
+  const cx = dot.cx * s
+  const cy = dot.cy * s
+  const rIn = dot.r * s
+  const rOut = (dot.r + dot.stroke / 2) * s
+  const SS = 4  // 4x4 supersample — the same cheap anti-aliasing the tray uses
+  const n = SS * SS
+  const blend = (i, b, g, r, a) => {
+    if (a <= 0) return
+    const inv = 1 - a
+    buf[i] = Math.round(b * a + buf[i] * inv)
+    buf[i + 1] = Math.round(g * a + buf[i + 1] * inv)
+    buf[i + 2] = Math.round(r * a + buf[i + 2] * inv)
+    buf[i + 3] = Math.round(255 * a + buf[i + 3] * inv)
+  }
+  const x0 = Math.max(0, Math.floor(cx - rOut - 1))
+  const x1 = Math.min(width - 1, Math.ceil(cx + rOut + 1))
+  const y0 = Math.max(0, Math.floor(cy - rOut - 1))
+  const y1 = Math.min(height - 1, Math.ceil(cy + rOut + 1))
+  for (let y = y0; y <= y1; y++) {
+    for (let x = x0; x <= x1; x++) {
+      let covIn = 0
+      let covOut = 0
+      for (let sy = 0; sy < SS; sy++) {
+        for (let sx = 0; sx < SS; sx++) {
+          const dx = x + (sx + 0.5) / SS - cx
+          const dy = y + (sy + 0.5) / SS - cy
+          const d2 = dx * dx + dy * dy
+          if (d2 <= rOut * rOut) covOut += 1
+          if (d2 <= rIn * rIn) covIn += 1
+        }
+      }
+      if (covOut === 0) continue
+      const i = (y * width + x) * 4
+      // White halo first, then the red dot on top — same z-order as before.
+      blend(i, 255, 255, 255, (covOut / n) * 0.96)
+      blend(i, 0x30, 0x3b, 0xff, covIn / n)
+    }
+  }
+}
+
 function getDockUnreadIcon() {
   if (dockUnreadIcon) return dockUnreadIcon
-  const base64 = fs.readFileSync(ICON_PATH).toString('base64')
-  const dot = DOCK_UNREAD_DOT
-  const svg = `
-    <svg xmlns="http://www.w3.org/2000/svg" width="${DOCK_ICON_SIZE}" height="${DOCK_ICON_SIZE}" viewBox="0 0 ${DOCK_ICON_SIZE} ${DOCK_ICON_SIZE}">
-      <image href="data:image/png;base64,${base64}" width="${DOCK_ICON_SIZE}" height="${DOCK_ICON_SIZE}"/>
-      <circle cx="${dot.cx}" cy="${dot.cy}" r="${dot.r + dot.stroke / 2}" fill="#ffffff" opacity="0.96"/>
-      <circle cx="${dot.cx}" cy="${dot.cy}" r="${dot.r}" fill="#ff3b30"/>
-    </svg>`
-  dockUnreadIcon = nativeImage.createFromDataURL(`data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`)
+  const base = nativeImage.createFromPath(ICON_PATH)
+  const { width, height } = base.getSize()
+  // No icon on disk (or an undecodable one) — hand back the empty image and let
+  // setDockUnreadDot's isEmpty() guard skip the update, exactly as before.
+  if (!width || !height) return base
+  const buf = base.toBitmap()
+  paintDockUnreadDot(buf, width, height)
+  dockUnreadIcon = nativeImage.createFromBitmap(buf, { width, height })
   return dockUnreadIcon
 }
 

--- a/server/src/__tests__/electron-native-image.test.ts
+++ b/server/src/__tests__/electron-native-image.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Guard: no Electron icon may be built from an SVG data URL.
+ *
+ * `nativeImage.createFromDataURL` only decodes the raster formats Chromium
+ * knows (PNG/JPEG/WebP/GIF). An SVG data URL silently yields an EMPTY image —
+ * verified against this repo's own bundled Electron: `isEmpty()` true at 0x0,
+ * while a PNG buffer decodes fine. There is no error and no warning.
+ *
+ * The tray already learned this the hard way — its comment records that "the old
+ * SVG-based tray icon never appeared" — and moved to raw BGRA bitmaps. The dock
+ * unread dot was left on the SVG technique, so `setDockUnreadDot`'s
+ * `!img.isEmpty()` guard skipped `setIcon` every time and the dock never showed
+ * an unread indicator.
+ *
+ * electron/ has no runtime test harness, so this is a source-level guard in the
+ * same shape as guard-big-brain.test.ts: pin the invariant, and self-test the
+ * matcher so it cannot quietly become a no-op.
+ *
+ * Run: node --import tsx --test server/src/__tests__/electron-native-image.test.ts
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
+const MAIN_CJS = join(REPO_ROOT, 'electron', 'main.cjs')
+
+/** Lines that hand an SVG payload to a nativeImage decoder. Comments are
+ *  ignored — the file legitimately DISCUSSES this trap at length. */
+function svgDecoderCalls(source: string): string[] {
+  const out: string[] = []
+  for (const raw of source.split('\n')) {
+    const line = raw.trim()
+    if (line.startsWith('//') || line.startsWith('*') || line.startsWith('/*')) continue
+    if (!/createFromDataURL|createFromBuffer/.test(line)) continue
+    if (!/svg/i.test(line)) continue
+    out.push(line)
+  }
+  return out
+}
+
+test('no Electron icon is decoded from an SVG data URL', () => {
+  const offenders = svgDecoderCalls(readFileSync(MAIN_CJS, 'utf8'))
+  assert.deepEqual(
+    offenders, [],
+    '\nnativeImage cannot decode SVG — these produce a silently EMPTY image:\n' +
+    offenders.map((l) => `  ${l}`).join('\n') +
+    '\nRasterise to a BGRA bitmap and use nativeImage.createFromBitmap instead.',
+  )
+})
+
+test('the dock unread icon is built from a bitmap', () => {
+  // The positive half: it is not enough that the SVG is gone, the dot must
+  // actually be composited into the icon.
+  const src = readFileSync(MAIN_CJS, 'utf8')
+  const fn = src.slice(src.indexOf('function getDockUnreadIcon'))
+  const body = fn.slice(0, fn.indexOf('\n}\n') + 3)
+  assert.match(body, /createFromBitmap/, 'getDockUnreadIcon must composite via a raw bitmap')
+})
+
+// --- the matcher actually catches a regression (so the guard isn't a no-op) ---
+
+test('the matcher flags an SVG data URL icon', () => {
+  const bad = "  dockUnreadIcon = nativeImage.createFromDataURL('data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svg))"
+  assert.equal(svgDecoderCalls(bad).length, 1)
+})
+
+test('the matcher ignores a PNG data URL and prose about SVG', () => {
+  assert.deepEqual(svgDecoderCalls("  const i = nativeImage.createFromDataURL('data:image/png;base64,' + b64)"), [])
+  assert.deepEqual(svgDecoderCalls('  // SVG data URLs silently produce an empty image via createFromDataURL'), [])
+})


### PR DESCRIPTION
## The bug

`getDockUnreadIcon()` composited the unread dot with an SVG data URL. But `nativeImage.createFromDataURL` only decodes the raster formats Chromium knows (PNG/JPEG/WebP/GIF) — an SVG data URL silently yields an **empty** image. No error, no warning.

Verified against this repo's own bundled Electron:

```
SVG dataURL -> isEmpty: true   size: {"width":0,"height":0}
PNG buffer  -> isEmpty: false  size: {"width":1,"height":1}
```

So the chain is: `getDockUnreadIcon()` returns a 0×0 image → `setDockUnreadDot`'s `if (!img.isEmpty())` guard skips `app.dock.setIcon` → and the unconditional `app.dock.setBadge('')` just above it clears any badge that might otherwise have shown.

Net effect on macOS: `App.tsx` faithfully calls `setUnreadDot(true)` whenever an unmuted conversation has unread, and **nothing whatsoever appears on the dock icon**. Because the tray mirror already uses baked bitmaps and works fine, the symptom reads as "tray shows unread, dock doesn't" — which points away from the actual cause.

**This file already documents the trap.** The tray's own comment records it:

> `nativeImage.createFromDataURL` only decodes raster formats Chromium knows (PNG/JPEG/WebP/GIF) — SVG data URLs silently produce an empty image, which is why the old SVG-based tray icon never appeared.

The tray was moved to raw BGRA bitmaps for exactly this reason. The dock path was left behind on the broken technique.

## The fix

Use the technique the tray already established: rasterise the dot straight into the app icon's bitmap and hand that to `nativeImage.createFromBitmap`.

- Geometry stays in the existing 1024-unit design space and is scaled to the icon's real pixel size, so `DOCK_UNREAD_DOT` keeps its meaning and remains the one place to tune.
- Blending `c*a + dst*(1-a)` on all four channels preserves Chromium's premultiplied-alpha invariant (a premultiplied channel never exceeds its alpha).
- 4×4 supersampling for anti-aliasing, matching the tray's approach; it runs once, memoized.
- A missing or undecodable icon still returns an empty image, so the existing `isEmpty()` guard behaves exactly as before.
- Same z-order as the old SVG: white halo, then the red dot.

## Verification

Ran the **real** `paintDockUnreadDot` extracted from the shipped source, under this repo's bundled Electron, against the real `build/icon.png`:

```
base icon: 1024x1024 isEmpty: false
dot centre before: {"B":253,"G":248,"R":239,"A":255}   // the icon's own pixels
dot centre after : {"B":48,"G":59,"R":255,"A":255}     // #ff3b30 exactly
result isEmpty   : false  size: {"width":1024,"height":1024}   // was isEmpty:true at 0x0
far pixel unchanged: true
premultiplied violations: 0
```

## Regression guard

`electron/` has no runtime test harness, so the shipped guard is source-level, in the same shape as `guard-big-brain.test.ts`: `server/src/__tests__/electron-native-image.test.ts` asserts no icon is decoded from an SVG data URL, and — the positive half — that `getDockUnreadIcon` actually composites via a bitmap. Two further cases self-test the matcher so it can't become a no-op.

Red before / green after:

```
# against the previous dock code
not ok 1 - no Electron icon is decoded from an SVG data URL
not ok 2 - the dock unread icon is built from a bitmap
ok   3 - the matcher flags an SVG data URL icon
ok   4 - the matcher ignores a PNG data URL and prose about SVG
# pass 2 | fail 2
```

Cases 3 and 4 pass on both, which is what shows the guard isn't failing indiscriminately. The matcher skips comment lines, since the file legitimately discusses this trap at length.

## Checks

`npm run lint`, `npm run typecheck`, `npm run server:typecheck` pass. The guard test needs no Postgres/Redis/`OPENAI_API_KEY`.

One thing I could not do here: confirm the dot's final appearance on a real macOS dock at retina scale. The pixel assertions above cover correctness of the composite; the visual read at 1024→dock downsample is worth a glance on merge.
