### PR TITLE
perf(agenda): keep heartbeat classifier prefix cacheable

### DIFF
--- a/server/src/__tests__/agents-agenda.test.ts
+++ b/server/src/__tests__/agents-agenda.test.ts
@@ -184,6 +184,73 @@ test('renderAgendaForClassifier includes assigned/mentioned tags + ids', () => {
   assert.match(out, /Bring the migration status update/)
 })
 
+test('renderAgendaForClassifier keeps a stable prefix while preserving silence minutes', () => {
+  const stall = {
+    conversationId: 'direct-1',
+    kind: 'direct',
+    title: 'Lumi ↔ boss',
+    lastMessageId: 'm-1',
+    lastAuthorId: 'storyicon',
+    lastAuthorName: 'storyicon',
+    lastAuthorIsSelf: false,
+    lastBody: 'need a build',
+    minutesSilent: 47,
+    recentTail: 'storyicon: need a build\nLumi@Secretary: looking',
+  }
+  const base: AgentAgenda = {
+    cards: [{
+      id: 'c-1', board_id: 'b1', board_title: 'Ops', column_id: 'col1',
+      column_title: 'Doing', title: 'Ship', description: null,
+      assignee_id: 'agent-1', mentions: [], updated_at: '2026-05-20T10:00:00Z',
+    }],
+    events: [{
+      id: 'evt-1', title: 'Standup', description: null,
+      start_at: '2026-05-20T15:00:00Z', agent_prompt: null,
+      target_conversation_id: null,
+    }],
+    stalls: [stall],
+  }
+  const a = renderAgendaForClassifier(base)
+  const b = renderAgendaForClassifier({
+    ...base,
+    stalls: [{ ...stall, minutesSilent: 48 }],
+  })
+  const timingMarker = '\n\nCurrent stall timing:\n'
+  assert.equal(a.slice(0, a.indexOf(timingMarker)), b.slice(0, b.indexOf(timingMarker)))
+  assert.match(a, /direct-1: 47m silent/)
+  assert.match(b, /direct-1: 48m silent/)
+  assert.match(a, /need a build/)
+  assert.ok(a.indexOf('need a build') < a.indexOf('Standup'), 'stall messages precede calendar')
+  assert.ok(a.indexOf('Standup') < a.indexOf('47m silent'), 'dynamic timing follows stable agenda data')
+})
+
+test('renderAgendaForClassifier sorts cards and stalls by id, not recency', () => {
+  const stall = (id: string) => ({
+    conversationId: id,
+    kind: 'direct',
+    title: id,
+    lastMessageId: 'm',
+    lastAuthorId: 'x',
+    lastAuthorName: 'x',
+    lastAuthorIsSelf: false,
+    lastBody: 'hi',
+    minutesSilent: 10,
+    recentTail: 'x: hi',
+  })
+  const card = (id: string) => ({
+    id, board_id: 'b1', board_title: 'Ops', column_id: 'col1',
+    column_title: 'Doing', title: id, description: null,
+    assignee_id: 'agent-1', mentions: [], updated_at: '2026-05-20T10:00:00Z',
+  })
+  const out = renderAgendaForClassifier({
+    cards: [card('c-z'), card('c-a')],
+    events: [],
+    stalls: [stall('direct-z'), stall('direct-a')],
+  })
+  assert.ok(out.indexOf('c-a') < out.indexOf('c-z'), 'cards sorted by id')
+  assert.ok(out.indexOf('direct-a') < out.indexOf('direct-z'), 'stalls sorted by conversationId')
+})
+
 test('renderAgendaBrief opens with the action override + includes ids', () => {
   const agenda: AgentAgenda = {
     cards: [
@@ -370,4 +437,25 @@ test('classifyAgendaActionable: empty output_text → classifier_error (model ga
   })
   assert.equal(v.actionable, false)
   assert.equal(v.reason, AGENDA_CLASSIFIER_ERROR)
+})
+
+test('classifyAgendaActionable: identical content is re-evaluated on every heartbeat', async () => {
+  let calls = 0
+  __setLlmClientOverrideForTesting((async () => ({
+    responses: {
+      create: async () => {
+        calls += 1
+        return { output_text: JSON.stringify({ actionable: true, focus: `ship-${calls}`, reason: 'card' }) }
+      },
+    },
+  })) as unknown as Parameters<typeof __setLlmClientOverrideForTesting>[0])
+  const args = {
+    persona: STUB_PERSONA, companyId: 'c1', agenda: SINGLE_CARD_AGENDA, agentId: 'agent-1',
+  }
+  const v1 = await classifyAgendaActionable(args)
+  const v2 = await classifyAgendaActionable(args)
+  assert.equal(v1.actionable, true)
+  assert.equal(v1.focus, 'ship-1')
+  assert.equal(v2.focus, 'ship-2')
+  assert.equal(calls, 2, 'time-sensitive agenda decisions must not reuse an old verdict')
 })

--- a/server/src/agents/agenda.ts
+++ b/server/src/agents/agenda.ts
@@ -330,14 +330,42 @@ export async function gatherAgentAgenda(
 /** Render the agenda as a compact text block for the classifier. We
  *  intentionally do not include the full description body — the
  *  classifier only needs to decide go/no-go, and the brain will see
- *  the full card via the `kanban` CLI on actual wake. */
+ *  the full card via the `kanban` CLI on actual wake.
+ *
+ *  Prefix-cache order (providers cache the longest unchanged prefix):
+ *    1. cards (change only when a card row changes)
+ *    2. stall identity + recent messages (change only on new chat)
+ *    3. calendar slot (slides as wall-clock crosses 30m/15m windows)
+ *  Wall-clock "Nm silent" is kept in a final timing section. That preserves
+ *  the original recency signal while preventing a ticking value from
+ *  invalidating the stable agenda prefix on every heartbeat. */
+function byId<T extends { id: string }>(a: T, b: T): number {
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0
+}
+
 function renderAgendaForClassifier(agenda: AgentAgenda): string {
   const lines: string[] = []
-  if (agenda.cards.length > 0) {
-    lines.push(`Kanban cards (${agenda.cards.length}):`)
-    for (const c of agenda.cards) {
+  // Sort by id so inserting/updating one row does not reshuffle the rest and
+  // bust the prefix cache of every later line. Selection (most-recent LIMIT)
+  // still happens in SQL; this is display order only.
+  const cards = [...agenda.cards].sort(byId)
+  const stalls = [...agenda.stalls].sort((a, b) => (
+    a.conversationId < b.conversationId ? -1 : a.conversationId > b.conversationId ? 1 : 0
+  ))
+  if (cards.length > 0) {
+    lines.push(`Kanban cards (${cards.length}):`)
+    for (const c of cards) {
       const tag = c.assignee_id ? 'assigned' : 'mentioned'
       lines.push(`- [${tag}] "${c.title}" in ${c.board_title} / ${c.column_title} (id=${c.id}, updated ${c.updated_at})`)
+    }
+  }
+  if (stalls.length > 0) {
+    if (lines.length > 0) lines.push('')
+    lines.push(`Conversations you're in that have gone quiet (${stalls.length}) — judge each: genuinely WAITING on someone, or already CONCLUDED/wound down?`)
+    for (const s of stalls) {
+      const who = s.lastAuthorIsSelf ? 'YOU spoke last, no reply since' : `${s.lastAuthorName} spoke last, you haven't responded`
+      lines.push(`- [${s.kind}] ${s.title ?? s.conversationId} (${s.conversationId}) — ${who}. Last few messages:`)
+      for (const ln of (s.recentTail || s.lastBody).split('\n')) lines.push(`    ${ln}`)
     }
   }
   if (agenda.events.length > 0) {
@@ -348,14 +376,10 @@ function renderAgendaForClassifier(agenda: AgentAgenda): string {
       lines.push(`- "${e.title}" at ${e.start_at}${prompt}`)
     }
   }
-  if (agenda.stalls.length > 0) {
+  if (stalls.length > 0) {
     if (lines.length > 0) lines.push('')
-    lines.push(`Conversations you're in that have gone quiet (${agenda.stalls.length}) — judge each: genuinely WAITING on someone, or already CONCLUDED/wound down?`)
-    for (const s of agenda.stalls) {
-      const who = s.lastAuthorIsSelf ? 'YOU spoke last, no reply since' : `${s.lastAuthorName} spoke last, you haven't responded`
-      lines.push(`- [${s.kind}] ${s.title ?? s.conversationId} — ${who}, ${s.minutesSilent}m silent. Last few messages:`)
-      for (const ln of (s.recentTail || s.lastBody).split('\n')) lines.push(`    ${ln}`)
-    }
+    lines.push('Current stall timing:')
+    for (const s of stalls) lines.push(`- ${s.conversationId}: ${s.minutesSilent}m silent`)
   }
   if (lines.length === 0) return '(empty)'
   return lines.join('\n')
@@ -406,6 +430,8 @@ Decide "actionable: true" only when at least one item is concrete, fresh, AND cl
 - cards already in a done/archive-style column
 - events that are personal markers (no agent_prompt)
 - duplicates of work the agent has obviously already started
+
+ORDERING: list order is for prompt-cache stability, not priority. Judge urgency from each card's updated timestamp, each event's start time, and each stalled conversation's current silence duration and message content.
 
 STALLED CONVERSATIONS: for each, READ the recent messages shown and judge whether it is genuinely WAITING or already CONCLUDED. actionable=true ONLY when the recent messages show a CONCRETE unanswered ask directed at someone, or an explicitly in-progress step plainly waiting on a next move. It is NOT actionable (false) when the thread has CONCLUDED or socially CLOSED — participants exchanging wrap-up / closing / acknowledgement remarks, a conclusion or result already reached, nothing pending and no one waiting on a specific next step — no matter how "quiet" it now is. A merely quiet conversation is NOT a stall; "someone spoke last and I didn't reply" is NOT by itself a reason (most messages need no reply). Resurrecting a finished conversation with a late reply is a failure — when in doubt that it's truly still waiting, choose false.
 


### PR DESCRIPTION
## Problem

The idle-heartbeat cerebellum classifier re-runs about once a minute per agent. Providers cache the longest unchanged **prefix** of the prompt. The stall block inlined a wall-clock `Nm silent` value in the middle of that prompt, so every tick invalidated the stall section (and everything after it) even when no card, message, or calendar row had changed.

On a live workspace this showed up as a low cache-read share on agenda calls: about **32%** of input tokens were served from prefix cache over a 15-minute window (mean prompt ~1.7k tokens). Agents sitting on a few stalled threads were in the same range (~33%).

## Change

Keep the same facts in the classifier input; only the layout changes so the ticking value is a suffix:

1. **Prefix-stable order:** Kanban cards, then stall identity + recent messages, then calendar (the slot can still slide; it is rarer than the clock).
2. **Trailing timing block:** `Current stall timing:` lists `conversationId → Nm silent` after the stable agenda. Recency is still visible; it no longer sits inside the stall narrative.
3. **Id order for cards and stalls:** SQL still selects the most-recent `LIMIT`; render sorts by id so inserting or updating one row does not reshuffle every later line.
4. **Ordering instruction:** tell the model that list order is for cache stability, not priority. Urgency still comes from card `updated` timestamps, event start times, silence duration, and message content.

The classifier still runs on every heartbeat. A previous verdict is never reused.

## What this does not change

- Stall window (5 minutes – 6 hours)
- Nudge claim / cooldown
- `renderAgendaBrief` for the big-brain wake (still includes `Nm ago`)
- Inbox triage, coding turns, or any other purpose

## Observed cache hit

After deploying the same prompt layout on that workspace, agenda cache-read share over a comparable 15-minute window rose from **~32% to ~76%** of input tokens (mean prompt ~1.6k). Heartbeats with three stalled conversations went **~33% → ~84%**. Remaining misses are the expected last cache block plus real agenda changes (new messages, stall membership, calendar slot).

## Tests

- Prefix is byte-identical when only `minutesSilent` changes; the timing footer still carries 47m vs 48m
- Cards/stalls render in id order, not recency
- Identical agendas still call the model twice (no verdict reuse)