### PR TITLE
fix(byoa): restore agent replies on Windows

### DIFF
--- a/server/src/__tests__/agent-computer-shim-output.test.ts
+++ b/server/src/__tests__/agent-computer-shim-output.test.ts
@@ -12,14 +12,22 @@
  *
  * Run: node --import tsx --test server/src/__tests__/agent-computer-shim-output.test.ts
  */
-import { spawn } from 'node:child_process'
+import { execFile, spawn } from 'node:child_process'
 import { createServer, type Server } from 'node:http'
-import { mkdtemp, writeFile, chmod, rm } from 'node:fs/promises'
+import { mkdtemp, writeFile, chmod, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { delimiter, join } from 'node:path'
 import { afterEach, test } from 'node:test'
+import { promisify } from 'node:util'
 import assert from 'node:assert/strict'
-import { CUMORA_SHIM } from '../agents/computer/daemon.js'
+import {
+  CUMORA_SHIM,
+  CUMORA_WINDOWS_SHIM,
+  prependAgentBinToPath,
+  writeShim,
+} from '../agents/computer/daemon.js'
+
+const execFileP = promisify(execFile)
 
 const cleanup: Array<() => Promise<void> | void> = []
 
@@ -103,4 +111,65 @@ test('an empty payload exits without writing', async () => {
   const r = await runShim(url)
   assert.equal(r.stdoutBytes, 0)
   assert.equal(r.exitCode, 1)
+})
+
+test('agent bin is prepended with the platform PATH delimiter', () => {
+  const inherited = ['first', 'second'].join(delimiter)
+  assert.equal(
+    prependAgentBinToPath('agent-bin', inherited),
+    ['agent-bin', 'first', 'second'].join(delimiter),
+  )
+  assert.equal(prependAgentBinToPath('agent-bin', ''), 'agent-bin')
+})
+
+test('writeShim emits a Windows command launcher beside the shared Node shim', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'cumora-windows-shim-'))
+  cleanup.push(() => rm(dir, { recursive: true, force: true }))
+
+  await writeShim(dir, 'win32')
+
+  assert.equal(await readFile(join(dir, 'cumora'), 'utf8'), CUMORA_SHIM)
+  assert.equal(await readFile(join(dir, 'cumora.cmd'), 'utf8'), CUMORA_WINDOWS_SHIM)
+})
+
+test('PowerShell resolves cumora from the injected PATH and forwards arguments', {
+  skip: process.platform !== 'win32',
+}, async () => {
+  let receivedAuthorization = ''
+  let receivedArgv: string[] | undefined
+  const server: Server = createServer(async (req, res) => {
+    receivedAuthorization = req.headers.authorization ?? ''
+    let body = ''
+    for await (const chunk of req) body += chunk.toString()
+    receivedArgv = (JSON.parse(body) as { argv: string[] }).argv
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end(JSON.stringify({ text: 'sent from test', exitCode: 0, ok: true, sideEffects: [] }))
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  cleanup.push(() => new Promise<void>((resolve) => { server.close(() => resolve()) }))
+  const addr = server.address()
+  if (!addr || typeof addr === 'string') throw new Error('no port')
+
+  const dir = await mkdtemp(join(tmpdir(), 'cumora-powershell-shim-'))
+  cleanup.push(() => rm(dir, { recursive: true, force: true }))
+  await writeShim(dir)
+
+  const { stdout, stderr } = await execFileP(
+    'powershell.exe',
+    ['-NoProfile', '-NonInteractive', '-Command', "cumora reply direct-test 'hello from windows'"],
+    {
+      env: {
+        ...process.env,
+        PATH: prependAgentBinToPath(dir),
+        CUMORA_AGENT_RUNTIME_URL: `http://127.0.0.1:${addr.port}`,
+        CUMORA_AGENT_RUNTIME_TOKEN: 'test-token',
+        CUMORA_AGENT_RUNTIME_TOKEN_FILE: '',
+      },
+    },
+  )
+
+  assert.equal(stdout.trim(), 'sent from test')
+  assert.equal(stderr, '')
+  assert.equal(receivedAuthorization, 'Bearer test-token')
+  assert.deepEqual(receivedArgv, ['reply', 'direct-test', 'hello from windows'])
 })

--- a/server/src/agents/computer/daemon.ts
+++ b/server/src/agents/computer/daemon.ts
@@ -21,7 +21,7 @@ import { createHash } from 'node:crypto'
 import { mkdir, writeFile, readFile, chmod, rm, stat, copyFile, truncate } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { homedir, hostname } from 'node:os'
-import { join, dirname } from 'node:path'
+import { delimiter, join, dirname } from 'node:path'
 import { execFile, spawn } from 'node:child_process'
 import { promisify } from 'node:util'
 
@@ -764,11 +764,26 @@ export const CUMORA_SHIM = `#!/usr/bin/env node
 })().catch((e) => { console.error('cumora:', (e && e.message) || e); process.exit(70) })
 `
 
-async function writeShim(binDir: string): Promise<void> {
+/** PowerShell only resolves files on PATH through PATHEXT, so the extensionless
+ *  POSIX shim needs a .cmd launcher on Windows. Keep the Node program itself in
+ *  one file so both launchers exercise the exact same argument/HTTP path. */
+export const CUMORA_WINDOWS_SHIM = '@echo off\r\nnode "%~dp0cumora" %*\r\n'
+
+export function prependAgentBinToPath(binDir: string, currentPath = process.env.PATH ?? ''): string {
+  return currentPath ? `${binDir}${delimiter}${currentPath}` : binDir
+}
+
+export async function writeShim(
+  binDir: string,
+  platform: NodeJS.Platform = process.platform,
+): Promise<void> {
   await mkdir(binDir, { recursive: true })
   const shim = join(binDir, 'cumora')
   await writeFile(shim, CUMORA_SHIM, 'utf8')
   await chmod(shim, 0o755)
+  if (platform === 'win32') {
+    await writeFile(join(binDir, 'cumora.cmd'), CUMORA_WINDOWS_SHIM, 'utf8')
+  }
 }
 
 // ─── pairing ────────────────────────────────────────────────────────────
@@ -1231,7 +1246,7 @@ class AgentRunner {
   private engineEnv(): NodeJS.ProcessEnv {
     return {
       ...process.env,
-      PATH: `${this.binDir}:${process.env.PATH ?? ''}`,
+      PATH: prependAgentBinToPath(this.binDir),
       CUMORA_AGENT_RUNTIME_URL: `${this.cfg.serverUrl}/runtime`,
       CUMORA_AGENT_RUNTIME_TOKEN: this.token,
       // A long-lived engine reads the FRESH token from this file (the env token


### PR DESCRIPTION
## Summary

Fix the Windows BYOA reply path by making the per-agent `cumora` CLI shim directly executable from PowerShell.

- emit a `cumora.cmd` launcher beside the shared Node shim on Windows
- prepend the agent bin directory using the platform PATH delimiter
- preserve argument forwarding, exit codes, and the existing cross-platform shim behavior

## Relationship to #63

#63 fixes the inbound half of the Windows Codex flow: sending prompts from Cumora to `codex exec` through stdin.

This PR fixes the outbound/reply half: after Codex generates a response, its PowerShell subprocess can resolve `cumora` and send the reply back to the Cumora conversation.

The two fixes address separate halves of the same end-to-end BYOA conversation flow and can be reviewed independently.

## Root cause

The daemon only wrote an extensionless `bin/cumora` Node script. On Windows, PowerShell command discovery does not treat that file as an executable command through `PATHEXT`, so agent calls such as `cumora reply ...` failed even when the agent bin directory was present on `PATH`.

The injected PATH was also assembled with a hard-coded `:`, which is not the Windows PATH separator.

## Fix

- write `bin/cumora.cmd` on Windows with `%~dp0`-relative forwarding to the existing Node shim
- use `path.delimiter` when prepending the agent bin directory
- keep the extensionless shim as the shared implementation for non-Windows platforms

## Verification

- `node --import tsx --test server/src/__tests__/agent-computer-shim-output.test.ts` - 7/7 passed
- `npm run server:typecheck` - passed
- Biome lint for the changed files - passed
- real PowerShell process resolved `cumora` from the injected PATH and forwarded spaced arguments unchanged
- real source daemon generated `cumora.cmd` for all four hosted agents and `cumora inbox --json` completed successfully
- integration-tested locally together with #63: a long prompt reached Codex, `cumora reply` returned `sent (...)`, and the turn completed with exit 0
