### PR TITLE
fix(byoa): `--stop` no longer skips daemons whose argv contains `npx`

### DIFF
--- a/server/src/__tests__/agents-computer-stop-daemon-match.test.ts
+++ b/server/src/__tests__/agents-computer-stop-daemon-match.test.ts
@@ -1,0 +1,99 @@
+/**
+ * `--stop` promises a full stop: the service is uninstalled AND every running
+ * daemon process is killed. That promise rests entirely on classifying a
+ * `ps`-reported command line as "long-running daemon" vs. "one-shot CLI", and
+ * the cost of getting it wrong is asymmetric and silent — a spared daemon keeps
+ * holding wake-streams and processing turns while `--stop` reports success.
+ *
+ * The regression these pin: the matcher's exclusions were written as
+ * `--(stop|…|pair)\b|\bnpx\b`, but `|` binds looser than the group, so `\bnpx\b`
+ * matched anywhere in the command line rather than only as the wrapper. Every
+ * daemon launched the documented way (`npx -y cumora@latest agent computer …`,
+ * which is also the LaunchAgent's ProgramArguments) was therefore spared.
+ *
+ * Run: node --import tsx --test server/src/__tests__/agents-computer-stop-daemon-match.test.ts
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { isStoppableDaemonCommand } from '../agents/computer/daemon.js'
+
+// ── real long-running daemons: must be killed ────────────────────────────────
+
+test('the npx-launched daemon IS stoppable (the precedence regression)', () => {
+  // Exactly the plist's ProgramArguments, and what --pair tells users to run.
+  // Spared before the fix purely because "npx" appeared in its argv.
+  assert.equal(
+    isStoppableDaemonCommand('npx -y cumora@latest agent computer --server https://api.cumora.ai'),
+    true,
+  )
+})
+
+test('a daemon resolved through the _npx bin shim IS stoppable', () => {
+  // How the wrapper's child actually shows up in `ps`.
+  assert.equal(
+    isStoppableDaemonCommand(
+      'node /Users/x/.npm/_npx/302120fbb92394c3/node_modules/.bin/cumora agent computer --server https://api.cumora.ai',
+    ),
+    true,
+  )
+})
+
+test('an `npm exec` launched daemon IS stoppable', () => {
+  assert.equal(
+    isStoppableDaemonCommand('npm exec cumora@latest agent computer --server https://api.cumora.ai'),
+    true,
+  )
+})
+
+test('a bare foreground daemon with no flags IS stoppable', () => {
+  assert.equal(isStoppableDaemonCommand('cumora agent computer'), true)
+})
+
+test('the supervised daemon IS stoppable even with env noise in the command line', () => {
+  // launchd-reported argv carries trailing environment; it must not confuse the match.
+  assert.equal(
+    isStoppableDaemonCommand(
+      'npm exec cumora@latest agent computer --server https://api.cumora.ai CUMORA_SUPERVISED=1 XPC_SERVICE_NAME=io.cumora.daemon',
+    ),
+    true,
+  )
+})
+
+// ── one-shot CLIs: must be spared ────────────────────────────────────────────
+
+test('every one-shot flag is spared', () => {
+  for (const flag of [
+    '--stop', '--status', '--restart', '--logs', '--version',
+    '--install-service', '--uninstall-service', '--pair',
+  ]) {
+    assert.equal(
+      isStoppableDaemonCommand(`node /usr/local/bin/cumora agent computer ${flag}`),
+      false,
+      flag,
+    )
+  }
+})
+
+test('--pair with a value is spared', () => {
+  assert.equal(
+    isStoppableDaemonCommand('npx cumora@latest agent computer --pair 8lkqelTbO --server https://api.cumora.ai'),
+    false,
+  )
+})
+
+test('an unrelated process is never a victim', () => {
+  assert.equal(isStoppableDaemonCommand('node /Users/x/some-other-tool serve --port 3000'), false)
+  assert.equal(isStoppableDaemonCommand('cumora agent pod --agent-id a1'), false)
+})
+
+test('a one-shot flag is only matched behind its `--`', () => {
+  // The bare words must not spare a real daemon just by appearing in a path,
+  // a server URL, or a repo name — that is the same class of bug as `npx`.
+  for (const cmd of [
+    'node /Users/status/bin/cumora agent computer --server https://api.cumora.ai',
+    'npx cumora@latest agent computer --server https://logs.internal.example.com',
+    'node /opt/restart-tools/cumora agent computer --server https://api.cumora.ai',
+  ]) {
+    assert.equal(isStoppableDaemonCommand(cmd), true, cmd)
+  }
+})

--- a/server/src/agents/computer/daemon.ts
+++ b/server/src/agents/computer/daemon.ts
@@ -2585,12 +2585,32 @@ async function restartService(): Promise<void> {
  *  removed from the supervisor so KeepAlive/Restart won't relaunch it; the
  *  plist/unit stays on disk, so `--restart` brings it back. (To remove it
  *  entirely, use `--uninstall-service`.) */
