### PR TITLE
fix(embeddings): prevent backfill retry hot loop

### DIFF
--- a/server/src/__tests__/agents-embeddings.test.ts
+++ b/server/src/__tests__/agents-embeddings.test.ts
@@ -1,0 +1,56 @@
+import { after, afterEach, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+process.env.OPENAI_API_KEY ??= 'test-key'
+
+const { pool } = await import('../db/pool.js')
+const {
+  __setEmbedTextOverrideForTesting,
+  backfillMemoryEmbeddings,
+} = await import('../agents/embeddings.js')
+
+type PoolQueryFn = typeof pool.query
+const savedQuery = pool.query
+
+afterEach(() => {
+  __setEmbedTextOverrideForTesting(null)
+  ;(pool as unknown as { query: PoolQueryFn }).query = savedQuery
+})
+
+after(async () => {
+  await pool.end()
+})
+
+test('backfillMemoryEmbeddings advances past a full batch of failed embeddings', async () => {
+  const attempts = new Map<string, number>()
+  let pageQueries = 0
+
+  __setEmbedTextOverrideForTesting((body) => {
+    attempts.set(body, (attempts.get(body) ?? 0) + 1)
+    return null
+  })
+
+  ;(pool as unknown as { query: PoolQueryFn }).query = (async (sql: string, params?: unknown[]) => {
+    if (sql.includes('FROM pg_extension')) return { rows: [{ exists: true }] }
+    if (!sql.includes('FROM agent_workspace')) throw new Error(`unexpected query: ${sql}`)
+
+    pageQueries++
+    if (pageQueries === 1) {
+      assert.deepEqual(params, [2, null, null])
+      return {
+        rows: [
+          { agent_id: 'agent-a', path: 'memory/a', body: 'first' },
+          { agent_id: 'agent-b', path: 'memory/b', body: 'second' },
+        ],
+      }
+    }
+
+    assert.deepEqual(params, [2, 'agent-b', 'memory/b'])
+    return { rows: [] }
+  }) as unknown as PoolQueryFn
+
+  await backfillMemoryEmbeddings({ batchSize: 2, delayMs: 0 })
+
+  assert.equal(pageQueries, 2)
+  assert.deepEqual([...attempts], [['first', 1], ['second', 1]])
+})

--- a/server/src/agents/embeddings.ts
+++ b/server/src/agents/embeddings.ts
@@ -83,31 +83,44 @@ export async function backfillMemoryEmbeddings(opts: { batchSize?: number; delay
   if (!(await hasPgVector())) return
   let processed = 0
   let failed = 0
+  let afterAgentId: string | null = null
+  let afterPath: string | null = null
   while (true) {
-    const { rows } = await pool.query<{ agent_id: string; path: string; body: string }>(
+    const result: { rows: Array<{ agent_id: string; path: string; body: string }> } = await pool.query(
       `SELECT agent_id, path, body
          FROM agent_workspace
         WHERE path LIKE 'memory/%' AND embedding IS NULL AND body <> ''
+          AND ($2::text IS NULL OR (agent_id, path) > ($2::text, $3::text))
+        ORDER BY agent_id, path
         LIMIT $1`,
-      [batchSize],
+      [batchSize, afterAgentId, afterPath],
     )
+    const rows: Array<{ agent_id: string; path: string; body: string }> = result.rows
     if (rows.length === 0) break
     for (const r of rows) {
-      const vec = await embedText(r.body)
-      if (!vec) { failed++; continue }
       try {
-        await pool.query(
-          `UPDATE agent_workspace SET embedding = $1::vector
-            WHERE agent_id = $2 AND path = $3`,
-          [vec, r.agent_id, r.path],
-        )
-        processed++
-      } catch (e) {
-        failed++
-        console.warn('[embed:backfill] UPDATE failed for', r.path, e instanceof Error ? e.message : String(e))
+        const vec = await embedText(r.body)
+        if (!vec) {
+          failed++
+          continue
+        }
+        try {
+          await pool.query(
+            `UPDATE agent_workspace SET embedding = $1::vector
+              WHERE agent_id = $2 AND path = $3`,
+            [vec, r.agent_id, r.path],
+          )
+          processed++
+        } catch (e) {
+          failed++
+          console.warn('[embed:backfill] UPDATE failed for', r.path, e instanceof Error ? e.message : String(e))
+        }
+      } finally {
+        if (delayMs > 0) await new Promise((res) => setTimeout(res, delayMs))
       }
-      if (delayMs > 0) await new Promise((res) => setTimeout(res, delayMs))
     }
+    afterAgentId = rows[rows.length - 1].agent_id
+    afterPath = rows[rows.length - 1].path
     if (rows.length < batchSize) break
   }
   if (processed + failed > 0) {


### PR DESCRIPTION
## Root cause

The backfill loop used a short page as its only termination condition. When embedding generation failed, the early `continue` skipped the `UPDATE`, leaving every failed row with `embedding IS NULL`.

For example, if all 50 rows in the default batch fail:

1. the query returns 50 eligible rows
2. none of them are updated, so all 50 remain eligible
3. `rows.length === batchSize`, so the loop does not exit
4. the next unpaginated query selects another full batch of the same still-eligible failures

PostgreSQL does not guarantee that each query returns rows in the same order, but ordering does not prevent the bug: as long as at least `batchSize` permanently failing rows remain, every iteration can return a full page and the loop cannot terminate. The early `continue` also bypassed the throttle delay, turning this into a hot loop that continuously called OpenAI, queried PostgreSQL, and occupied the process.

## Summary

- paginate missing embeddings by `(agent_id, path)` so failed rows are not selected again during the same backfill run
- apply the throttle delay in `finally` so successful and failed attempts are both rate-limited
- add a regression test covering a full batch of two permanently failing records

Failed rows remain unmodified and can be retried on the next server start.

## Testing

- `node --import tsx --test server/src/__tests__/agents-embeddings.test.ts`
- `npm run server:typecheck`
- `npx biome lint server/src/agents/embeddings.ts server/src/__tests__/agents-embeddings.test.ts`