### PR TITLE
fix(agenda): preserve structured classifier verdicts

### DIFF
--- a/server/src/__tests__/agents-agenda.test.ts
+++ b/server/src/__tests__/agents-agenda.test.ts
@@ -9,6 +9,7 @@ import assert from 'node:assert/strict'
 import {
   renderAgendaBrief,
   classifyAgendaActionable,
+  parseAgendaVerdict,
   AGENDA_CLASSIFIER_ERROR,
   __test,
   type AgentAgenda,
@@ -307,6 +308,33 @@ test('renderAgendaBrief works with only calendar events', () => {
 })
 
 // ────────────────────────────────────────────────────────────────────────────
+// Agenda verdict parsing — fail closed while recovering provider formatting
+// drift that still carries an explicit decision.
+// ────────────────────────────────────────────────────────────────────────────
+
+test('parseAgendaVerdict accepts fenced strict JSON', () => {
+  const parsed = parseAgendaVerdict('```json\n{"actionable":false,"focus":"","reason":"done"}\n```')
+  assert.deepEqual(parsed, { actionable: false, focus: '', reason: 'done' })
+})
+
+test('parseAgendaVerdict salvages unquoted keys and single-quoted strings', () => {
+  const parsed = parseAgendaVerdict("{ actionable: false, focus: '', reason: 'already concluded' }")
+  assert.deepEqual(parsed, { actionable: false, focus: '', reason: 'already concluded' })
+})
+
+test('parseAgendaVerdict salvages a truncated explicit negative', () => {
+  const parsed = parseAgendaVerdict('{"actionable":false,"focus":"","reason":"already done"')
+  assert.deepEqual(parsed, { actionable: false, focus: '', reason: 'already done' })
+})
+
+test('parseAgendaVerdict never salvages an unfocused malformed positive as actionable', () => {
+  const parsed = parseAgendaVerdict('{ actionable: true, reason: "maybe" }')
+  assert.deepEqual(parsed, {
+    actionable: false, focus: '', reason: 'malformed positive verdict without focus',
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────────────
 // classifyAgendaActionable JSON-robustness — the production classifier is a
 // boundary between us and a non-deterministic LLM. Every branch in the
 // parse path needs explicit coverage so a single malformed reply can't
@@ -328,6 +356,22 @@ test('classifyAgendaActionable: empty agenda short-circuits before the LLM call'
   assert.equal(v.actionable, false)
   assert.equal(v.reason, 'empty agenda')
   assert.equal(called, false, 'must not call the LLM when there is nothing to triage')
+})
+
+test('classifyAgendaActionable leaves output headroom beyond reasoning tokens', async () => {
+  let maxOutputTokens = 0
+  __setLlmClientOverrideForTesting((async () => ({
+    responses: {
+      create: async (request: { max_output_tokens?: number }) => {
+        maxOutputTokens = request.max_output_tokens ?? 0
+        return { output_text: JSON.stringify({ actionable: false, focus: '', reason: 'done' }) }
+      },
+    },
+  })) as unknown as Parameters<typeof __setLlmClientOverrideForTesting>[0])
+  await classifyAgendaActionable({
+    persona: STUB_PERSONA, companyId: 'c1', agenda: SINGLE_CARD_AGENDA,
+  })
+  assert.ok(maxOutputTokens >= 2_000, 'live support-model reasoning exceeded 800 tokens before emitting JSON')
 })
 
 test('classifyAgendaActionable: happy path with strict boolean true', async () => {

--- a/server/src/agents/agenda.ts
+++ b/server/src/agents/agenda.ts
@@ -403,6 +403,45 @@ export interface AgendaVerdict {
  *  string-matching. */
 export const AGENDA_CLASSIFIER_ERROR = 'classifier error'
 
+/** Parse the support model's verdict conservatively. JSON mode is not enough
+ * for every OpenAI-compatible provider: DeepSeek sometimes wraps JSON, omits
+ * key quotes, or truncates after all required fields. Recover only an explicit
+ * actionable value. A malformed positive also needs a non-empty focus, so
+ * salvage can never turn ambiguous output into a wake. */
+export function parseAgendaVerdict(raw: string): {
+  actionable?: unknown
+  focus?: unknown
+  reason?: unknown
+} | null {
+  const unfenced = raw.trim()
+    .replace(/^```(?:json)?\s*/i, '')
+    .replace(/\s*```$/i, '')
+  const firstBrace = unfenced.indexOf('{')
+  if (firstBrace < 0) return null
+  const lastBrace = unfenced.lastIndexOf('}')
+  const candidate = unfenced.slice(firstBrace, lastBrace > firstBrace ? lastBrace + 1 : undefined)
+  try {
+    return JSON.parse(candidate) as { actionable?: unknown; focus?: unknown; reason?: unknown }
+  } catch { /* conservative field salvage below */ }
+
+  const actionMatch = candidate.match(
+    /(?:["']?actionable["']?)\s*:\s*(true|false|1|0|["']true["']|["']false["'])/i,
+  )
+  if (!actionMatch) return null
+  const actionToken = actionMatch[1].replace(/["']/g, '').toLowerCase()
+  const actionable = actionToken === 'true' || actionToken === '1'
+  const stringField = (name: string): string => {
+    const match = candidate.match(new RegExp(`(?:["']?${name}["']?)\\s*:\\s*(["'])([\\s\\S]*?)\\1(?:\\s*[,}]|$)`, 'i'))
+    return match?.[2] ?? ''
+  }
+  const focus = stringField('focus')
+  const reason = stringField('reason')
+  if (actionable && !focus.trim()) {
+    return { actionable: false, focus: '', reason: 'malformed positive verdict without focus' }
+  }
+  return { actionable, focus, reason }
+}
+
 /** Cerebellum classifier: given the agenda + persona, decide if a
  *  wake is justified. Strict JSON. Falls back to "actionable=false"
  *  on any error so a classifier outage doesn't burn brain calls on
@@ -459,12 +498,15 @@ Reply as strict JSON.`
       instructions,
       input,
       text: { format: { type: 'json_object' } },
-      max_output_tokens: 300,
-      reasoning: { effort: 'low' },
+      // DeepSeek V4 Flash regularly spends the first ~300 tokens on hidden
+      // reasoning. A 300-token cap then truncates the JSON to one character,
+      // which made every minute-level BYOA agenda check fail closed. Leave
+      // enough room for reasoning plus the small structured verdict.
+      max_output_tokens: 2000,
+      reasoning: { effort: 'minimal' },
     })
-    const parsed = JSON.parse(r.output_text ?? '{}') as {
-      actionable?: unknown; focus?: unknown; reason?: unknown
-    }
+    const parsed = parseAgendaVerdict(r.output_text ?? '')
+    if (!parsed) throw new Error('agenda classifier returned no recoverable verdict')
     // Coerce to a real boolean *strictly*. `Boolean("no")` is `true`
     // because non-empty strings are truthy — so if the model replies
     // {"actionable": "no"} (treating it as natural language) we'd


### PR DESCRIPTION
## Summary

- leave enough output headroom for support-model reasoning plus the JSON verdict
- request minimal reasoning for the minute-level classifier
- parse fenced, lightly malformed, or truncated explicit verdicts conservatively
- require a non-empty focus before salvaging any malformed positive decision
- keep unrecoverable and ambiguous output fail-closed

## Why

Some OpenAI-compatible reasoning models consume most of a small output budget before emitting the requested JSON. The existing 300-token cap can therefore truncate a verdict even in JSON mode, turning every heartbeat into a classifier error. Providers can also return fenced or lightly malformed objects despite structured-output instructions.

This change gives the small verdict sufficient headroom and recovers only explicit decisions. It cannot promote an ambiguous malformed response into an agent wake.

## Verification

- 670 tests passed, 1 skipped
- production build passed
- server typecheck passed
- lint passed
- big-brain and tracked-LLM guards passed
- Chaperone deterministic review passed
