### PR TITLE
fix(byoa): report source-mode daemon version

### DIFF
--- a/server/src/__tests__/agents-computer-daemon-version.test.ts
+++ b/server/src/__tests__/agents-computer-daemon-version.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { resolveCurrentVersion } from '../agents/computer/daemon.js'
+
+test('bundled version wins in packaged CLI builds', () => {
+  assert.equal(resolveCurrentVersion('1.2.3', '9.9.9'), '1.2.3')
+})
+
+test('source-mode daemon accepts the version supplied by its launcher', () => {
+  assert.equal(resolveCurrentVersion(undefined, ' 1.2.3 '), '1.2.3')
+})
+
+test('missing or blank version retains the development fallback', () => {
+  assert.equal(resolveCurrentVersion(undefined, undefined), '0.0.0')
+  assert.equal(resolveCurrentVersion(undefined, '   '), '0.0.0')
+})

--- a/server/src/agents/computer/daemon.ts
+++ b/server/src/agents/computer/daemon.ts
@@ -263,10 +263,16 @@ class AdaptivePacer {
 const spawnPacer = new AdaptivePacer(MIN_SPAWN_INTERVAL_MS)
 
 // ─── self-update ──────────────────────────────────────────────────────────
-// Injected by esbuild at build time (agent-cli/build.mjs). Undefined when run
-// un-bundled (tsx dev); guarded with typeof so that path is a safe no-op.
+// Injected by esbuild at build time (agent-cli/build.mjs). Source-mode
+// launchers may provide CUMORA_VERSION; otherwise development falls back to
+// 0.0.0. The typeof guard keeps an undefined build constant safe at runtime.
 declare const __CUMORA_VERSION__: string | undefined
-const CURRENT_VERSION = typeof __CUMORA_VERSION__ === 'string' ? __CUMORA_VERSION__ : '0.0.0'
+export function resolveCurrentVersion(bundledVersion: string | undefined, envVersion = process.env.CUMORA_VERSION): string {
+  return bundledVersion ?? (envVersion?.trim() || '0.0.0')
+}
+const CURRENT_VERSION = resolveCurrentVersion(
+  typeof __CUMORA_VERSION__ === 'string' ? __CUMORA_VERSION__ : undefined,
+)
 const UPDATE_CHECK_MS = 6 * 60 * 60 * 1000 // re-check npm every 6h
 // Log rotation: the service supervisor (launchd StandardOutPath / systemd) writes
 // the daemon's stdout to ~/.cumora/daemon.log and NEVER rotates it — left alone it


### PR DESCRIPTION
## Summary

- let source-mode daemon launchers provide the package version through `CUMORA_VERSION`
- preserve the esbuild-injected version as the packaged CLI authority
- retain `0.0.0` as the fallback when neither source is available
- cover bundled, source-mode, blank, and missing values with unit tests

## Why

When the daemon runs directly from TypeScript, `__CUMORA_VERSION__` is absent and the process currently reports `0.0.0`. That can produce a false update notice even when the source checkout and CLI package are current. A launcher already knows the package version, so this adds an explicit source-mode handoff without changing packaged builds.

## Verification

- 668 tests passed, 1 skipped
- production build passed
- server typecheck passed
- lint passed
- big-brain and tracked-LLM guards passed
- Chaperone deterministic review passed
