### PR TITLE
fix(ws): upgrade vulnerable dependency and cap payloads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "tailwind-merge": "^2.5.4",
         "tsx": "^4.21.0",
         "unist-util-visit": "^5.1.0",
-        "ws": "^8.20.0",
+        "ws": "^8.21.3",
         "y-protocols": "^1.0.7",
         "yjs": "^13.6.30",
         "zustand": "^5.0.1"
@@ -16083,9 +16083,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "tailwind-merge": "^2.5.4",
     "tsx": "^4.21.0",
     "unist-util-visit": "^5.1.0",
-    "ws": "^8.20.0",
+    "ws": "^8.21.3",
     "y-protocols": "^1.0.7",
     "yjs": "^13.6.30",
     "zustand": "^5.0.1"

--- a/server/src/ws.ts
+++ b/server/src/ws.ts
@@ -494,7 +494,7 @@ async function resolveDisplayName(id: string, companyId: string): Promise<string
 }
 
 export function attachWebSocket(httpServer: Server) {
-  const wss = new WebSocketServer({ server: httpServer, path: '/ws' })
+  const wss = new WebSocketServer({ server: httpServer, path: '/ws', maxPayload: 4 * 1024 * 1024 })
 
   wss.on('connection', async (ws, req) => {
     const ip = req.socket.remoteAddress


### PR DESCRIPTION
## Summary

- upgrade `ws` from 8.20.0 to 8.21.3 to address the current fragment/chunk memory-exhaustion audit finding
- set the WebSocket server `maxPayload` to 4 MiB instead of the 100 MiB default

## Why 4 MiB

Cumora's inbound WebSocket traffic is primarily small control frames and incremental Yjs updates. A 4 MiB limit substantially reduces the memory impact of oversized messages while leaving headroom for unusually large single-paste document updates after JSON and base64 overhead.

Document images continue to upload over HTTP; WebSocket document frames contain only their URLs and metadata.

## Security impact

The dependency upgrade clears the current `ws` audit finding, including [GHSA-96hv-2xvq-fx4p](https://github.com/advisories/GHSA-96hv-2xvq-fx4p). The explicit payload limit bounds the size of any inbound WebSocket message before JSON parsing, base64 decoding, and Yjs processing.

## Validation

- `npm run server:typecheck`
- `npm run build`
- `npx biome check package.json`
- `npm audit --json` reports no `ws` finding

The existing import-order finding in `server/src/ws.ts` is unchanged from `main`; imports were intentionally left untouched to keep this fix minimal.