### PR TITLE
fix(ui): picking Grok Build paired the computer to Claude

### DIFF
--- a/src/desktop/MeView.tsx
+++ b/src/desktop/MeView.tsx
@@ -708,7 +708,8 @@ function ComputersTab() {
   const [code, setCode] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
   // Engine for a NEWLY added computer's starter/assigned agents. Claude is the
-  // default (no flag → daemon auto-detects); Codex appends `--engine codex`.
+  // default (no flag → daemon auto-detects); every other pick is named
+  // explicitly, or the daemon auto-detects and engines[0] silently wins.
   const [engine, setEngine] = useState<'claude' | 'codex' | 'grok'>('claude')
   // Default on: install the always-on service (auto-start/restart/update).
   // --install-service is macOS/Linux only (daemon throws on Windows) → off + hidden there.
@@ -736,7 +737,8 @@ function ComputersTab() {
 
   const origin = getPairingServerOrigin()
   const serverFlag = origin ? ` --server ${origin}` : ''
-  const pairCommand = code ? `npx cumora@latest agent computer --pair ${code}${serverFlag}${engine === 'codex' ? ' --engine codex' : ''}${asService ? ' --install-service' : ''}` : ''
+  const engineFlag = engine === 'claude' ? '' : ` --engine ${engine}`
+  const pairCommand = code ? `npx cumora@latest agent computer --pair ${code}${serverFlag}${engineFlag}${asService ? ' --install-service' : ''}` : ''
   const list = Object.values(byId).sort((a, b) =>
     (a.kind === 'cloud' ? 0 : 1) - (b.kind === 'cloud' ? 0 : 1) || a.name.localeCompare(b.name))
 

--- a/src/desktop/Onboarding.tsx
+++ b/src/desktop/Onboarding.tsx
@@ -17,8 +17,8 @@ export function Onboarding() {
   const [err, setErr] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
   // The engine the starter team (and agents later assigned here) will run on.
-  // Claude is the default; picking Codex appends `--engine codex`. We DON'T
-  // append `--engine claude` so a Codex-only machine still auto-detects rather
+  // Claude is the default; ANY other pick must be named explicitly. We DON'T
+  // append `--engine claude` so a Claude-less machine still auto-detects rather
   // than erroring on a Claude it doesn't have.
   const [engine, setEngine] = useState<'claude' | 'codex' | 'grok'>('claude')
   // Default to installing the always-on service: it auto-starts on boot,
@@ -36,7 +36,10 @@ export function Onboarding() {
   }, [copied])
 
   const origin = getPairingServerOrigin()
-  const engineFlag = engine === 'codex' ? ' --engine codex' : ''
+  // Every non-default engine, not just Codex: without the flag the daemon
+  // auto-detects and the server takes engines[0] as this computer's DEFAULT, so
+  // picking Grok on a machine that also has Claude silently paired it to Claude.
+  const engineFlag = engine === 'claude' ? '' : ` --engine ${engine}`
   const serviceFlag = asService ? ' --install-service' : ''
   const cmd = code ? `npx cumora@latest agent computer --pair ${code}${origin ? ` --server ${origin}` : ''}${engineFlag}${serviceFlag}` : ''
 


### PR DESCRIPTION
Follow-up to #23 / #4.

## The bug

Both pairing surfaces now offer a three-engine toggle:

```ts
{([['claude', 'Claude Code'], ['codex', 'Codex'], ['grok', 'Grok Build']] as const).map(...)}
```

but the pair command is still built with a two-way ternary:

```ts
const engineFlag = engine === 'codex' ? ' --engine codex' : ''      // Onboarding.tsx
...${engine === 'codex' ? ' --engine codex' : ''}...                // MeView.tsx
```

So selecting **Grok Build** emits **no `--engine` flag at all**.

The daemon then auto-detects: `engines = detected`, ordered by `ENGINE_IDS` = `['claude', 'codex', 'grok']`. The server stores `available_engines[0]` as this computer's **default** engine — and `doPair`'s own comment spells out what that means:

> The chosen engine becomes this computer's DEFAULT — it's sent first in the engines list, which the server stores as `available_engines[0]` and uses as the engine for the starter team and any agent assigned here without an explicit override.

**Net effect on any machine that also has Claude Code installed: the user picks Grok Build and gets Claude.** Silently — no error, and nothing in the UI hints at it. Which makes the engine added in #23 effectively unreachable from onboarding for exactly the users most likely to have both CLIs installed.

## The fix

Name every non-default engine explicitly instead of special-casing Codex:

```ts
const engineFlag = engine === 'claude' ? '' : ` --engine ${engine}`
```

Claude stays flagless, which is the documented intent:

> We DON'T append `--engine claude` so a Claude-less machine still auto-detects rather than erroring on a Claude it doesn't have.

and a fourth engine now works without touching this line again.

| picked | before | after |
| --- | --- | --- |
| claude | `--pair ABC123` | `--pair ABC123` *(unchanged)* |
| codex | `--pair ABC123 --engine codex` | `--pair ABC123 --engine codex` *(unchanged)* |
| grok | `--pair ABC123` | `--pair ABC123 --engine grok` |

Only the Grok row changes.

Worth noting the failure mode also becomes *loud* where it should be: with `--engine grok` on a machine without Grok, `doPair` now errors with `--engine grok chosen, but grok is not installed on this machine. Installed: …` instead of quietly pairing to something else.

## Verification

`npm run lint` and `npm run typecheck` pass.

This repo has no frontend test harness (`CONTRIBUTING.md`: "There are no frontend unit tests yet"; `npm test` globs only `server/src/__tests__` and `workers/`), so no automated test ships with this — stated as a limitation, not an oversight. What I did instead was evaluate both flag builders across all three toggle values, which is the table above.

I also verified the downstream half against the real code rather than assuming it: `detectEngines` returns `Object.keys(ADAPTERS)` order, `doPair` puts `preferredEngine` first only when the flag is present, and `available_engines[0]` is what the server treats as the default.

## Context

While confirming this I also ran the merged Grok adapter against a real `grok` 1.0.4 install. The one-shot and ACP-session paths both work — `seedHome` writes `AGENTS.md` (correct: `grok inspect` shows it reads `AGENTS.md` and `CLAUDE.md`, not `GROK.md`), session ids and Anthropic-shaped usage parse cleanly, and `--resume` genuinely carries context across wakes. The engine itself is in good shape; it was just unreachable from the pairing UI.

I did find a separate cost-attribution issue on the ACP path, which I'll send as its own PR rather than mixing it in here.
