### PR TITLE
fix(byoa): let a local engine keep its own model (custom providers)

### DIFF
--- a/docs/BYOA.md
+++ b/docs/BYOA.md
@@ -215,6 +215,30 @@ Model selection: the per-agent `participants.model` / `fast_model`
 columns, else the deploy-level `CUMORA_DEFAULT_CLAUDE_MODEL` /
 `CUMORA_DEFAULT_CODEX_MODEL` pins.
 
+### Running against a custom provider
+
+Those pins are resolved server-side and name Anthropic / OpenAI models. If your
+local `claude` or `codex` is pointed at a **custom provider** (CC Switch and
+friends), it has never heard of `claude-opus-4-7`, so every turn fails with
+*"There's an issue with the selected model"* even though the CLI works fine in
+your terminal.
+
+Set `CUMORA_ENGINE_MODEL` on the daemon to fix it:
+
+| value | effect |
+| --- | --- |
+| unset | use the model Cumora pinned (default) |
+| `local` | pass **no** model at all — the CLI runs on whatever it is already configured for, and the small/fast pin is dropped too |
+| any model id | use that model instead of the pinned one |
+
+Pair it with `CUMORA_TRIAGE_MODEL` if your provider also lacks the small brain
+(`haiku` / `gpt-5.4-mini`); `cumora agent computer doctor` probes the same model
+that triage will use, so a green doctor means real wakes will work.
+
+```bash
+CUMORA_ENGINE_MODEL=local CUMORA_TRIAGE_MODEL=local-small cumora agent computer
+```
+
 ---
 
 ## Per-agent home (local state)

