### PR TITLE
fix(byoa): record the real model for Grok ACP turns

### DIFF
--- a/server/src/__tests__/agents-computer-engine.test.ts
+++ b/server/src/__tests__/agents-computer-engine.test.ts
@@ -9,7 +9,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, test } from 'node:test'
 import { setTimeout as delay } from 'node:timers/promises'
-import { getAdapter, resolveSpawn } from '../agents/computer/engine.js'
+import { getAdapter, resolveSpawn, type EngineHopReport, type EngineRunResult } from '../agents/computer/engine.js'
 
 const IS_WIN = process.platform === 'win32'
 const tempDirs: string[] = []
@@ -427,4 +427,93 @@ test('a normal run is unaffected by the abort wiring', { skip: IS_WIN }, async (
     signal: new AbortController().signal,
   })
   assert.equal(r.exitCode, 0)
+})
+
+// ── Grok ACP session: the ledger must see the REAL model ─────────────────────
+// `opts.model` is only the pin Cumora asked for, and it is null whenever the
+// operator left the model unpinned — the default. Reporting the engine id
+// ('grok') in its place puts a model that does not exist into llm_calls, and
+// prices the turn on a fallback rate. Grok announces the live model over ACP.
+
+/** A fake `grok agent … stdio`: ACP handshake, a models/update notification,
+ *  then one prompt result carrying usage. */
+async function fakeGrokAcp(root: string, opts: { announceModel?: string } = {}): Promise<string> {
+  const binDir = join(root, 'bin')
+  await mkdir(binDir, { recursive: true })
+  const announce = opts.announceModel
+    ? `if (msg.method === 'initialize') send({ jsonrpc: '2.0', method: '_x.ai/models/update', params: { currentModelId: ${JSON.stringify(opts.announceModel)} } })\n`
+    : ''
+  await writeFile(
+    join(binDir, 'grok'),
+    '#!/usr/bin/env node\n' +
+    "let buf = ''\n" +
+    "const send = (o) => process.stdout.write(JSON.stringify(o) + '\\n')\n" +
+    "process.stdin.on('data', (d) => {\n" +
+    "  buf += d.toString('utf8')\n" +
+    '  let nl\n' +
+    "  while ((nl = buf.indexOf('\\n')) >= 0) {\n" +
+    '    const line = buf.slice(0, nl); buf = buf.slice(nl + 1)\n' +
+    '    if (!line.trim()) continue\n' +
+    '    let msg; try { msg = JSON.parse(line) } catch { continue }\n' +
+    announce +
+    "    if (msg.method === 'initialize') send({ jsonrpc: '2.0', id: msg.id, result: { protocolVersion: 1 } })\n" +
+    "    else if (msg.method === 'session/new') send({ jsonrpc: '2.0', id: msg.id, result: { sessionId: 'sess-acp-1' } })\n" +
+    "    else if (msg.method === 'session/prompt') send({ jsonrpc: '2.0', id: msg.id, result: { stopReason: 'end_turn', usage: { input_tokens: 11, output_tokens: 4 } } })\n" +
+    '  }\n' +
+    '})\n' +
+    'setInterval(() => {}, 1 << 30)\n',
+    'utf8',
+  )
+  await chmod(join(binDir, 'grok'), 0o755)
+  return binDir
+}
+
+async function grokAcpTurn(binDir: string, home: string) {
+  const hops: EngineHopReport[] = []
+  const session = getAdapter('grok').startSession!({
+    home,
+    env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ''}` },
+    onLog: () => {},
+    onHopUsage: (h) => hops.push(h),
+  })
+  assert.ok(session, 'grok must start an ACP session on this platform')
+  liveSessions.push(session!)
+  const result = await Promise.race([
+    session!.send('go'),
+    delay(15_000).then(() => 'TIMEOUT' as const),
+  ])
+  assert.notEqual(result, 'TIMEOUT', 'the ACP turn never settled')
+  return { result: result as EngineRunResult, hops }
+}
+
+test('a Grok ACP turn reports the model the engine announced', { skip: IS_WIN }, async () => {
+  const root = await mkdtemp(join(tmpdir(), 'cumora-grok-acp-'))
+  tempDirs.push(root)
+  const home = join(root, 'home')
+  await mkdir(home)
+  // No model pinned — the default, and exactly when the old code fell back to
+  // the engine id.
+  const binDir = await fakeGrokAcp(root, { announceModel: 'grok-4.6' })
+  const { result, hops } = await grokAcpTurn(binDir, home)
+
+  assert.equal(result.exitCode, 0)
+  assert.equal(result.model, 'grok-4.6', 'the turn must be priced on the real model, not left null')
+  assert.equal(hops.length, 1)
+  assert.equal(hops[0].model, 'grok-4.6', 'the ledger hop must name a real model, not the engine id')
+  assert.equal(hops[0].usage.output_tokens, 4)
+})
+
+test('a Grok ACP turn still settles when no model is announced', { skip: IS_WIN }, async () => {
+  // Older CLI, or a build that drops the notification: fall back rather than
+  // hang or crash.
+  const root = await mkdtemp(join(tmpdir(), 'cumora-grok-acp2-'))
+  tempDirs.push(root)
+  const home = join(root, 'home')
+  await mkdir(home)
+  const binDir = await fakeGrokAcp(root)
+  const { result, hops } = await grokAcpTurn(binDir, home)
+
+  assert.equal(result.exitCode, 0)
+  assert.equal(result.model, null, 'with nothing announced and nothing pinned there is no model to report')
+  assert.equal(hops[0].model, 'grok', 'the hop keeps its last-resort label')
 })

--- a/server/src/agents/computer/engine.ts
+++ b/server/src/agents/computer/engine.ts
@@ -1517,6 +1517,12 @@ class GrokSession implements EngineSession {
   private queuedPrompt: string | null = null
   private steerWarned = false
   private readonly model: string | null
+  /** The model the agent is ACTUALLY running on, as reported by the ACP stream
+   *  (`_x.ai/models/update` → `currentModelId`). `this.model` is only the pin
+   *  Cumora asked for, and is null whenever the operator left the model
+   *  unpinned — which is the default. Mirrors ClaudeSession sniffing
+   *  `message.model` off its own stream. */
+  private curModel: string | null = null
   readonly carriesStandingPrompt: boolean
 
   constructor(bin: string, spawnArgs: string[], home: string, env: NodeJS.ProcessEnv, opts: EngineSessionArgs) {
@@ -1642,6 +1648,14 @@ class GrokSession implements EngineSession {
       }
       return
     }
+    // Grok announces the live model here, and again whenever it changes mid
+    // session. Without it the ledger prices every ACP turn on a pin that is
+    // usually absent (see curModel).
+    if (msg.method === '_x.ai/models/update') {
+      const id = (msg.params as { currentModelId?: unknown } | undefined)?.currentModelId
+      if (typeof id === 'string' && id) this.curModel = id
+      return
+    }
     if (msg.method === 'session/update') {
       const update = (msg.params?.update ?? msg.params?.sessionUpdate) as Record<string, unknown> | undefined
       const kind = typeof update?.sessionUpdate === 'string' ? update.sessionUpdate
@@ -1665,7 +1679,7 @@ class GrokSession implements EngineSession {
       if (this.onHopUsage) {
         try {
           this.onHopUsage({
-            model: this.model || 'grok',
+            model: this.curModel || this.model || 'grok',
             usage: usage ?? {},
             latencyMs: Date.now() - this.pending.startedAt,
             hopIndex: 1,
@@ -1674,7 +1688,7 @@ class GrokSession implements EngineSession {
       }
       const p = this.pending
       this.pending = null
-      p.resolve({ exitCode: 0, sessionId: this.sid, usage, model: this.model })
+      p.resolve({ exitCode: 0, sessionId: this.sid, usage, model: this.curModel || this.model })
       return
     }
     if (msg.error && msg.id !== undefined) {

--- a/src/desktop/ObservabilityView.tsx
+++ b/src/desktop/ObservabilityView.tsx
@@ -631,7 +631,10 @@ function StatCard({ label, value, sub, tone }: {
  *  (haiku/mini = cerebellum/small; everything else = main/big). */
 function PriceMenuTable({ rows }: { rows: { model: string; inPer1M: number; cachedInPer1M: number; outPer1M: number; estimated: boolean }[] }) {
   if (rows.length === 0) return null
-  const isSmall = (m: string) => /haiku|mini/i.test(m)
+  // Each engine's cerebellum: claude→haiku, codex→gpt-5.4-mini, grok→grok-4.5
+  // (see the daemon's triageModel). Without grok-4.5 here every Grok triage hop
+  // renders as "big brain" and the brain-tier split reads wrong.
+  const isSmall = (m: string) => /haiku|mini|grok-4\.5/i.test(m)
   return (
     <div className="rounded-[10px] border border-ink-100 bg-paper px-3.5 py-3">
       <div className="text-[9.5px] font-bold uppercase tracking-[0.12em] text-ink-300">Token unit prices · small brain vs big brain (per 1M tokens — all ESTIMATES unless you set CUMORA_MODEL_PRICES_JSON)</div>


### PR DESCRIPTION
Follow-up to #23 / #4. Separate from #42, which fixes the pairing UI.

## The bug

`GrokSession` reported `opts.model` for both the ledger hop and the turn result, with the engine id as a fallback:

```ts
this.onHopUsage({ model: this.model || 'grok', ... })
p.resolve({ ..., model: this.model })
```

But `opts.model` is only the **pin Cumora asked for**, and it's `null` whenever the operator left the model unpinned — which is the default, and also exactly what `CUMORA_ENGINE_MODEL=local` produces for a custom provider (#32).

So on the ACP path — the default on macOS and Linux — every turn wrote `model: 'grok'` into `llm_calls` (a model id that doesn't exist) or nothing at all, while the one-shot `grok -p` path **on the same machine** correctly reported `grok-4.6` off its stream. Two paths, two answers, and `cost.priceFor` resolves neither, so the spend lands on `FALLBACK_PRICE`.

## The fix

Grok announces the live model over ACP, and re-announces it when it changes:

```json
{"jsonrpc":"2.0","method":"_x.ai/models/update",
 "params":{"currentModelId":"grok-4.6","availableModels":[…]}}
```

Sniff it — exactly as `ClaudeSession` sniffs `message.model` off its own stream — and prefer it over the pin.

**Verified against a real `grok` 1.0.4 install**, driving the actual adapter:

```
before   turn model: null        hop model: grok
after    turn model: grok-4.6    hop model: grok-4.6
```

which also makes the ACP path agree with the one-shot path on the same machine.

## Also: the brain-tier split didn't know Grok's cerebellum

`isSmall` in the observability view matched only `/haiku|mini/`, so `grok-4.5` — the small model the daemon's own `triageModel()` picks for Grok — rendered as **"big brain"**. One line.

## Tests

Two cases in `server/src/__tests__/agents-computer-engine.test.ts`, driven by a fake `grok agent … stdio` that speaks the ACP handshake — no real CLI needed in CI:

```
# against the merged code
not ok 12 - a Grok ACP turn reports the model the engine announced
    the turn must be priced on the real model, not left null
ok   13 - a Grok ACP turn still settles when no model is announced
# pass 11 | fail 1
```

Case 13 passes on both, deliberately: it pins the fallback for an older CLI that doesn't send the notification, so the fix can't turn a missing announcement into a hang or a crash. That it passes before *and* after is what shows case 12 isn't just failing indiscriminately.

## Deliberately not included

`cost.ts` has no `grok-*` price seed, so Grok spend still prices on `FALLBACK_PRICE` (the mid-tier $3/$15 estimate). I have two sampled `total_cost_usd` values from the CLI and three unknowns — input, cached-input and output rates — so the system is underdetermined and any seed I derived would be a guess dressed up as a rate. That one needs xAI's published prices; happy to add it if you have them.

## Checks

`npm run lint`, `npm run typecheck`, `npm run server:typecheck` pass. The new tests need no Postgres/Redis/`OPENAI_API_KEY` and no `grok` binary; they're skipped on Windows, where `startSession` returns null by design.
