### PR TITLE
feat(byoa): name the project in the wake digest

### DIFF
--- a/server/src/__tests__/agents-computer-inbox-digest.test.ts
+++ b/server/src/__tests__/agents-computer-inbox-digest.test.ts
@@ -13,7 +13,7 @@
  */
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { renderInboxDigest } from '../agents/computer/daemon.js'
+import { conversationHeader, renderInboxDigest } from '../agents/computer/daemon.js'
 
 type Convo = { head: string; msgs: string[] }
 
@@ -88,4 +88,49 @@ test('a conversation budgeted to zero shows none of its messages, not all of the
 
 test('an empty inbox renders as an empty digest', () => {
   assert.equal(renderInboxDigest(new Map(), 40), '')
+})
+
+// ── conversation header ──────────────────────────────────────────────────────
+// A BYOA agent that sits in several project groups has to be able to tell them
+// apart from the digest alone. The cloud turn has always rendered a project
+// line; without it here, everything the agent knows reads as one context and
+// work from one project gets quoted as background in another.
+
+test('the header names the project the group belongs to', () => {
+  const head = conversationHeader({
+    conversation_id: 'c-1',
+    conversation_kind: 'group',
+    conversation_title: 'Paper review',
+    project_name: 'Paper review',
+    conversation_topic: 'ICML submission',
+  })
+  assert.match(head, /^# c-1 \[group\] "Paper review"/)
+  assert.match(head, /\n {2}Project: Paper review/)
+  assert.match(head, /\n {2}Topic: ICML submission/)
+  // Project reads before topic: which project, then what this group is for.
+  assert.ok(head.indexOf('Project:') < head.indexOf('Topic:'))
+})
+
+test('a project-less conversation is unchanged', () => {
+  // Direct chats and ungrouped conversations are genuinely project-less; they
+  // must render exactly as they did before.
+  const head = conversationHeader({
+    conversation_id: 'c-2',
+    conversation_kind: 'dm',
+    conversation_title: 'yetone',
+    conversation_topic: null,
+  })
+  assert.equal(head, '# c-2 [dm] "yetone"')
+})
+
+test('a project with no topic still renders its project line', () => {
+  const head = conversationHeader({ conversation_id: 'c-3', project_name: 'OpenRouter plan' })
+  assert.equal(head, '# c-3\n  Project: OpenRouter plan')
+})
+
+test('an explicitly null project is treated as absent', () => {
+  // loadInbox LEFT JOINs projects, so an unassigned conversation arrives as null
+  // rather than undefined.
+  const head = conversationHeader({ conversation_id: 'c-4', project_name: null, conversation_topic: 'ship it' })
+  assert.equal(head, '# c-4\n  Topic: ship it')
 })

--- a/server/src/agents/computer/daemon.ts
+++ b/server/src/agents/computer/daemon.ts
@@ -313,6 +313,7 @@ interface RuntimeInboxResponse {
     conversation_kind?: string
     conversation_title?: string
     conversation_topic?: string | null
+    project_name?: string | null
     author_name?: string
     author_kind?: string
     body?: string
@@ -344,6 +345,31 @@ const DIGEST_MAX_MESSAGE_LINES = 40
  *  shown, exactly as before.
  *
  *  Exported for tests — pure, no server and no engine. */
+/** The per-conversation header the wake digest opens each group with: the id,
+ *  its kind/title, the project it belongs to, and the topic it exists for.
+ *
+ *  Project matters as much as topic here. An agent that sits in several project
+ *  groups otherwise cannot tell them apart from the digest alone, so everything
+ *  it has learned reads as one undifferentiated context — which is how work from
+ *  one project ends up quoted as background in another. The cloud turn has
+ *  always rendered a project line; this is the BYOA counterpart.
+ *
+ *  Exported for tests — pure, no server and no engine. */
+export function conversationHeader(row: {
+  conversation_id?: string
+  conversation_kind?: string
+  conversation_title?: string
+  project_name?: string | null
+  conversation_topic?: string | null
+}): string {
+  const kind = row.conversation_kind ? ` [${row.conversation_kind}]` : ''
+  const title = row.conversation_title ? ` "${row.conversation_title}"` : ''
+  let head = `# ${row.conversation_id}${kind}${title}`
+  if (row.project_name) head += `\n  Project: ${row.project_name}`
+  if (row.conversation_topic) head += `\n  Topic: ${row.conversation_topic}`
+  return head
+}
+
 export function renderInboxDigest(
   byConvo: Map<string, { head: string; msgs: string[] }>,
   budget = DIGEST_MAX_MESSAGE_LINES,
@@ -1487,11 +1513,7 @@ class AgentRunner {
       if (row.kind !== 'system' || (alarm && (!alarm.assigneeId || alarm.assigneeId === this.agent.id))) hasReal = true
       let convo = byConvo.get(row.conversation_id)
       if (!convo) {
-        const kind = row.conversation_kind ? ` [${row.conversation_kind}]` : ''
-        const title = row.conversation_title ? ` "${row.conversation_title}"` : ''
-        let head = `# ${row.conversation_id}${kind}${title}`
-        if (row.conversation_topic) head += `\n  Topic: ${row.conversation_topic}`
-        convo = { head, msgs: [] }
+        convo = { head: conversationHeader(row), msgs: [] }
         byConvo.set(row.conversation_id, convo)
       }
       const author = row.author_name ?? 'someone'

--- a/server/src/agents/runtime/client.ts
+++ b/server/src/agents/runtime/client.ts
@@ -59,6 +59,13 @@ export interface InboxRow {
   /** The group's topic ("what this group is for"), so every agent — the cloud
    *  turn context AND the BYOA inbox digest — stays on-task. Null if unset. */
   conversation_topic: string | null
+  /** The project this group belongs to. Optional because not every row source
+   *  selects it, and null because direct chats and ungrouped conversations are
+   *  genuinely project-less. `loadInbox` populates it; the cloud turn has always
+   *  rendered a project, and carrying it here is what lets the BYOA wake digest
+   *  do the same. */
+  project_id?: string | null
+  project_name?: string | null
   author_id: string
   /** Joined from participants.kind. Lets prompt-building code (turn.ts)
    *  identify human vs agent messages without a hardcoded id allow-list. */

--- a/server/src/agents/runtime/inproc-client.ts
+++ b/server/src/agents/runtime/inproc-client.ts
@@ -124,6 +124,12 @@ export class InProcRuntimeClient implements AgentRuntimeClient {
       `WITH convos AS (
          SELECT c.id, c.company_id,
                 c.title AS conversation_title, c.kind AS conversation_kind, c.topic AS conversation_topic,
+                -- Which project this group belongs to. The cloud turn already
+                -- shows it (turn.ts renders "Project: <name>"); BYOA agents saw
+                -- nothing, so an agent in several project groups had no way to
+                -- tell them apart. PK join on a tiny table inside the CTE that
+                -- already walks the agent's conversations.
+                c.project_id, pr.name AS project_name,
                 COALESCE(cr.last_read_at, '1970-01-01T00:00:00Z'::timestamptz) AS lr_at,
                 COALESCE(cr.last_read_message_id, '') AS lr_id,
                 EXISTS (
@@ -133,11 +139,13 @@ export class InProcRuntimeClient implements AgentRuntimeClient {
                 ) AS muted
            FROM conversations c
            LEFT JOIN conversation_reads cr ON cr.user_id = $1 AND cr.conversation_id = c.id
+           LEFT JOIN projects pr ON pr.id = c.project_id
           WHERE c.members @> to_jsonb(ARRAY[$1::text])
        )
        SELECT
           m.id, m.conversation_id, co.company_id,
           co.conversation_title, co.conversation_kind, co.conversation_topic,
+          co.project_id, co.project_name,
           m.author_id, p.kind AS author_kind, COALESCE(p.name, m.author_id) AS author_name,
           m.body, m.kind, m.sequence, m.created_at, m.attachment, m.quoted_message_id,
           (


### PR DESCRIPTION
Toward #45 — the prerequisite, not the whole thing. Please read the corrections below before taking the issue's proposed mechanism at face value; I think it would build the wrong thing.

## What this changes

`loadInbox` selected a conversation's title, kind and topic but **not its project**, so the BYOA wake digest's per-conversation header never named one — while the cloud turn has rendered `Project: <name>` all along (`turn.ts`). The migration that added `conversations.project_id` even says it is *"Surfaced to agents in the wake prompt"*; for BYOA it simply wasn't.

So an agent sitting in several project groups could not tell them apart from its wake prompt. With nothing distinguishing the groups, everything it has learned reads as one undifferentiated context — which is the mechanism behind the symptom in #45.

- carry `project_id` / `project_name` on the inbox row
- render a `Project:` line above the existing `Topic:` line
- extract `conversationHeader()` so it is testable without booting a runner, the same reason `renderInboxDigest` and `resolveEngineModel` are exported in that file

The join is a PK lookup on a tiny table, placed **inside the CTE that already walks the agent's conversations** — I kept it there deliberately because the comments around that query document a past 8s plan that starved the pool.

The new fields are optional on `InboxRow` rather than required-nullable: not every row source selects them, and direct chats are genuinely project-less. **A conversation without a project renders byte-identically to before** — pinned by two of the tests.

## Corrections to the issue's analysis

I went looking to implement the fix as proposed and found two things that change the design. Flagging them so nobody builds on them:

**1. `source.conversationId` is not available to derive a project from.** The issue says "the plumbing to fix this already exists: `agent_memory.source` stores `conversationId`". That's true only for rows the old migration copied over. Both live write paths hardcode it:

```ts
// server/src/agents/cli.ts — `cumora memory note`
const meta = { type: 'memory', kind, about, pinned: false, source: null, createdAt: … }

// server/src/agents/runtime/fs-endpoints.ts — metaForPath(), the BYOA fs write
return { type: 'memory', kind, about: null, pinned: false, source: null, createdAt: … }
```

So nothing written by a live agent records where it came from. Deriving a project from `source` would silently match zero recent memories. Recording provenance at write time is a **prerequisite**, not an optional step — and neither write path currently knows the conversation, so that needs a decision about how it gets there.

**2. The reported BYOA symptom isn't `loadMemory` at all.** The issue points at `loadMemory` / `agent_memory`, but the symptom it describes — `~/.cumora/agents/<id>/memory/MEMORY.md` indexing five unrelated projects — is the BYOA **local filesystem** memory, which never touches that query. The actual injection point is the daemon:

```ts
private async memoryDigest(): Promise<string> {
  const txt = (await readFile(join(this.home, 'memory', 'MEMORY.md'), 'utf8')).trim()
  …
}
// → chatDelta: "Your memory index (`memory/MEMORY.md`):\n<the whole index>"
```

The entire index, up to 4000 chars, is injected into **every** wake regardless of which conversation woke the agent. That is precisely "nova reads all five and treats the others as background". `loadMemory` is the cloud path; fixing it would not move the reported symptom at all.

## What I deliberately did not do

Scoping memory itself needs a product decision I don't think a contributor should make unilaterally:

- **Where project-scoped memories live.** Filtering a freeform `MEMORY.md` isn't possible; it needs a layout (e.g. `memory/projects/<id>/` alongside a global `memory/`), which changes the persona contract every existing agent is running on.
- **What happens to existing memories**, which are all in the global index today.
- **Whether climate is scoped too**, which the issue itself lists as an open question.

Happy to implement whichever shape you prefer — this PR is the piece that's unambiguous and that every version of the fix needs first.

## Checks

`npm run lint`, `npm run typecheck`, `npm run server:typecheck` pass. 4 new cases in `agents-computer-inbox-digest.test.ts`; verified red-before/green-after, with the two "project-less renders unchanged" cases passing on both sides so the suite isn't failing indiscriminately.

My sandbox has no Postgres/Redis, so 20 server test files fail on env alone. I diffed the failure set against baseline with and without this change — identical.

Note the SQL change itself is only exercised by the integration suite, which I can't run here; that half rests on review.