--- a/server/src/__tests__/agents-computer-engine-model.test.ts
+++ b/server/src/__tests__/agents-computer-engine-model.test.ts
@@ -1,0 +1,60 @@
+/**
+ * BYOA model selection.
+ *
+ * Cumora pins a model per agent so a CLI upgrade can't silently change an
+ * agent's behaviour. That pin is resolved SERVER-side and is an Anthropic /
+ * OpenAI model id — which is wrong for an operator whose local `claude` points
+ * at a custom provider (CC Switch and friends). The provider has never heard of
+ * `claude-opus-4-7`, so every turn dies with "There's an issue with the selected
+ * model", and on hosted Cumora the operator cannot change the pin.
+ *
+ * CUMORA_ENGINE_MODEL is the daemon-side escape; `local` imposes nothing.
+ *
+ * Run: node --import tsx --test server/src/__tests__/agents-computer-engine-model.test.ts
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { resolveEngineModel, resolveEngineFastModel } from '../agents/computer/daemon.js'
+
+test('with no override, the model Cumora pinned is used', () => {
+  assert.equal(resolveEngineModel('claude-opus-4-7', undefined), 'claude-opus-4-7')
+  assert.equal(resolveEngineFastModel('claude-haiku-4-5', undefined), 'claude-haiku-4-5')
+})
+
+test('an unset agent model stays unset', () => {
+  assert.equal(resolveEngineModel(null, undefined), null)
+  assert.equal(resolveEngineModel(undefined, undefined), null)
+})
+
+test('`local` passes NO model, so the CLI uses its own configuration', () => {
+  assert.equal(resolveEngineModel('claude-opus-4-7', 'local'), null)
+})
+
+test('`local` also drops the small/fast pin', () => {
+  // Otherwise ANTHROPIC_SMALL_FAST_MODEL would still name a model the custom
+  // provider lacks and the CLI's own quick calls would fail instead.
+  assert.equal(resolveEngineFastModel('claude-haiku-4-5', 'local'), null)
+})
+
+test('`local` is matched case- and whitespace-insensitively', () => {
+  // It comes from a hand-edited shell profile or .env file.
+  for (const v of ['local', 'LOCAL', 'Local', '  local  ']) {
+    assert.equal(resolveEngineModel('claude-opus-4-7', v), null, `not honoured: ${JSON.stringify(v)}`)
+  }
+})
+
+test('a concrete override replaces the pinned model', () => {
+  assert.equal(resolveEngineModel('claude-opus-4-7', 'my-provider/some-model'), 'my-provider/some-model')
+})
+
+test('a concrete override leaves the fast model alone', () => {
+  // Only `local` means "impose nothing"; naming a big model says nothing about
+  // the small one.
+  assert.equal(resolveEngineFastModel('claude-haiku-4-5', 'my-provider/some-model'), 'claude-haiku-4-5')
+})
+
+test('an empty or whitespace-only override is ignored, not treated as `local`', () => {
+  // An exported-but-empty env var must not silently unpin the model.
+  assert.equal(resolveEngineModel('claude-opus-4-7', ''), 'claude-opus-4-7')
+  assert.equal(resolveEngineModel('claude-opus-4-7', '   '), 'claude-opus-4-7')
+})

--- a/server/src/agents/computer/daemon.ts
+++ b/server/src/agents/computer/daemon.ts
@@ -771,6 +771,48 @@ class HopReporter {
   }
 }
 
+/** CUMORA_ENGINE_MODEL value meaning "impose no model at all — use whatever
+ *  the local CLI is already configured for". */
+const ENGINE_MODEL_LOCAL = 'local'
+
+/** The model the LOCAL engine should run this agent's turns on.
+ *
+ *  Cumora pins a model per agent (participants.model, else the deploy-level
+ *  CUMORA_DEFAULT_* default) so a CLI upgrade can't silently change behaviour.
+ *  That pin is an Anthropic/OpenAI model id — which is simply wrong for a BYOA
+ *  operator whose `claude` points at a custom provider (CC Switch and friends):
+ *  the provider has never heard of e.g. `claude-opus-4-7`, so EVERY turn dies
+ *  with "There's an issue with the selected model". The pin is resolved
+ *  server-side, so on hosted Cumora the operator cannot change it, and their
+ *  only escape was CUMORA_CLAUDE_ARGS — which also disables the persistent
+ *  session and makes them hand-write the entire flag set.
+ *
+ *  CUMORA_ENGINE_MODEL overrides the pin daemon-side. The value `local` passes
+ *  NO model at all, so the CLI runs on whatever it is already configured for —
+ *  the same escape CUMORA_TRIAGE_MODEL already gives the small brain.
+ *
+ *  Exported for tests. */
+export function resolveEngineModel(
+  configured: string | null | undefined,
+  override: string | undefined,
+): string | null {
+  const o = override?.trim()
+  if (!o) return configured ?? null
+  return o.toLowerCase() === ENGINE_MODEL_LOCAL ? null : o
+}
+
+/** The same knob governs the small-brain pin. `local` has to impose NOTHING:
+ *  otherwise ANTHROPIC_SMALL_FAST_MODEL would still name a model the custom
+ *  provider lacks, and the CLI's own quick calls would fail instead of the turn.
+ *  A concrete override only replaces the big-brain pin, so fast_model is left
+ *  alone there. */
+export function resolveEngineFastModel(
+  configured: string | null | undefined,
+  override: string | undefined,
+): string | null {
+  return override?.trim().toLowerCase() === ENGINE_MODEL_LOCAL ? null : (configured ?? null)
+}
+
 class AgentRunner {
   private token = ''
   private tokenExpiresAt = 0
@@ -1022,6 +1064,16 @@ class AgentRunner {
 
   /** Env handed to the engine subprocess: the `cumora` shim on PATH, wired to
    *  this agent's runtime URL + token. */
+  /** Big-brain model for the local engine, after the CUMORA_ENGINE_MODEL escape. */
+  private engineModel(): string | null {
+    return resolveEngineModel(this.agent.model, process.env.CUMORA_ENGINE_MODEL)
+  }
+
+  /** Small/fast-brain model for the local engine, after the same escape. */
+  private engineFastModel(): string | null {
+    return resolveEngineFastModel(this.agent.fastModel, process.env.CUMORA_ENGINE_MODEL)
+  }
+
   private engineEnv(): NodeJS.ProcessEnv {
     return {
       ...process.env,
@@ -1047,8 +1099,8 @@ class AgentRunner {
     this.engineSession = this.adapter.startSession({
       home: this.home,
       env: this.engineEnv(),
-      model: this.agent.model,
-      fastModel: this.agent.fastModel,
+      model: this.engineModel(),
+      fastModel: this.engineFastModel(),
       resumeSessionId: this.sessionId,
       standingPrompt: this.standingPrompt(),
       onLog: (line) => this.logEngineLine(line),
@@ -1544,7 +1596,7 @@ class AgentRunner {
         ? await session.send(prompt)
         : await this.adapter.run({
           home: this.home, prompt, env: this.engineEnv(),
-          model: this.agent.model, fastModel: this.agent.fastModel,
+          model: this.engineModel(), fastModel: this.engineFastModel(),
           resumeSessionId: this.sessionId, onLog: (line) => this.logEngineLine(line),
           // Same trajectory hook as the persistent-session path so the
           // one-shot fallback (or codex `exec` path) also lands hops in the
@@ -1914,8 +1966,8 @@ class AgentRunner {
               home: this.home,
               prompt,
               env: this.engineEnv(),
-              model: this.agent.model,
-              fastModel: this.agent.fastModel,
+              model: this.engineModel(),
+              fastModel: this.engineFastModel(),
               resumeSessionId,
               onLog: (line) => this.logEngineLine(line),
               onHopUsage: (r) => this.onEngineHop(r, 'agent-turn'),

--- a/server/src/agents/computer/engine.ts
+++ b/server/src/agents/computer/engine.ts
@@ -522,6 +522,13 @@ function spawnCapture(
   })
 }
 
+/** The small/fast model the triage path actually runs on. `probe` must use the
+ *  SAME one or `doctor` reports a red small-brain for an operator whose custom
+ *  provider has no `haiku` — even though their triage is configured correctly. */
+function triageModel(fallback: string): string {
+  return process.env.CUMORA_TRIAGE_MODEL?.trim() || fallback
+}
+
 function extraArgs(envVar: string): string[] {
   const raw = process.env[envVar]
   return raw ? raw.split(/\s+/).filter(Boolean) : []
@@ -834,7 +841,7 @@ class ClaudeAdapter implements EngineAdapter {
     // → haiku (the cerebellum); 'big' → omit --model so Claude uses its DEFAULT
     // (the main reasoning brain). One token in, "OK" out — proves the binary runs
     // and that tier is authed/has quota, with NO tools/MCP/persona.
-    const model = args.tier === 'small' ? ['--model', 'haiku'] : []
+    const model = args.tier === 'small' ? ['--model', triageModel('haiku')] : []
     const { command, shell, wantsStdinPrompt } = resolveSpawn(this.bin)
     const base = ['-p', ...model, '--output-format', 'text', '--dangerously-skip-permissions', '--strict-mcp-config']
     const argv = wantsStdinPrompt ? base : ['-p', DOCTOR_PROMPT, ...base.slice(1)]
@@ -1268,7 +1275,7 @@ class CodexAdapter implements EngineAdapter {
     // 'small' → gpt-5.4-mini (the cerebellum); 'big' → omit --model so Codex uses
     // its default model. `exec` non-interactive, no bypass/sandbox flags needed
     // for a tool-free one-token reply.
-    const model = args.tier === 'small' ? ['--model', 'gpt-5.4-mini'] : []
+    const model = args.tier === 'small' ? ['--model', triageModel('gpt-5.4-mini')] : []
     const { command, shell } = resolveSpawn(this.bin)
     const argv = ['exec', ...model, '--skip-git-repo-check', DOCTOR_PROMPT]
     return spawnCapture(command, argv, {


### PR DESCRIPTION
Fixes #21.

## What's actually wrong

The report reads like a provider/auth problem, but the error in the screenshot names the real cause:

> engine turn error: There's an issue with the selected model (**claude-opus-4-7**). It may not exist or you may not have access to it.

Cumora pins a model per agent — `participants.model`, else the deploy-level `CUMORA_DEFAULT_CLAUDE_MODEL` / `CUMORA_DEFAULT_CODEX_MODEL` — and the daemon passes it to the local CLI as `--model`. The pin exists for a good reason, and `registry.ts` says so:

> a model upgrade in the underlying CLI (e.g. claude 4.7 → 4.8) silently changes agent behavior on every user's machine unless we pin here

But the pin is resolved **server-side** and names an Anthropic/OpenAI model. When someone points their local `claude` at a custom provider (CC Switch and friends), that provider has never heard of `claude-opus-4-7` — so **every turn fails**, while the very same CLI works fine in their terminal. That's exactly the confusing shape both reporters describe.

And on hosted Cumora they can't change the pin: it comes from the server. The only daemon-side escape was `CUMORA_CLAUDE_ARGS`, which does drop `--model` but *also* disables the persistent session (`startSession` returns null) and forces them to hand-write the entire flag set. That's a trap, not an escape.

## The fix

Add `CUMORA_ENGINE_MODEL` — the big-brain counterpart of the `CUMORA_TRIAGE_MODEL` escape the small brain already had:

| value | effect |
| --- | --- |
| unset | the model Cumora pinned — **unchanged default** |
| `local` | pass **no** model; the CLI runs on whatever it's configured for |
| any model id | use that model instead of the pin |

`local` also drops the small/fast pin. Leaving `ANTHROPIC_SMALL_FAST_MODEL` naming a model the provider lacks would just move the failure from the turn to the CLI's own quick calls. A concrete override replaces only the big-brain pin, since naming a big model says nothing about the small one.

Applied in the daemon where the model is chosen, so it covers the persistent session, the one-shot run, and the agenda turn without touching any adapter.

## Second, related fix: `doctor` was lying

`probe`'s small tier hardcoded `haiku` / `gpt-5.4-mini` while triage runs on `CUMORA_TRIAGE_MODEL`. So an operator whose provider lacks haiku saw a **red small brain even when their triage was configured correctly** — the diagnostic contradicting the thing it exists to diagnose. It now probes the same model triage will use.

## Verification

End to end against a fake CLI that echoes its argv:

```
CUMORA_ENGINE_MODEL=(unset)              --model claude-opus-4-7      fast pin: claude-haiku-4-5
CUMORA_ENGINE_MODEL=local                (no --model)                 fast pin: none
CUMORA_ENGINE_MODEL=my-provider/glm-4.6  --model my-provider/glm-4.6  fast pin: claude-haiku-4-5
```

8 unit cases in `server/src/__tests__/agents-computer-engine-model.test.ts` cover the resolution rules, including two that guard against footguns: `local` is matched case- and whitespace-insensitively (it's typed into a shell profile), and an **exported-but-empty** `CUMORA_ENGINE_MODEL=` is ignored rather than silently unpinning the model.

`docs/BYOA.md` gains a "Running against a custom provider" section with the table and a copy-pasteable command, right under the existing model-selection paragraph.

## Note

I don't have a custom provider set up to reproduce the original failure end to end, so the diagnosis rests on the error text in the issue plus the code path that produces it (`--model` from the server-side pin → the CLI). The mechanism is unambiguous, but it'd be worth one of the reporters confirming with `CUMORA_ENGINE_MODEL=local` before this merges.

## Checks

`npm run lint`, `npm run typecheck`, `npm run server:typecheck` pass. New tests need no Postgres/Redis/`OPENAI_API_KEY`.
