### PR TITLE
fix(byoa): show "typing…" for poll-driven and coalesced turns

### DIFF
--- a/server/src/__tests__/agents-computer-typing-conversation.test.ts
+++ b/server/src/__tests__/agents-computer-typing-conversation.test.ts
@@ -1,0 +1,66 @@
+/**
+ * A BYOA agent that is working must not look dead.
+ *
+ * "<agent> is typing…" is the only feedback a human gets between sending a
+ * message and receiving a reply, and a BYOA turn can run for minutes. The
+ * indicator is gated on the turn having a conversation id — and a wake often
+ * carries none:
+ *
+ *   - a POLL-driven turn never has one (only an SSE wake sets lastWakeConvo), and
+ *     polling is the ONLY path left whenever the wake-stream is down;
+ *   - a wake arriving mid-turn is coalesced through scheduleWake's busy branch,
+ *     which re-kicks the turn without a conversation.
+ *
+ * Both are precisely when someone IS waiting. Observed: an agent mentioned in a
+ * group ran a 3-minute turn — engine spawned, `turn DONE … exit 0`, reply posted
+ * — while the room showed no indicator at all for the entire turn, which reads as
+ * "it never started".
+ *
+ * Run: node --import tsx --test server/src/__tests__/agents-computer-typing-conversation.test.ts
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { typingConversation } from '../agents/computer/daemon.js'
+
+/** `seen` as snapshotUnread builds it: conversation_id → newest unread msg id. */
+const unread = (...ids: string[]): Map<string, string> =>
+  new Map(ids.map((id, i) => [id, `m-${i}`]))
+
+test("the wake's own conversation always wins", () => {
+  // An SSE wake named the room — that is the most precise signal available and
+  // must not be second-guessed by the inbox.
+  assert.equal(typingConversation('g-abc', unread('g-abc')), 'g-abc')
+  assert.equal(typingConversation('g-abc', unread('g-other', 'g-third')), 'g-abc')
+})
+
+test('a poll-driven turn falls back to the single unread conversation', () => {
+  // The regression: no wake conversation → previously null → no typing at all,
+  // for the whole turn. This is the common case when the wake-stream is down.
+  assert.equal(typingConversation(null, unread('g-6e361c41')), 'g-6e361c41')
+})
+
+test('a coalesced wake falls back the same way', () => {
+  // scheduleWake's busy branch re-kicks without a conversation, so the rerun sees
+  // wakeConvo = null even though a real @mention triggered it.
+  assert.equal(typingConversation(null, unread('direct-linus-bcccd5')), 'direct-linus-bcccd5')
+})
+
+test('several unread conversations stay silent rather than guess', () => {
+  // Lighting up an arbitrary room would be a WRONG indicator — worse than none,
+  // and it would leak which other rooms the agent has unread mail in. The reply
+  // still lands in the right place regardless.
+  assert.equal(typingConversation(null, unread('g-one', 'g-two')), null)
+  assert.equal(typingConversation(null, unread('g-one', 'g-two', 'g-three')), null)
+})
+
+test('an empty inbox produces no indicator', () => {
+  // A catch-up turn with nothing unread must not flash typing anywhere — the
+  // phantom-typing case the original code was guarding against.
+  assert.equal(typingConversation(null, unread()), null)
+})
+
+test('an empty-string wake conversation is not treated as a name', () => {
+  // Defensive: a malformed SSE payload must fall through to the inbox, not send a
+  // typing ping for the conversation "".
+  assert.equal(typingConversation('', unread('g-abc')), 'g-abc')
+})

--- a/server/src/agents/computer/daemon.ts
+++ b/server/src/agents/computer/daemon.ts
@@ -487,6 +487,29 @@ async function runtimeGet<T>(
   } catch { return null }
 }
 
+/** Which conversation should show "<agent> is typing…" for this turn.
+ *
+ *  The wake's own conversation when it had one. Otherwise derive it from what is
+ *  unread, because a wake frequently carries none: a poll-driven turn never does
+ *  (only an SSE wake sets it, and polling is the only path left when the
+ *  wake-stream is down), and a wake that lands mid-turn is coalesced through
+ *  scheduleWake's busy branch, which re-kicks without a conversation.
+ *
+ *  `seen` is keyed by conversation_id, so the daemon already knows where the work
+ *  came from. With exactly one unread conversation that's unambiguous. With
+ *  several, stay silent rather than light up an arbitrary room — a wrong
+ *  indicator is worse than none, and the reply itself still lands correctly.
+ *
+ *  Exported for tests: this decides whether a working agent looks alive or dead,
+ *  and the "no indicator at all" case is the one users read as a hang. */
+export function typingConversation(
+  wakeConvo: string | null,
+  seen: Map<string, string>,
+): string | null {
+  if (wakeConvo) return wakeConvo
+  return seen.size === 1 ? [...seen.keys()][0] : null
+}
+
 function hashText(text: string): string {
   return createHash('sha1').update(text).digest('hex').slice(0, 12)
 }
