### PR TITLE
fix(byoa): don't ack unread the wake digest never showed

### DIFF
--- a/server/src/__tests__/agents-computer-inbox-digest.test.ts
+++ b/server/src/__tests__/agents-computer-inbox-digest.test.ts
@@ -1,0 +1,91 @@
+/**
+ * The BYOA wake digest is line-budgeted, and `ackSeen` marks the WHOLE snapshot
+ * read on a clean turn. So anything the digest omits is marked read having never
+ * been shown — and because mark-read pins each conversation's cursor at its
+ * NEWEST message, it can never resurface in a later wake.
+ *
+ * That makes two properties load-bearing, and this file pins both:
+ *   1. no conversation with unread may vanish from the digest entirely
+ *   2. nothing may be dropped in silence — the count and how to read it must
+ *      appear in place
+ *
+ * Run: node --import tsx --test server/src/__tests__/agents-computer-inbox-digest.test.ts
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { renderInboxDigest } from '../agents/computer/daemon.js'
+
+type Convo = { head: string; msgs: string[] }
+
+function build(spec: Array<[string, number]>): Map<string, Convo> {
+  const m = new Map<string, Convo>()
+  for (const [id, n] of spec) {
+    m.set(id, {
+      head: `# ${id} [group] "${id}"`,
+      msgs: Array.from({ length: n }, (_, i) => `  [m-${id}-${i}] ${id}  someone: message ${i}`),
+    })
+  }
+  return m
+}
+
+const messageLines = (digest: string): string[] =>
+  digest.split('\n').filter((l) => /^ {2}\[m-/.test(l))
+
+test('everything is shown verbatim when it fits the budget', () => {
+  const digest = renderInboxDigest(build([['a', 3], ['b', 2]]), 40)
+  assert.equal(messageLines(digest).length, 5)
+  assert.ok(!digest.includes('not shown'), 'nothing should be announced as omitted')
+  // Conversations keep first-seen order, messages stay chronological.
+  assert.ok(digest.indexOf('# a ') < digest.indexOf('# b '))
+  assert.ok(digest.indexOf('[m-a-0]') < digest.indexOf('[m-a-2]'))
+})
+
+test('a busy room cannot evict a quiet conversation entirely', () => {
+  // The shape that bites: a human DM arrives FIRST, then a group bursts. Under a
+  // global newest-N tail the DM is the oldest thing in the list, so it is the
+  // first evicted — and the very next clean turn marks it read.
+  const digest = renderInboxDigest(build([['dm', 1], ['busy', 200]]), 40)
+  assert.ok(digest.includes('# dm '), 'the quiet conversation must still appear')
+  assert.ok(
+    messageLines(digest).some((l) => l.includes('[m-dm-0]')),
+    'the quiet conversation\'s only unread message must be shown, not evicted',
+  )
+})
+
+test('no conversation with unread disappears from the digest', () => {
+  // 25 conversations x 2 unread — the offline-catch-up shape.
+  const byConvo = build(Array.from({ length: 25 }, (_, i) => [`c${i}`, 2] as [string, number]))
+  const digest = renderInboxDigest(byConvo, 40)
+  for (const id of byConvo.keys()) {
+    assert.ok(digest.includes(`# ${id} `), `conversation ${id} vanished from the digest`)
+  }
+})
+
+test('omitted unread is announced with its count and how to read it', () => {
+  const digest = renderInboxDigest(build([['busy', 60]]), 40)
+  const shown = messageLines(digest).length
+  assert.ok(shown < 60, 'the budget must actually cap the output')
+  assert.match(
+    digest,
+    new RegExp(`… ${60 - shown} older unread message\\(s\\) not shown`),
+    'the exact number dropped must be stated',
+  )
+  assert.match(digest, /cumora messages busy --tail 60/, 'the digest must say how to read the rest')
+})
+
+test('the budget is respected', () => {
+  const digest = renderInboxDigest(build([['a', 100], ['b', 100], ['c', 100]]), 40)
+  assert.ok(messageLines(digest).length <= 40, 'must not exceed the line budget')
+})
+
+test('a conversation budgeted to zero shows none of its messages, not all of them', () => {
+  // Guards the slice(length - shown) vs slice(-shown) trap: slice(-0) is
+  // slice(0), which would dump the whole conversation.
+  const digest = renderInboxDigest(build([['a', 5], ['b', 5]]), 0)
+  assert.equal(messageLines(digest).length, 0)
+  assert.match(digest, /5 older unread message\(s\) not shown/)
+})
+
+test('an empty inbox renders as an empty digest', () => {
+  assert.equal(renderInboxDigest(new Map(), 40), '')
+})

--- a/server/src/agents/computer/daemon.ts
+++ b/server/src/agents/computer/daemon.ts
@@ -321,6 +321,62 @@ interface RuntimeInboxResponse {
   }>
 }
 
+// How many unread MESSAGE lines the pre-loaded wake digest may carry. It rides
+// in EVERY chat turn's prompt (see chatDelta), so it stays small.
+const DIGEST_MAX_MESSAGE_LINES = 40
+
+/** Render the pre-loaded unread digest for the wake prompt within
+ *  DIGEST_MAX_MESSAGE_LINES.
+ *
+ *  The budget is spent PER CONVERSATION rather than as one global "newest N
+ *  lines" tail, because `ackSeen` marks the WHOLE snapshot read: anything the
+ *  digest leaves out is marked read having never been shown, and since
+ *  mark-read pins each conversation's cursor at its NEWEST message it can never
+ *  resurface in a later wake. A global tail let a burst in one busy room evict —
+ *  and then ack away — every message of a quieter conversation, including a
+ *  human DM the agent could not even name afterwards. The cloud path avoids this
+ *  by giving every conversation with unread its own window (see loadContext).
+ *
+ *  Whatever the budget still cannot fit is announced IN PLACE with its exact
+ *  count and the command that reads it, so the engine can recover the rest
+ *  instead of never learning it existed. Conversations keep first-seen order and
+ *  their messages stay chronological; when everything fits, every unread line is
+ *  shown, exactly as before.
+ *
+ *  Exported for tests — pure, no server and no engine. */
+export function renderInboxDigest(
+  byConvo: Map<string, { head: string; msgs: string[] }>,
+  budget = DIGEST_MAX_MESSAGE_LINES,
+): string {
+  if (byConvo.size === 0) return ''
+  // Water-fill quietest-first: each conversation takes at most an even share of
+  // what is LEFT, so a small conversation keeps all of its messages and the busy
+  // one absorbs the slack. When the total fits, this hands every conversation
+  // its full set (nothing omitted, nothing announced).
+  const keep = new Map<string, number>()
+  let lineBudget = budget
+  let unserved = byConvo.size
+  for (const [id, convo] of [...byConvo].sort((a, b) => a[1].msgs.length - b[1].msgs.length)) {
+    const n = Math.min(convo.msgs.length, Math.max(0, Math.floor(lineBudget / unserved)))
+    keep.set(id, n)
+    lineBudget -= n
+    unserved -= 1
+  }
+  const lines: string[] = []
+  for (const [id, convo] of byConvo) {
+    const shown = keep.get(id) ?? 0
+    lines.push(convo.head)
+    // Never drop unread in SILENCE — this turn is about to mark it read.
+    if (convo.msgs.length > shown) {
+      lines.push(`  … ${convo.msgs.length - shown} older unread message(s) not shown — \`cumora messages ${id} --tail ${convo.msgs.length}\` to read them`)
+    }
+    // slice(length - shown), NOT slice(-shown): slice(-0) is slice(0) and would
+    // print everything for a conversation budgeted to zero.
+    lines.push(...convo.msgs.slice(convo.msgs.length - shown))
+  }
+  return lines.join('\n')
+}
+
 interface RuntimeInboxTriageResponse {
   actionable?: boolean
   reason?: string
@@ -1298,16 +1354,17 @@ class AgentRunner {
   private async snapshotUnread(token: string): Promise<{ seen: Map<string, string>; digest: string; hasReal: boolean }> {
     const inbox = await runtimeGet<RuntimeInboxResponse>(this.cfg.serverUrl, '/inbox', token)
     const seen = new Map<string, string>()
-    const lines: string[] = []
+    // Unread grouped BY CONVERSATION (first-seen order), each with the header
+    // (title + topic) the cloud agent's context also carries — so a BYOA agent
+    // always sees what the group is FOR (its topic), not just the messages.
+    // Grouped rather than one flat line list because the digest has a LINE
+    // BUDGET, and spending it per conversation is what stops a busy room from
+    // evicting — and `ackSeen` then burying — a quiet one. See renderInboxDigest.
+    const byConvo = new Map<string, { head: string; msgs: string[] }>()
     // `hasReal` = is ANY unread a genuine human/agent message (not a system
     // relay/status/membership notice)? The cost gate in runTurn uses this to
     // refuse to spend ANY model on a system-only (or empty) inbox.
     let hasReal = false
-    // Emit a per-conversation header (title + topic) the first time each convo
-    // appears, mirroring the cloud agent's context header — so a BYOA agent
-    // always sees what the group is FOR (its topic) while chatting, not just the
-    // messages.
-    const headered = new Set<string>()
     // rows are ordered created_at ASC, so the last row per conversation is its
     // newest unread message — exactly the cursor we want to advance to.
     for (const row of inbox?.rows ?? []) {
@@ -1318,13 +1375,14 @@ class AgentRunner {
       // engine (the cloud path special-cases these system rows the same way).
       const alarm = row.kind === 'system' && typeof row.body === 'string' ? this.parseAlarmPayload(row.body) : null
       if (row.kind !== 'system' || (alarm && (!alarm.assigneeId || alarm.assigneeId === this.agent.id))) hasReal = true
-      if (!headered.has(row.conversation_id)) {
-        headered.add(row.conversation_id)
+      let convo = byConvo.get(row.conversation_id)
+      if (!convo) {
         const kind = row.conversation_kind ? ` [${row.conversation_kind}]` : ''
         const title = row.conversation_title ? ` "${row.conversation_title}"` : ''
         let head = `# ${row.conversation_id}${kind}${title}`
         if (row.conversation_topic) head += `\n  Topic: ${row.conversation_topic}`
-        lines.push(head)
+        convo = { head, msgs: [] }
+        byConvo.set(row.conversation_id, convo)
       }
       const author = row.author_name ?? 'someone'
       const who = row.author_kind ? `${author} (${row.author_kind})` : author
@@ -1336,10 +1394,9 @@ class AgentRunner {
       // Keep the message id + convo id on each line (like the cloud agent's
       // context) so the engine can QUOTE the exact message: `cumora reply
       // <convo> '<body>' --quote <message_id>`.
-      lines.push(`  [${row.id}] ${row.conversation_id}  ${who}: ${body}`)
+      convo.msgs.push(`  [${row.id}] ${row.conversation_id}  ${who}: ${body}`)
     }
-    const digest = lines.length ? lines.slice(-40).join('\n') : ''
-    return { seen, digest, hasReal }
+    return { seen, digest: renderInboxDigest(byConvo), hasReal }
   }
 
   /** Advance this agent's read cursor over the conversations it just saw, so a


### PR DESCRIPTION
## The bug

`snapshotUnread` builds `seen` from **every** inbox row, but caps the digest handed to the engine with one **global** tail:

```ts
for (const row of inbox?.rows ?? []) {
  if (typeof row.id === 'string' && row.id) seen.set(row.conversation_id, row.id)   // ALL rows
  …
}
const digest = lines.length ? lines.slice(-40).join('\n') : ''                      // newest 40 only
```

On a clean turn the daemon then calls `ackSeen(token, seen)` — its own comment reads *"Clean turn → ack everything this turn saw"* — over the **full** map.

So anything the tail evicted is marked read **having never been shown**. And because `/conversation/mark-read` pins each conversation's cursor at its newest message id (the unread filter is `ROW(mm.created_at, mm.id) > ROW(lr_at, lr_id)`), those messages can never reappear in a later wake digest.

The contract comment directly above `snapshotUnread` states the opposite is intended:

> Captured BEFORE the engine runs so `ackSeen` advances exactly what THIS turn saw

The wake prompt compounds it by presenting the truncated set as complete — *"Your unread messages (ALREADY FETCHED — no need to re-run `cumora inbox` / `cumora messages` to re-read these)"* — so the model has no cue to re-fetch and no count with which to notice a gap.

## Measured against the previous renderer

| shape | result |
|---|---|
| a human DM that arrived **before** a 200-message group burst | the DM's conversation does not appear in the digest **at all** — then gets acked |
| 25 conversations × 2 unread (offline catch-up) | **12 conversations vanish entirely**, all 25 cursors jump forward |
| 60 unread in one room | 20 dropped, **no marker of any kind** |

The ordering detail matters and is why this is easy to miss: with the global tail, a quiet conversation survives if it happens to sort *last*. It's the DM that arrived *first* — human messages first, group noise after — that gets evicted.

## The fix

Spend the same 40-line budget **per conversation**, water-filling quietest-first so a small conversation keeps all of its messages and the busy one absorbs the slack.

This mirrors what the cloud path already does — `loadContext` gives every conversation with unread its own window, and `turn.ts` prints an explicit unread count and a "NEW since your last visit" boundary — so this brings BYOA in line with existing behavior rather than inventing a policy.

Whatever still can't fit is **announced in place** with its exact count and the command that reads it. That part is not cosmetic: this turn is about to mark those messages read, so dropping them in silence is precisely what makes the loss unrecoverable.

**When everything fits, the digest is byte-for-byte what it was.**

## Tests

`server/src/__tests__/agents-computer-inbox-digest.test.ts` — 7 cases against the extracted pure renderer (no server, no engine, no Postgres).

Checked each behavioural case against the old global-tail renderer to be sure none is vacuous:

```
PASS (old) fits budget verbatim          ← must pass on both; guards against over-fixing
FAIL (old) quiet convo survives burst
FAIL (old) no convo disappears
FAIL (old) omission announced
```

One case guards an implementation trap I'd otherwise have shipped: the slice must be `slice(length - shown)`, not `slice(-shown)` — `slice(-0)` is `slice(0)` and would dump a conversation budgeted to zero in full.

## Checks

`npm run lint`, `npm run typecheck`, `npm run server:typecheck` pass.

Scope note: this changes only how the pre-loaded digest is *rendered*. I deliberately did not touch `ackSeen` itself — narrowing the ack to only-what-was-shown would leave the remainder permanently unread and re-trigger a turn every `INBOX_POLL_MS`, which trades silent loss for a wake loop. Showing every conversation and naming what was omitted fixes the harm without that side effect.
