### PR TITLE
fix(runtime): scope context reads to agent membership

### DIFF
--- a/server/src/__integration__/runtime-server.test.ts
+++ b/server/src/__integration__/runtime-server.test.ts
@@ -12,6 +12,8 @@
  *  - Identity pin: when a request body claims `agentId: <spoof>` while
  *    the JWT pins someone else, the row that lands in Postgres uses the
  *    JWT subject, not the body claim.
+ *  - Conversation scope: context reads return only conversations in the
+ *    JWT-pinned agent's tenant where that agent is a current member.
  *  - Payload validation: 400s for missing required fields, without ever
  *    touching the DB.
  *
@@ -92,6 +94,26 @@ async function seedAgent(): Promise<{ agentId: string; companyId: string; token:
   return { agentId, companyId, token }
 }
 
+async function seedContextConversation(opts: {
+  companyId: string
+  members: string[]
+  authorId: string
+  body: string
+}): Promise<string> {
+  const conversationId = `cv-${randomUUID().slice(0, 8)}`
+  await pool.query(
+    `INSERT INTO conversations (id, kind, title, members, company_id)
+       VALUES ($1, 'group', $2, $3::jsonb, $4)`,
+    [conversationId, `Context ${conversationId}`, JSON.stringify(opts.members), opts.companyId],
+  )
+  await pool.query(
+    `INSERT INTO messages (id, conversation_id, author_id, kind, body, sequence, company_id)
+       VALUES ($1, $2, $3, 'text', $4, 1, $5)`,
+    [`m-${randomUUID()}`, conversationId, opts.authorId, opts.body, opts.companyId],
+  )
+  return conversationId
+}
+
 // ── auth gate ──────────────────────────────────────────────────────────
 
 test('[integration] runtime: missing Authorization → 401', async () => {
@@ -130,6 +152,53 @@ test('[integration] runtime: expired token → 401', async () => {
   const r = await call('/runtime/inbox', { method: 'GET', token: tok })
   assert.equal(r.status, 401)
   assert.match(String(r.body?.error ?? ''), /expired/i)
+})
+
+test('[integration] runtime: /context enforces tenant and conversation membership', async () => {
+  const { agentId, companyId, token } = await seedAgent()
+  const peerId = `a-${randomUUID().slice(0, 8)}`
+  await pool.query(
+    `INSERT INTO participants (id, company_id, kind, name, role, initial, avatar_bg, status)
+       VALUES ($1, $2, 'agent', $3, 'tester', 'P', '#abcdef', 'avail')`,
+    [peerId, companyId, peerId],
+  )
+
+  const allowedId = await seedContextConversation({
+    companyId,
+    members: [agentId, peerId],
+    authorId: peerId,
+    body: 'member-visible',
+  })
+  const nonMemberId = await seedContextConversation({
+    companyId,
+    members: [peerId],
+    authorId: peerId,
+    body: 'same-tenant-private',
+  })
+  const otherTenant = await seedAgent()
+  const crossTenantId = await seedContextConversation({
+    companyId: otherTenant.companyId,
+    // Deliberately include the caller's globally unique id: tenant binding
+    // must still reject a corrupt or forged cross-company members array.
+    members: [agentId, otherTenant.agentId],
+    authorId: otherTenant.agentId,
+    body: 'cross-tenant-private',
+  })
+
+  const r = await call('/runtime/context', {
+    token,
+    body: { conversationIds: [allowedId, nonMemberId, crossTenantId] },
+  })
+
+  assert.equal(r.status, 200)
+  assert.deepEqual(
+    (r.body?.rows ?? []).map((row: { conversation_id: string; company_id: string; body: string }) => ({
+      conversationId: row.conversation_id,
+      companyId: row.company_id,
+      body: row.body,
+    })),
+    [{ conversationId: allowedId, companyId, body: 'member-visible' }],
+  )
 })
 
 // ── identity pin: agentId comes from JWT, not request body ────────────

--- a/server/src/agents/runtime/client.ts
+++ b/server/src/agents/runtime/client.ts
@@ -209,7 +209,9 @@ export interface AgentRuntimeClient {
     projectIds?: readonly string[];
     conversationIds?: readonly string[];
   }): Promise<MemoryRow[]>
-  /** Per-conversation recent history for every convo with unread items. */
+  /** Per-conversation recent history for every convo with unread items.
+   *  Implementations must treat conversationIds as selectors, not proof of
+   *  access, and enforce the agent's tenant + current membership. */
   loadContext(agentId: string, conversationIds: string[]): Promise<ContextRow[]>
   /** Agent's feelings about people (the climate model). */
   loadClimate(agentId: string): Promise<ClimateRow[]>

--- a/server/src/agents/runtime/inproc-client.ts
+++ b/server/src/agents/runtime/inproc-client.ts
@@ -353,6 +353,9 @@ export class InProcRuntimeClient implements AgentRuntimeClient {
    *  JSON array so the prompt renderer doesn't need a second roundtrip. */
   async loadContext(agentId: string, conversationIds: string[]): Promise<ContextRow[]> {
     if (conversationIds.length === 0) return []
+    // conversationIds can come directly from an authenticated runtime caller.
+    // They narrow the read but do not authorize it: bind every conversation to
+    // the active agent's tenant and require current conversation membership.
     // Drive from conversations (PK lookup on the given ids) + a LATERAL that pulls
     // each conversation's most-recent 25 messages via idx_messages_convo_created.
     // The old form scanned ALL messages of each conversation (big "allhands" rooms
@@ -391,6 +394,11 @@ export class InProcRuntimeClient implements AgentRuntimeClient {
                WHERE cr.conversation_id = c.id AND hp.kind = 'human'
             ) AS human_last_read_at
            FROM conversations c
+           JOIN participants requesting_agent
+             ON requesting_agent.id = $1
+            AND requesting_agent.company_id = c.company_id
+            AND requesting_agent.kind = 'agent'
+            AND requesting_agent.departed_at IS NULL
            LEFT JOIN projects pr ON pr.id = c.project_id
            JOIN LATERAL (
              SELECT * FROM messages mm
@@ -400,6 +408,7 @@ export class InProcRuntimeClient implements AgentRuntimeClient {
            ) m ON true
            LEFT JOIN participants p ON p.id = m.author_id AND p.company_id = c.company_id
           WHERE c.id = ANY($2::text[])
+            AND c.members @> to_jsonb(ARRAY[$1::text])
        )
        SELECT id, conversation_id, company_id, conversation_title, conversation_kind, conversation_topic,
               project_name,


### PR DESCRIPTION
## Summary

- bind every requested context conversation to the active Agent participant in the same company
- require the JWT-pinned Agent id to be a current member before loading messages, reactions, quotes, or attachment URLs
- document tenant and membership enforcement as part of the runtime client contract
- add an end-to-end runtime test covering an allowed conversation, a same-tenant non-member conversation, and a cross-tenant conversation with a deliberately polluted members array

## Security context

The authenticated `/runtime/context` endpoint previously treated caller-supplied conversation ids as authorization and loaded recent messages by id alone. A valid Agent runtime token could therefore request private context from conversations outside its membership and tenant.

Unauthorized ids now contribute no rows. The authorization predicate lives in the shared `loadContext` query so both HTTP and in-process callers fail closed.

## Validation

### Local

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run server:typecheck`
- [x] `npm run guard:big-brain`
- [x] `npm run guard:llm-tracked`
- full local Unit and Integration suites require the Postgres and Redis services supplied by CI

### GitHub CI

- [x] Unit tests
- [x] Integration tests
- [x] Typecheck
- [x] Lint
- [x] Big-brain guard
- [x] LLM-tracked guard