+
+/** One-shot CLI invocations: these do a thing and exit, so they are never the
+ *  long-running daemon we mean to stop. Anchored to the `--` so the words can't
+ *  match incidentally elsewhere in the command line. */
+const ONE_SHOT_FLAG_RE =
+  /--(stop|status|restart|logs|version|install-service|uninstall-service|pair)\b/
+
+/** Is this `ps`-reported command line a long-running BYOA daemon that `--stop`
+ *  should kill? True only for `agent computer` with no one-shot flag.
+ *
+ *  The npx *wrapper* used to be excluded here too, but that exclusion was both
+ *  wrong and unnecessary: `npx -y cumora@latest agent computer --server …` is
+ *  exactly how the LaunchAgent (and the docs) start a real daemon, and self/parent
+ *  protection is already handled by dropping process.pid / process.ppid from the
+ *  candidate set. Killing the wrapper's child is what actually stops the daemon,
+ *  and the wrapper exits with it. */
+export function isStoppableDaemonCommand(cmd: string): boolean {
+  return /agent computer/.test(cmd) && !ONE_SHOT_FLAG_RE.test(cmd)
+}
+
 /** Kill any RUNNING daemon process — the supervised one (after the service is
  *  uninstalled), a foreground one, or a stray/orphaned one. Sources: the pid the
  *  daemon records in running.json, plus a `pgrep` sweep for "agent computer". We
  *  verify each candidate's command line really is a long-running daemon (and is
- *  NOT this --stop command, its npx wrapper, or another one-shot CLI) before
- *  killing — SIGTERM, then SIGKILL anything that ignores it. Best-effort. */
+ *  NOT this --stop command or another one-shot CLI) before killing — SIGTERM,
+ *  then SIGKILL anything that ignores it. Best-effort. */
 async function killRunningDaemons(): Promise<void> {
   const candidates = new Set<number>()
   try {
@@ -2610,9 +2630,10 @@ async function killRunningDaemons(): Promise<void> {
     try {
       const { stdout } = await execFileP('ps', ['-p', String(pid), '-o', 'command='])
       const cmd = stdout.trim()
-      // A genuine long-running daemon: "agent computer" with NO one-shot flag,
-      // and not the npx wrapper — so we never kill ourselves or a sibling CLI.
-      if (/agent computer/.test(cmd) && !/--(stop|status|restart|logs|version|install-service|uninstall-service|pair)\b|\bnpx\b/.test(cmd)) {
+      // A genuine long-running daemon: "agent computer" with NO one-shot flag —
+      // so we never kill a sibling one-shot CLI. (Ourselves and our parent are
+      // already out of `candidates`.)
+      if (isStoppableDaemonCommand(cmd)) {
         victims.push(pid)
       }
     } catch { /* gone */ }


### PR DESCRIPTION
Fixes #36.

## Problem

The command-line filter in `killRunningDaemons()` (`server/src/agents/computer/daemon.ts`) excluded one-shot CLI invocations *and* the npx wrapper with a single regex:

```
--(stop|status|restart|logs|version|install-service|uninstall-service|pair)\b|\bnpx\b
```

`|` binds looser than the group, so this parses as `(--(stop|…|pair)\b)` **or** `(\bnpx\b)` — the `\bnpx\b` alternative is not scoped to the `--` prefix and matches anywhere in the command line.

The consequence is that any genuine long-running daemon whose argv contains `npx` was spared. That is not an edge case:

- it is the installed LaunchAgent's `ProgramArguments` (`npx -y cumora@latest agent computer --server …`)
- it is what the docs and the `--pair` output tell users to run

For such a daemon, `--stop` found the pid via its `pgrep` sweep, discarded it, and then printed *"service removed and daemon process(es) killed"* without having killed anything — leaving a daemon still holding wake-streams and processing turns, with no indication that anything was missed. Recording the pid in `running.json` doesn't rescue it either, since that candidate goes through the same predicate.

## Fix

Split the one-shot check into its own anchored regex and drop the npx exclusion entirely.

Dropping it is safe and was the right call rather than just re-grouping: self/parent protection already comes from removing `process.pid` / `process.ppid` from the candidate set, so the wrapper exclusion was both wrong and unnecessary. Killing the wrapper's child is what actually stops the daemon, and the wrapper exits with it.

The predicate is extracted as `isStoppableDaemonCommand` so the classification is unit-testable, matching how `isStaleResumeError` is already covered in this codebase.

## Tests

New: `server/src/__tests__/agents-computer-stop-daemon-match.test.ts` (9 tests).

Verified that the two tests pinning the regression **fail against the old regex** and pass with the fix:

```
✖ the npx-launched daemon IS stoppable (the precedence regression)
✖ a one-shot flag is only matched behind its `--`
   → 7 pass, 2 fail on the buggy version;  9 pass after the fix
```

Coverage includes the npx wrapper, the `_npx` bin shim, `npm exec`, launchd argv with trailing env noise, every one-shot flag, `--pair <value>`, unrelated processes, and one-shot words appearing in paths/URLs (the same class of bug as `npx`).

The broader `agents-computer-*` suite passes: 46 tests, 0 failures.

<sub>Note on local verification: `npm install` could not complete in my environment (my registry mirror 500s on the `esbuild` tarball), so `tsc -p server/tsconfig.json` couldn't run — the pre-existing `agent-computer-pairing-token.test.ts` also fails there purely on a missing `pg`. I ran the tests and `biome lint` (clean) via a separately installed `tsx`/`biome`. Worth a CI confirmation.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
