### PR TITLE
fix(agents): don't drop engine stream-json events split across pipe chunks

### DIFF
--- a/server/src/__tests__/agents-computer-engine.test.ts
+++ b/server/src/__tests__/agents-computer-engine.test.ts
@@ -218,3 +218,81 @@ test('a Codex session whose resume fallback also fails dies instead of wedging',
   ])
   assert.notEqual(second, 'HUNG', 'a later turn must settle rather than park forever')
 })
+
+// ── stream-json events split across pipe reads ──────────────────────────────
+// A pipe read chops stdout at an arbitrary byte offset, so a long event arrives
+// as two 'data' chunks. Parsing each chunk in isolation threw away both halves,
+// and the swallow-partial-lines catch made it silent: no ledger row, and the
+// turn's authoritative usage/model/session id lost.
+
+test('a stream-json event split across pipe chunks is still parsed', { skip: IS_WIN }, async () => {
+  const root = await mkdtemp(join(tmpdir(), 'cumora-chunk-'))
+  tempDirs.push(root)
+  const binDir = join(root, 'bin')
+  const home = join(root, 'home')
+  await mkdir(binDir); await mkdir(home)
+
+  // One assistant event padded far past any pipe buffer, then the terminating
+  // result. Emitted with NO trailing newline on the last line, which is how the
+  // engines actually finish.
+  const fake = join(binDir, 'claude')
+  await writeFile(
+    fake,
+    '#!/usr/bin/env node\n' +
+    "const big = 'z'.repeat(400000)\n" +
+    "const assistant = { type: 'assistant', session_id: 'sess-chunked', message: { model: 'claude-sonnet-4-6', usage: { input_tokens: 11, output_tokens: 7 }, content: [{ type: 'text', text: big }] } }\n" +
+    "const result = { type: 'result', session_id: 'sess-chunked', usage: { input_tokens: 11, output_tokens: 7 }, model: 'claude-sonnet-4-6' }\n" +
+    "process.stdout.write(JSON.stringify(assistant) + '\\n')\n" +
+    "process.stdout.write(JSON.stringify(result))\n",
+    'utf8',
+  )
+  await chmod(fake, 0o755)
+
+  const hops: Array<{ model: string }> = []
+  const r = await getAdapter('claude').run({
+    home,
+    prompt: 'go',
+    env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ''}` },
+    onLog: () => {},
+    onHopUsage: (h) => hops.push({ model: h.model }),
+    signal: new AbortController().signal,
+  })
+
+  assert.equal(r.exitCode, 0)
+  assert.equal(r.sessionId, 'sess-chunked', 'session id must survive a chunk split (else no --resume next wake)')
+  assert.equal(r.usage?.output_tokens, 7, "the result event's usage must survive")
+  assert.equal(r.model, 'claude-sonnet-4-6')
+  assert.equal(hops.length, 1, 'the assistant hop must reach the trajectory ledger exactly once')
+})
+
+test('a multi-byte character split across pipe chunks is not corrupted', { skip: IS_WIN }, async () => {
+  const root = await mkdtemp(join(tmpdir(), 'cumora-utf8-'))
+  tempDirs.push(root)
+  const binDir = join(root, 'bin')
+  const home = join(root, 'home')
+  await mkdir(binDir); await mkdir(home)
+
+  // Pad so the event is long enough to be chopped, and fill it with multi-byte
+  // characters so a boundary is very likely to land mid-codepoint.
+  const fake = join(binDir, 'claude')
+  await writeFile(
+    fake,
+    '#!/usr/bin/env node\n' +
+    "const big = '中'.repeat(150000)\n" +
+    "const ev = { type: 'result', session_id: 'sess-utf8', usage: { input_tokens: 1, output_tokens: 2 }, model: 'm', note: big }\n" +
+    "process.stdout.write(JSON.stringify(ev) + '\\n')\n",
+    'utf8',
+  )
+  await chmod(fake, 0o755)
+
+  const r = await getAdapter('claude').run({
+    home,
+    prompt: 'go',
+    env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ''}` },
+    onLog: () => {},
+    signal: new AbortController().signal,
+  })
+
+  assert.equal(r.sessionId, 'sess-utf8', 'a codepoint split mid-boundary must not corrupt the JSON')
+  assert.equal(r.usage?.output_tokens, 2)
+})

--- a/server/src/agents/computer/engine.ts
+++ b/server/src/agents/computer/engine.ts
@@ -23,6 +23,7 @@ import { mkdir, writeFile, access, mkdtemp } from 'node:fs/promises'
 import { existsSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, delimiter as PATH_DELIMITER } from 'node:path'
+import { StringDecoder } from 'node:string_decoder'
 import { stripLoneSurrogates } from '../text-safety.js'
 
 const IS_WIN = process.platform === 'win32'
