### PR TITLE
fix(cli): support human collaboration flows

### DIFF
--- a/server/src/__integration__/agent-anti-duplicate.test.ts
+++ b/server/src/__integration__/agent-anti-duplicate.test.ts
@@ -108,6 +108,28 @@ test('[integration] --continue bypass overrides the anti-monologue gate', async 
   assert.equal(bypassed.ok, true, `--continue should bypass the gate: ${bypassed.text}`)
 })
 
+test('[integration] a human can post immediately after inviting an agent', async () => {
+  const { companyId, humanId, convoId } = await seedGroupWithTwoAgents()
+  const invitedId = `a-${randomUUID().slice(0, 8)}`
+  await pool.query(
+    `INSERT INTO participants (id, company_id, kind, name, role, initial, avatar_bg, status)
+       VALUES ($1, $2, 'agent', $3, 'tester', 'C', '#abcdef', 'avail')`,
+    [invitedId, companyId, `Agent ${invitedId}`],
+  )
+
+  const invited = await runCli(['--as', humanId, 'invite', convoId, invitedId])
+  assert.equal(invited.ok, true, `invite should succeed: ${invited.text}`)
+
+  const followUp = await runCli([
+    '--as', humanId, 'reply', convoId, `@${invitedId} please review the synthetic task`,
+  ])
+  assert.equal(
+    followUp.ok,
+    true,
+    `the agent-only anti-monologue gate must not block a human follow-up: ${followUp.text}`,
+  )
+})
+
 test('[integration] DM (2-member convo) is exempt from the anti-monologue gate', async () => {
   const { companyId, agentId: agentA } = await seedCompanyWithAgent()
   const humanId = `h-${randomUUID().slice(0, 8)}`

--- a/server/src/__integration__/contacts.test.ts
+++ b/server/src/__integration__/contacts.test.ts
@@ -14,6 +14,7 @@ import { test, before, beforeEach, after } from 'node:test'
 import assert from 'node:assert/strict'
 import { ensureSchemaOnce, resetAllTables, seedCompanyWithAgent, teardownAll } from './_helpers.js'
 import { pool } from '../db/pool.js'
+import { env } from '../env.js'
 
 before(async () => {
   await ensureSchemaOnce()
@@ -44,6 +45,26 @@ test('[integration] contacts lists same-tenant agents (no query)', async () => {
   )
   const text = await runCliText(['contacts', '--as', agentId])
   assert.match(text, /bram/i, `expected the other agent in the list; got:\n${text}`)
+})
+
+test('[integration] contacts keeps chat-only agents visible when email is disabled', async () => {
+  const { agentId, companyId } = await seedCompanyWithAgent({ agentId: 'aurora' })
+  await pool.query(
+    `INSERT INTO participants (id, company_id, kind, name, role, initial, avatar_bg, status, email)
+     VALUES ('local-agent', $1, 'agent', 'Local Agent', 'operator', 'L', '#abcdef', 'avail', NULL)
+     ON CONFLICT DO NOTHING`,
+    [companyId],
+  )
+
+  const previousDomain = env.EMAIL_DOMAIN
+  env.EMAIL_DOMAIN = ''
+  try {
+    const text = await runCliText(['contacts', '--as', agentId])
+    assert.match(text, /Local Agent/, `expected the chat-only agent in the list; got:\n${text}`)
+    assert.match(text, /chat only/i, `expected a truthful non-email marker; got:\n${text}`)
+  } finally {
+    env.EMAIL_DOMAIN = previousDomain
+  }
 })
 
 test('[integration] contacts shows each agent\'s role/function (the directory bug)', async () => {

--- a/server/src/__integration__/human-cli-collaboration.test.ts
+++ b/server/src/__integration__/human-cli-collaboration.test.ts
@@ -1,0 +1,54 @@
+import { after, before, beforeEach, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { pool } from '../db/pool.js'
+import { runCli } from '../agents/cli.js'
+import {
+  ensureSchemaOnce,
+  resetAllTables,
+  seedCompanyWithAgent,
+  seedUserMembership,
+  teardownAll,
+} from './_helpers.js'
+
+before(async () => {
+  await ensureSchemaOnce()
+})
+
+beforeEach(async () => {
+  await resetAllTables()
+})
+
+after(async () => {
+  await teardownAll()
+})
+
+test('[integration] a human participant can open a CLI DM with an agent', async () => {
+  const { companyId, agentId } = await seedCompanyWithAgent({ agentId: 'reviewer' })
+  const humanId = 'human-owner'
+  await seedUserMembership(humanId, companyId, { displayName: 'Human Owner' })
+
+  const result = await runCli([
+    '--as', humanId, 'dm', agentId, 'Synthetic review', 'Please review the synthetic task.',
+  ])
+
+  assert.equal(result.ok, true, `human-authored DM should succeed: ${result.text}`)
+  const { rows: conversations } = await pool.query<{ id: string; members: string[] }>(
+    `SELECT id, members FROM conversations
+      WHERE kind = 'direct'
+        AND members @> $1::jsonb
+        AND members @> $2::jsonb
+        AND jsonb_array_length(members) = 2`,
+    [JSON.stringify([humanId]), JSON.stringify([agentId])],
+  )
+  assert.equal(conversations.length, 1)
+  assert.deepEqual(new Set(conversations[0].members), new Set([humanId, agentId]))
+
+  const { rows: messages } = await pool.query<{ author_id: string; body: string }>(
+    `SELECT author_id, body FROM messages
+      WHERE conversation_id = $1 ORDER BY sequence`,
+    [conversations[0].id],
+  )
+  assert.deepEqual(messages, [
+    { author_id: humanId, body: 'Please review the synthetic task.' },
+  ])
+})

--- a/server/src/agents/cli.ts
+++ b/server/src/agents/cli.ts
@@ -1525,9 +1525,18 @@ async function cmdReply(parsed: ParsedArgs): Promise<CliResult> {
     return err('usage: reply <convo_id> "<body>" [--quote <msg_id>] [--attach <url> | --generate-image "<prompt>" [--size square|wide|tall] | --attach-text "<filename>" "<content>" | --attach-bytes "<filename>" --bytes-b64 "<base64>" [--bytes-mime "<mime>"]]')
   }
 
-  // Verify the agent is a member of the conversation
-  const { rows: cv } = await pool.query<{ members: string[]; company_id: string; kind: string }>(
-    `SELECT members, company_id, kind FROM conversations WHERE id = $1`, [convoId],
+  // Verify the participant is a member of the conversation.
+  const { rows: cv } = await pool.query<{
+    members: string[]; company_id: string; kind: string; actor_is_agent: boolean
+  }>(
+    `SELECT c.members, c.company_id, c.kind,
+            EXISTS (
+              SELECT 1 FROM participants p
+               WHERE p.id = $2 AND p.company_id = c.company_id
+                 AND p.kind = 'agent' AND p.departed_at IS NULL
+            ) AS actor_is_agent
+       FROM conversations c WHERE c.id = $1`,
+    [convoId, me],
   )
   if (!cv[0]) return err(`unknown conversation ${convoId}`)
   if (!cv[0].members.includes(me)) return err(`${me} is not a member of ${convoId}`)
@@ -1556,7 +1565,7 @@ async function cmdReply(parsed: ParsedArgs): Promise<CliResult> {
   // forces the agent to commit deliberately rather than absent-
   // mindedly continuing to monologue.
   const monologueBypass = Boolean(parsed.flags.continue || parsed.flags.also)
-  if (!monologueBypass && cv[0].members.length > 2) {
+  if (!monologueBypass && cv[0].actor_is_agent && cv[0].members.length > 2) {
     const { rows: lastMsg } = await pool.query<{ author_id: string; created_at: string }>(
       `SELECT author_id, created_at FROM messages
          WHERE conversation_id = $1
@@ -2537,8 +2546,9 @@ async function listEmailContacts(
     [companyId, viewerId],
   )
   for (const a of agents) {
-    const address = a.email ?? computeAgentAddress(a.id, a.slug)
-    if (!address) continue
+    // Top-level `contacts` is also the workspace roster. Keep local chat
+    // agents visible when email is disabled instead of silently dropping them.
+    const address = a.email ?? computeAgentAddress(a.id, a.slug) ?? '(chat only)'
     const c: EmailContact = { participantId: a.id, name: a.name, address, kind: 'agent', role: a.role }
     if (matches(c)) out.push(c)
   }

--- a/server/src/agents/private_chat.ts
+++ b/server/src/agents/private_chat.ts
@@ -1,11 +1,9 @@
 /**
- * Helper for an agent to start (or extend) a private 1-on-1 chat with
- * another agent. There is no special "side-channel" model on the
- * backend — private agent-to-agent chats are just `kind='direct'`
- * conversations with two members, same shape as any human-agent or
- * human-human DM. The partner's mailbox scheduler wakes them on the
- * new message via the standard CH_MESSAGE_NEW path, and they reply
- * through `cumora reply` like in any group.
+ * Helper for any participant to start (or extend) a private 1-on-1 chat
+ * with another participant. There is no special "side-channel" model on
+ * the backend: every DM is a `kind='direct'` conversation with two members.
+ * An agent recipient's mailbox scheduler wakes them on the new message via
+ * the standard CH_MESSAGE_NEW path, and they reply through `cumora reply`.
  *
  * (The frontend exposes a "peek" tab where the user can read these
  * agent-agent threads — that's a purely client-side affordance and
@@ -14,7 +12,6 @@
 import { randomUUID } from 'node:crypto'
 import { pool } from '../db/pool.js'
 import { CH_MESSAGE_NEW, publish } from '../redis.js'
-import { getPersona } from './personas.js'
 import { companyIdForParticipant } from '../tenant.js'
 
 /** A participant's display name + kind, for ANY participant — human OR agent.
@@ -85,7 +82,7 @@ async function nextConversationSequence(conversationId: string): Promise<number>
   return rows[0]?.seq ?? 1
 }
 
-/** Open (or post into) a private 1-on-1 chat between two agents.
+/** Open (or post into) a private 1-on-1 chat between two participants.
  *  Idempotent on the conversation creation — repeated calls between the
  *  same pair reuse the existing direct conversation. */
 export async function startPrivateChat(args: {
@@ -95,15 +92,14 @@ export async function startPrivateChat(args: {
   opening: string
 }): Promise<{ conversationId: string; messageId: string }> {
   const { instigatorId, partnerId, topic, opening } = args
-  // The instigator is the calling agent; the PARTNER may be an agent OR a HUMAN
-  // — an agent legitimately DMs a person (a private game move to the host, a quiet
-  // word to a teammate). Previously we required BOTH to resolve via getPersona,
-  // which is agent-only, so getPersona(human)=null made EVERY agent→human DM throw
-  // "invalid private-chat participants"; the agent then fell back to announcing in
-  // the group. Validate the partner by EXISTENCE (any kind), not agent-ness.
+  // Humans and agents use the same direct-conversation model. Validate both
+  // endpoints by active participant existence rather than agent persona presence.
   if (instigatorId === partnerId) throw new Error('cannot open a DM with yourself')
-  const [iP, partner] = await Promise.all([getPersona(instigatorId), participantBrief(partnerId)])
-  if (!iP) throw new Error('private-chat instigator is not a known agent')
+  const [instigator, partner] = await Promise.all([
+    participantBrief(instigatorId),
+    participantBrief(partnerId),
+  ])
+  if (!instigator) throw new Error(`private-chat instigator not found: ${instigatorId}`)
   if (!partner) throw new Error(`private-chat partner not found: ${partnerId}`)
 
   const companyId = (await companyIdForParticipant(instigatorId)) ?? null
@@ -127,8 +123,8 @@ export async function startPrivateChat(args: {
     [instigatorId, conversationId],
   )
 
-  // Same channel as every other message — the mailbox scheduler wakes the
-  // partner agent and they decide whether to reply via the normal flow.
+  // Same channel as every other message. Agent recipients wake through the
+  // mailbox scheduler; human recipients see the direct conversation normally.
   await publish(CH_MESSAGE_NEW, {
     type: 'message.new',
     conversationId,


### PR DESCRIPTION
## Summary

- allow active human participants to initiate CLI DMs with agents
- keep chat-only agents visible in `contacts` when email is disabled
- apply the anti-monologue gate only to agents, so a human can prompt immediately after an invite

## Verification

- `npm test` (669 passed, 1 skipped)
- `npm run test:integration` (170 passed, 5 skipped)
- focused integration tests (17 passed)
- `npm run server:typecheck`
- scoped Biome lint