### PR TITLE
fix(auth): send local dev sign-in to the local server, not production

### DIFF
--- a/src/components/AuthScreen.tsx
+++ b/src/components/AuthScreen.tsx
@@ -12,7 +12,7 @@
  * per-server.
  */
 import { useState, useEffect } from 'react'
-import { api, getServerOrigin, setServerOrigin } from '@/api/client'
+import { api, getPairingServerOrigin, getServerOrigin, setServerOrigin } from '@/api/client'
 import { isCapacitorIOS, isElectron } from '@/lib/runtime'
 import { isNativePlatform, nativePlatform, runAppleSignIn, runOAuth } from '@/lib/native'
 import { useAuth } from '@/stores/auth'
@@ -95,7 +95,10 @@ export function AuthScreen() {
       // — the loopback HTTP server in main.cjs serves a styled
       // "Signed in" page that POSTs the fragment back to the main
       // process, which IPCs the renderer (see AuthGate's onToken).
-      const origin = getServerOrigin() || 'https://api.cumora.ai'
+      // getServerOrigin() is '' in dev (relative, for the Vite proxy) —
+      // use the pairing origin so local dev opens the local server instead
+      // of falling through to production.
+      const origin = getPairingServerOrigin() || 'https://api.cumora.ai'
       // Arm a single-use nonce and thread it through the return URL. The server
       // round-trips it back onto /auth/done, the loopback page carries it into
       // the cumora:// deep link, and main accepts the token only if the nonce
@@ -119,7 +122,9 @@ export function AuthScreen() {
       // (our WebAuthPlugin). It hands the final cumora://auth#... callback
       // straight back to us — no SFSafariViewController, no broken 302
       // redirect to a custom URL scheme.
-      const origin = getServerOrigin() || 'https://api.cumora.ai'
+      // See the Electron branch above — same reasoning for preferring the
+      // pairing origin over getServerOrigin() in dev.
+      const origin = getPairingServerOrigin() || 'https://api.cumora.ai'
       const ret = encodeURIComponent('cumora://auth')
       void (async () => {
         try {


### PR DESCRIPTION
## Summary
- Local dev (`npm run electron:dev` / `npm run dev:all`) always opened the OAuth sign-in URL against production (`https://api.cumora.ai`) instead of the local API server, because `AuthScreen`'s fallback used `getServerOrigin()` — which is intentionally `''` in dev (relative, for the Vite proxy) — so `'' || 'https://api.cumora.ai'` always won.
- Swapped in `getPairingServerOrigin()` (already exported from `src/api/client.ts` for this exact "need an absolute origin outside the proxied page" case), which resolves to the local Vite dev-proxy target in dev and is provably identical to `getServerOrigin()` in every non-dev build (`import.meta.env.DEV` is a build-time constant, `false` for every packaged/web build), so this has no effect on production, the packaged desktop app, or iOS/Android.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run typecheck` / `npm run server:typecheck` — clean
- [x] `npm run guard:big-brain` / `npm run guard:llm-tracked` — pass
- [x] `npm test` — 660/661 pass (1 pre-existing skip, unrelated)
- [x] Manually verified locally: configured a local GitHub OAuth App with callback `http://localhost:5181/api/auth/callback/github`, confirmed "Continue with GitHub" now opens `http://localhost:5181/...` in dev and completes sign-in against the local Postgres DB (previously it silently authenticated against production and every subsequent local API call 401'd).

Note: found the same fallback-to-production pattern independently reimplemented in `src/components/InviteAcceptScreen.tsx`'s Electron sign-in branch — left out of this PR to keep it to one logical change; happy to follow up separately if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)