@@ -1906,17 +1929,31 @@ class AgentRunner {
         const turnStart = Date.now()
         await this.ensureToken()
         const token = this.token
-        // Consume the wake's conversation: only a turn driven by a fresh wake
-        // FOR a conversation shows a "typing…" indicator there. Clearing it
-        // means a reconnect/cold-start catch-up turn (which reuses no wake)
-        // won't flash phantom "typing" in whatever conversation last woke us.
-        const convo = this.lastWakeConvo
+        // Consume the wake's conversation, so a later turn that reuses no wake
+        // can't flash phantom "typing" in whatever conversation last woke us.
+        // (The fallback below is derived from CURRENTLY unread messages, so it
+        // can't go stale the way a leftover wake value could.)
+        const wakeConvo = this.lastWakeConvo
         this.lastWakeConvo = null
         // Snapshot what's unread BEFORE triaging, so triage provably sees a
         // superset of what we may ack — a real task that lands during/after
         // triage keeps a higher id, stays out of `seen`, and so survives to
         // drive the coalesced rerun rather than being silently acked away.
         const { seen, digest, hasReal } = await this.snapshotUnread(token)
+        // Which conversation should show "<agent> is typing…"? Prefer the one the
+        // wake named, but fall back to the unread we just snapshotted, because a
+        // wake often carries no conversation at all:
+        //
+        //   - a POLL-driven turn never has one (only an SSE wake sets
+        //     lastWakeConvo), and polling is the ONLY path left whenever the
+        //     wake-stream is down;
+        //   - a wake that arrives while this agent is mid-turn is coalesced, and
+        //     scheduleWake's busy branch re-kicks without a conversation.
+        //
+        // Both cases are exactly when a human IS waiting, and with no indicator
+        // the agent reads as dead: it can work for minutes — engine spawned, turn
+        // running — while the room shows nothing at all.
+        const convo = typingConversation(wakeConvo, seen)
         // HARD COST GATE (content-blind, fail-closed): if nothing unread is a
         // real human/agent message — empty, or system-only relays/status/
         // membership notices — NEVER run triage and NEVER spawn the big engine.


### PR DESCRIPTION
## Problem

The typing indicator is gated on the turn having a conversation id, and that id only ever came from an SSE wake payload (`lastWakeConvo`, set in `streamLoop`). Two very common paths therefore run a full turn with no indicator at all:

- **A poll-driven turn never has one.** Only an SSE wake sets it — and polling is the *only* path left whenever the wake-stream is down.
- **A wake arriving mid-turn is coalesced.** `scheduleWake`'s busy branch re-kicks via `kickTurn(reason)` without a conversation, and `lastWakeConvo` was already consumed and nulled at the start of the in-flight turn.

Both are precisely the moments a human *is* waiting, so the agent reads as dead.

## What it looks like

Two agents were @mentioned in the same group, one message apart. Both worked; only one showed "typing…":

```
03:42:32  linus SSE wake  convo=g-6e361c41
03:42:36  linus turn START (sse-wake) … for g-6e361c41   ← indicator shown
03:42:48  jesse turn START (poll) …                      ← no convo → silent
03:43:50  jesse turn DONE (poll) — total 63004ms, exit 0 ← replied, 63s later
```

From the room it looked like only one of the two mentioned agents had responded. `jesse` had spawned its engine, run for a minute, and posted a reply — with no feedback for the entire turn. Longer turns make it worse; I saw the same shape on a 182s and a 529s turn.

The `(poll)` vs `(sse-wake)` split isn't rare either: an agent whose wake-stream has dropped runs *every* turn through the poll path, so it never shows an indicator again until the stream is re-established.

## Fix

The daemon already knows where the work came from — `seen` from `snapshotUnread` is keyed by `conversation_id`. So fall back to it when the wake carried none:

```ts
const convo = typingConversation(wakeConvo, seen)
```

- exactly one unread conversation → that's unambiguously the one
- several → stay silent rather than light up an arbitrary room. A wrong indicator is worse than none, it would leak which other rooms have unread mail, and the reply lands correctly either way.

Extracted as `typingConversation` so the choice is unit-testable, matching how `isStaleResumeError` is covered in this file.

The phantom-typing case the original comment guards against still can't happen: the fallback is derived from **currently unread** messages, not a leftover wake value. I reworded that comment rather than dropping it.

## Tests

`server/src/__tests__/agents-computer-typing-conversation.test.ts` — 6 tests: wake conversation always wins, poll fallback, coalesced fallback, multiple-unread stays silent, empty inbox stays silent, and an empty-string wake id isn't treated as a name.

`agents-computer-*` suite: 57 tests, 0 failures. `biome lint` clean.

## Verified

Running this build, a mentioned agent now lights up immediately on the poll and coalesced paths where it previously showed nothing.

<sub>Local note: `npm install` can't complete in my environment (registry mirror 500s on the `esbuild` tarball), so `tsc -p server/tsconfig.json` couldn't run — the pre-existing `agent-computer-pairing-token.test.ts` also fails there purely on a missing `pg`. Tests and lint were run via a separately installed `tsx`/`biome`. Worth a CI confirmation.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