@@ -431,8 +432,26 @@ function spawnEngine(
     // emitted the hop, so latency_ms reflects actual time-on-the-wire.
     let hopStartedAt: number | null = null
     let hopIndex = 0
-    const pump = (stream: 'stdout' | 'stderr', buf: Buffer): void => {
-      for (const line of buf.toString('utf8').split('\n')) {
+    // A pipe read chops stdout at an arbitrary byte offset (~8KB on macOS, up to
+    // 64KB on Linux), so a long stream-json event — a Write/Edit tool_use carrying
+    // file content, or a big final `result` — arrives split across two 'data'
+    // events. Splitting each chunk on its own handed JSON.parse two halves, both
+    // of which throw and are swallowed by the catch below: the hop never reached
+    // the ledger and the turn's authoritative usage/model/session id were lost,
+    // silently. Carry the trailing partial line into the next chunk, exactly like
+    // ClaudeSession.onStdout already does for the persistent path. StringDecoder
+    // does the same job one level down, holding back a multi-byte character split
+    // across the boundary instead of emitting U+FFFD into the JSON.
+    const decoder: Record<'stdout' | 'stderr', StringDecoder> =
+      { stdout: new StringDecoder('utf8'), stderr: new StringDecoder('utf8') }
+    const carry: Record<'stdout' | 'stderr', string> = { stdout: '', stderr: '' }
+    // `buf === null` means end-of-stream: flush whatever is held back, since the
+    // engine's last line often has no trailing newline.
+    const pump = (stream: 'stdout' | 'stderr', buf: Buffer | null): void => {
+      const text = buf === null ? decoder[stream].end() : decoder[stream].write(buf)
+      const lines = (carry[stream] + text).split('\n')
+      carry[stream] = buf === null ? '' : (lines.pop() ?? '')
+      for (const line of lines) {
         const cleaned = cleanLine(line)
         if (!cleaned) continue
         pushTail(stream === 'stderr' ? stderrTail : stdoutTail, cleaned)
@@ -473,6 +492,10 @@ function spawnEngine(
     child.on('error', (err) => { signal.removeEventListener('abort', onAbort); reject(err) })
     child.on('close', (code, signalName) => {
       signal.removeEventListener('abort', onAbort)
+      // Flush the held-back tail BEFORE resolving: the terminating `result`
+      // event is usually the last line, and it carries the turn's usage.
+      pump('stdout', null)
+      pump('stderr', null)
       const exitCode = code ?? (signalName ? 128 : 1)
       resolve({
         exitCode,


### PR DESCRIPTION
## The bug

`spawnEngine`'s `pump` split each stdout chunk on `\n` **in isolation**, with no carry between chunks:

```ts
const pump = (stream, buf) => {
  for (const line of buf.toString('utf8').split('\n')) { … }
}
```

A pipe read chops stdout at an arbitrary byte offset — ~8KB on macOS, up to 64KB on Linux. So a long stream-json event (a `Write`/`Edit` `tool_use` carrying file content, or a big terminating `result`) arrives as **two** `'data'` events. Both halves fail `JSON.parse` and are swallowed by the `catch { /* partial / non-json line — ignore */ }` immediately below.

Nothing surfaces the loss, and what goes missing matters:

- the assistant hop never reaches `onHopUsage`, so **no `llm_calls` row** is written and the turn's spend is under-reported
- the terminating `result` event's `usage` and `model` are lost, so the turn is priced on a fallback guess or not at all
- the `session_id` sniff misses, so **the next wake spawns without `--resume`** and the agent loses the running task's context

That last one is the same class of continuity loss as #9.

**Every sibling reader in this same file already carries partial lines** — `ClaudeSession.onStdout` (via `outBuf`), `CodexSession.onStdout`, `CodexAdapter.probeWake` — and `sse-parse.ts` documents the carry as required. Only this one-shot path was left without it.

## The fix

Carry the trailing partial line into the next chunk, and flush at close — the engine's last line usually has no trailing newline, and that last line is typically the `result` event carrying the turn's usage.

Decode through a `StringDecoder` for the same reason one level down: a multi-byte character split across the same boundary would otherwise be emitted as U+FFFD, corrupting the reassembled JSON even after the line is stitched back together.

## Tests

Two cases in `server/src/__tests__/agents-computer-engine.test.ts`, using a fake engine that emits a 400KB assistant event (far past any pipe buffer) followed by a `result` with **no trailing newline** — how the engines actually finish.

Verified red before / green after:

```
# against the previous pump
not ok 4 - a stream-json event split across pipe chunks is still parsed
  expected: 1        # hops reaching the ledger
  actual: 0
not ok 5 - a multi-byte character split across pipe chunks is not corrupted
  expected: 'sess-utf8'
  actual: undefined  # no session id → no --resume next wake
# pass 2 | fail 2
```

The first case asserts all four losses at once: session id, `usage`, `model`, and exactly one hop reaching the trajectory ledger. The second fills the payload with `中` so a boundary is very likely to land mid-codepoint.

## Checks

`npm run lint`, `npm run typecheck`, `npm run server:typecheck` pass. The new tests need no Postgres/Redis/`OPENAI_API_KEY`, and are skipped on Windows alongside the file's existing platform-specific cases.
