### PR TITLE
feat(auth): sign in with GitLab, including self-managed instances

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,6 +108,15 @@ R2_URL_SIGNING_SECRET=
 # GOOGLE_CLIENT_SECRET=
 # GITHUB_CLIENT_ID=
 # GITHUB_CLIENT_SECRET=
+# GITLAB_CLIENT_ID=
+# GITLAB_CLIENT_SECRET=
+# Which GitLab to sign in against. Defaults to gitlab.com; point it at a
+# self-managed instance to use that one instead. Redirect URI to register in
+# GitLab: <CUMORA_PUBLIC_ORIGIN>/api/auth/callback/gitlab, scope `read_user`.
+# Whatever you set here is TRUSTED to attest its users' email ownership, the
+# same trust Google and GitHub get — a verified email is what lets sign-in
+# link to an existing account.
+# GITLAB_BASE_URL=https://gitlab.com
 #
 # Publicly reachable origin of THIS server — used to build the OAuth
 # redirect_uri handed to providers. For local dev with a tunnel, set this

--- a/server/src/__tests__/oauth-gitlab-profile.test.ts
+++ b/server/src/__tests__/oauth-gitlab-profile.test.ts
@@ -1,0 +1,116 @@
+/**
+ * GitLab sign-in profile normalization.
+ *
+ * `NormalizedProfile.email` feeds `findOrCreateUserByProfile`'s cross-provider
+ * auto-link, which attaches a new identity to an EXISTING account purely by
+ * matching the address. So the address has to be one the provider attests to,
+ * not merely one it reports — otherwise sign-in becomes an account-takeover
+ * primitive. Google gates on `email_verified`, GitHub on the address being
+ * `verified`; GitLab's equivalent is `confirmed_at`.
+ *
+ * These pin every refusal path, because the failure direction that matters is
+ * "refuse the login", never "link to someone else's account".
+ *
+ * Run: node --import tsx --test server/src/__tests__/oauth-gitlab-profile.test.ts
+ */
+import { test, afterEach, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { fetchProfile } from '../oauth.js'
+import { pool } from '../db/pool.js'
+
+const SAVED_FETCH = globalThis.fetch
+
+interface GitLabUser {
+  id: number
+  username: string
+  name?: string | null
+  email?: string | null
+  state?: string | null
+  confirmed_at?: string | null
+  avatar_url?: string | null
+}
+
+function mockGitLab(user: GitLabUser, base = 'https://gitlab.com') {
+  globalThis.fetch = (async (url: string | URL | Request) => {
+    const href = typeof url === 'string' ? url : url instanceof URL ? url.href : url.url
+    if (href === `${base}/api/v4/user`) return new Response(JSON.stringify(user), { status: 200 })
+    throw new Error(`unexpected fetch: ${href}`)
+  }) as typeof fetch
+}
+
+afterEach(() => { globalThis.fetch = SAVED_FETCH })
+
+after(async () => {
+  // oauth.ts opens a pool + redis at module load; close them so the runner exits.
+  try { await pool.end() } catch { /* ignore */ }
+  try {
+    const { redis, sub } = await import('../redis.js')
+    redis.disconnect()
+    sub.disconnect()
+  } catch { /* ignore */ }
+})
+
+const CONFIRMED: GitLabUser = {
+  id: 42,
+  username: 'yuluo',
+  name: 'Yu Luo',
+  email: 'yuluo@example.com',
+  state: 'active',
+  confirmed_at: '2026-05-23T09:05:22Z',
+  avatar_url: 'https://gitlab.com/uploads/-/system/user/avatar/42/avatar.png',
+}
+
+test('a confirmed, active account normalizes', async () => {
+  mockGitLab(CONFIRMED)
+  const p = await fetchProfile('gitlab', 'tok')
+  assert.equal(p.providerId, '42')
+  assert.equal(p.email, 'yuluo@example.com')
+  assert.equal(p.displayName, 'Yu Luo')
+  assert.equal(p.avatarUrl, CONFIRMED.avatar_url)
+})
+
+test('the email is lowercased, like the other providers', async () => {
+  mockGitLab({ ...CONFIRMED, email: 'YuLuo@Example.COM' })
+  const p = await fetchProfile('gitlab', 'tok')
+  assert.equal(p.email, 'yuluo@example.com')
+})
+
+test('an unconfirmed email is refused', async () => {
+  // A self-managed instance can disable user confirmation entirely, which
+  // leaves confirmed_at null on an otherwise ordinary account. Trusting that
+  // address would let anyone who can create an account there claim any
+  // existing Cumora account by email.
+  mockGitLab({ ...CONFIRMED, confirmed_at: null })
+  await assert.rejects(() => fetchProfile('gitlab', 'tok'), /no confirmed email/)
+})
+
+test('a non-active account is refused even when confirmed', async () => {
+  // Blocked / deactivated users can still be holding a live token.
+  mockGitLab({ ...CONFIRMED, state: 'blocked' })
+  await assert.rejects(() => fetchProfile('gitlab', 'tok'), /not active/)
+})
+
+test('an account that exposes no email is refused', async () => {
+  mockGitLab({ ...CONFIRMED, email: null })
+  await assert.rejects(() => fetchProfile('gitlab', 'tok'), /no email/)
+})
+
+test('the username stands in when the display name is empty', async () => {
+  mockGitLab({ ...CONFIRMED, name: '   ' })
+  const p = await fetchProfile('gitlab', 'tok')
+  assert.equal(p.displayName, 'yuluo')
+})
+
+test('a self-managed instance is read from GITLAB_BASE_URL', async () => {
+  // The whole point of the issue: sign in against your own GitLab.
+  const { env } = await import('../env.js')
+  const saved = env.GITLAB_BASE_URL
+  ;(env as { GITLAB_BASE_URL: string }).GITLAB_BASE_URL = 'https://gitlab.example.com'
+  try {
+    mockGitLab(CONFIRMED, 'https://gitlab.example.com')
+    const p = await fetchProfile('gitlab', 'tok')
+    assert.equal(p.email, 'yuluo@example.com')
+  } finally {
+    ;(env as { GITLAB_BASE_URL: string }).GITLAB_BASE_URL = saved
+  }
+})

--- a/server/src/api/router.ts
+++ b/server/src/api/router.ts
@@ -19,7 +19,7 @@ import {
 } from '../auth.js'
 import { joinAllHands, onboardStarterAgents, seedMemberDms } from '../onboardCompany.js'
 import {
-  type Provider, providerEnabled, createState, consumeState,
+  type Provider, providerEnabled, createState, consumeState, isWebOAuthProvider, WEB_OAUTH_PROVIDERS,
   authorizeUrl, handleCallback, errorUrl, returnUrlAllowed,
 } from '../oauth.js'
 import { adminRouter } from './admin-router.js'
@@ -651,9 +651,17 @@ api.get('/metrics', async (req, res) => {
  *  `?return=<url>` is the post-callback redirect target. Must startsWith
  *  one of CUMORA_AUTH_RETURN_ALLOWLIST entries; otherwise rejected so we
  *  can't be turned into an open redirect. Omit to use AUTH_DONE_URL. */
+/** Which browser sign-in providers this deployment actually has credentials
+ *  for. The sign-in screens use it to avoid offering a button that can only
+ *  503 — GitLab is opt-in (and points at whichever instance the operator
+ *  configured), so most deployments will not have it. */
+api.get('/auth/providers', safe(async (_req, res) => {
+  res.json({ providers: [...WEB_OAUTH_PROVIDERS].filter((p) => providerEnabled(p as Provider)) })
+}))
+
 api.get('/auth/start/:provider', safe(async (req, res) => {
   const provider = req.params.provider as Provider
-  if (provider !== 'google' && provider !== 'github') {
+  if (!isWebOAuthProvider(provider)) {
     res.status(404).json({ error: 'unknown provider' }); return
   }
   if (!providerEnabled(provider)) {
@@ -682,7 +690,7 @@ api.get('/auth/start/:provider', safe(async (req, res) => {
  *  On failure we 302 to the same target with `#error=...`. */
 api.get('/auth/callback/:provider', safe(async (req, res) => {
   const provider = req.params.provider as Provider
-  if (provider !== 'google' && provider !== 'github') {
+  if (!isWebOAuthProvider(provider)) {
     res.status(404).json({ error: 'unknown provider' }); return
   }
   const code = typeof req.query.code === 'string' ? req.query.code : ''

--- a/server/src/db/migrate.ts
+++ b/server/src/db/migrate.ts
@@ -808,7 +808,7 @@ CREATE INDEX IF NOT EXISTS idx_audit_events_kind    ON audit_events(kind, create
 -- provider gave us at link time — used for cross-provider lookup AND so we
 -- can audit changes if a provider later returns a different email.
 CREATE TABLE IF NOT EXISTS user_identities (
-  provider     TEXT NOT NULL,           -- 'google' | 'github'
+  provider     TEXT NOT NULL,           -- 'google' | 'github' | 'gitlab' | 'apple'
   provider_id  TEXT NOT NULL,           -- sub (Google) / numeric id (GitHub)
   user_id      TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   email_lower  TEXT NOT NULL,

--- a/server/src/env.ts
+++ b/server/src/env.ts
@@ -271,6 +271,14 @@ export const env = {
   GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET ?? '',
   GITHUB_CLIENT_ID:     process.env.GITHUB_CLIENT_ID     ?? '',
   GITHUB_CLIENT_SECRET: process.env.GITHUB_CLIENT_SECRET ?? '',
+  GITLAB_CLIENT_ID:     process.env.GITLAB_CLIENT_ID     ?? '',
+  GITLAB_CLIENT_SECRET: process.env.GITLAB_CLIENT_SECRET ?? '',
+  /** Which GitLab to talk to. Defaults to gitlab.com; point it at a
+   *  self-managed instance (https://gitlab.example.com) to sign in against
+   *  that one instead. Whatever you set here is TRUSTED to attest its users'
+   *  email ownership — the same trust Google and GitHub get — because a
+   *  verified email is what lets sign-in link to an existing account. */
+  GITLAB_BASE_URL: (process.env.GITLAB_BASE_URL ?? 'https://gitlab.com').replace(/\/+$/, ''),
   /** Public origin this server is reachable at. Used to construct the
    *  per-provider redirect_uri that we hand to Google / GitHub at flow
    *  start. Defaults to http://localhost:5181 for local dev. In prod

--- a/server/src/oauth.ts
+++ b/server/src/oauth.ts
@@ -41,7 +41,20 @@ import { storage } from './storage.js'
 import { provisionUser as provisionSub2apiUser, sub2apiConfigured } from './sub2api.js'
 import { isWaitlistEnabled, enqueueWaitlist, isAllowlistedAdmin } from './admin.js'
 
-export type Provider = 'google' | 'github' | 'apple'
+export type Provider = 'google' | 'github' | 'gitlab' | 'apple'
+
+/** Providers reachable through the BROWSER redirect flow (/auth/start/:provider
+ *  → /auth/callback/:provider). Apple is deliberately absent: it signs in
+ *  natively through /auth/apple/native and never goes through these routes.
+ *
+ *  One set rather than a `!== 'google' && !== 'github'` chain at each gate —
+ *  those have to be found and widened by hand for every new provider, and a
+ *  missed one fails as a 404 on a button the UI already renders. */
+export const WEB_OAUTH_PROVIDERS: ReadonlySet<string> = new Set(['google', 'github', 'gitlab'])
+
+export function isWebOAuthProvider(p: string): p is Provider {
+  return WEB_OAUTH_PROVIDERS.has(p)
+}
 
 interface ProviderConfig {
   authorizeUrl: string
@@ -60,6 +73,22 @@ function providerConfig(p: Provider): ProviderConfig {
     scope:        'openid email profile',
     clientId:     env.GOOGLE_CLIENT_ID,
     clientSecret: env.GOOGLE_CLIENT_SECRET,
+  }
+  if (p === 'gitlab') {
+    // Endpoints are derived from GITLAB_BASE_URL so a self-managed instance
+    // works with the same code path as gitlab.com. `read_user` is the scope
+    // that grants the `/api/v4/user` profile read we need — deliberately the
+    // narrowest one: `api` would hand us write access to the user's repos for
+    // no reason.
+    const base = env.GITLAB_BASE_URL
+    return {
+      authorizeUrl: `${base}/oauth/authorize`,
+      tokenUrl:     `${base}/oauth/token`,
+      userInfoUrl:  `${base}/api/v4/user`,
+      scope:        'read_user',
+      clientId:     env.GITLAB_CLIENT_ID,
+      clientSecret: env.GITLAB_CLIENT_SECRET,
+    }
   }
   return {
     authorizeUrl: 'https://github.com/login/oauth/authorize',
@@ -128,7 +157,7 @@ export async function consumeState(state: string): Promise<StateData | null> {
   if (!v) return null
   try {
     const parsed = JSON.parse(v) as StateData
-    if (parsed.provider !== 'google' && parsed.provider !== 'github') return null
+    if (!isWebOAuthProvider(parsed.provider)) return null
     return parsed
   } catch {
     return null
@@ -184,6 +213,18 @@ async function exchangeCode(p: Provider, code: string): Promise<string> {
 
 interface GoogleProfile { sub: string; email?: string; email_verified?: boolean; name?: string; picture?: string }
 interface GitHubProfile { id: number; login: string; name?: string | null; email?: string | null; avatar_url?: string }
+/** GitLab `GET /api/v4/user` (the authenticated user). `confirmed_at` is the
+ *  field that attests the address: GitLab sets it when the user completes email
+ *  confirmation, and leaves it null otherwise. */
+interface GitLabProfile {
+  id: number
+  username: string
+  name?: string | null
+  email?: string | null
+  state?: string | null
+  confirmed_at?: string | null
+  avatar_url?: string | null
+}
 interface GitHubEmail   { email: string; primary: boolean; verified: boolean }
 
 export async function fetchProfile(p: Provider, accessToken: string): Promise<NormalizedProfile> {
@@ -198,6 +239,33 @@ export async function fetchProfile(p: Provider, accessToken: string): Promise<No
       email: g.email.toLowerCase(),
       displayName: (g.name && g.name.trim()) || g.email.split('@')[0]!,
       avatarUrl: g.picture ?? null,
+    }
+  }
+  if (p === 'gitlab') {
+    const r = await fetch(cfg.userInfoUrl, {
+      headers: { authorization: `Bearer ${accessToken}`, accept: 'application/json' },
+    })
+    if (!r.ok) throw new Error(`gitlab user ${r.status}`)
+    const g = await r.json() as GitLabProfile
+    // The email must be ATTESTED, not merely present. NormalizedProfile.email
+    // feeds findOrCreateUserByProfile's cross-provider auto-link, which links a
+    // new identity onto an existing account purely by matching address — so an
+    // unattested address here would be an account-takeover primitive, not a
+    // cosmetic gap. Google gates on email_verified and GitHub on the address
+    // being `verified`; GitLab's equivalent is confirmed_at.
+    //
+    // Both checks are required. A self-managed instance can be configured with
+    // user confirmation disabled, in which case confirmed_at stays null even
+    // for an active account — refuse rather than trust it. `state` catches
+    // accounts that are blocked/deactivated but still hold a live token.
+    if (g.state !== 'active') throw new Error('gitlab account is not active')
+    if (!g.confirmed_at) throw new Error('gitlab account has no confirmed email')
+    if (!g.email) throw new Error('gitlab account exposes no email to read_user')
+    return {
+      providerId: String(g.id),
+      email: g.email.toLowerCase(),
+      displayName: (g.name && g.name.trim()) || g.username,
+      avatarUrl: g.avatar_url ?? null,
     }
   }
   // GitHub: /user doesn't expose email when the user hides it. Hit /user/emails

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -765,7 +765,7 @@ export const api = {
    *  `window.location.assign(api.authStartUrl('google'))` rather than
    *  fetch — the browser needs to do the actual navigation so the
    *  callback can land back on AUTH_DONE_URL with the session token. */
-  authStartUrl: (provider: 'google' | 'github', opts?: { inviteToken?: string | null; returnUrl?: string | null }) => {
+  authStartUrl: (provider: 'google' | 'github' | 'gitlab', opts?: { inviteToken?: string | null; returnUrl?: string | null }) => {
     const params = new URLSearchParams()
     if (opts?.returnUrl) params.set('return', opts.returnUrl)
     if (opts?.inviteToken) params.set('invite', opts.inviteToken)
@@ -1236,6 +1236,9 @@ export const api = {
     http<ApiConveneSession | null>(`/conversations/${encodeURIComponent(conversationId)}/convene`),
   getConveneTranscript: (sessionId: string) =>
     http<ApiConveneTranscript[]>(`/convene/${encodeURIComponent(sessionId)}/transcript`),
+  /** Browser sign-in providers this deployment has credentials for. Used to
+   *  avoid rendering a button that can only 503. */
+  authProviders: () => http<{ providers: string[] }>('/auth/providers'),
   getPreferences: () => http<Record<string, unknown>>('/me/preferences'),
   putPreferences: (prefs: Record<string, unknown>) =>
     http<{ ok: boolean }>('/me/preferences', { method: 'PUT', body: JSON.stringify(prefs) }),

--- a/src/components/AuthScreen.tsx
+++ b/src/components/AuthScreen.tsx
@@ -33,13 +33,25 @@ const PRESET_LABEL_KEY: Record<string, MessageKey> = {
 
 export function AuthScreen() {
   const t = useT()
-  const [busy, setBusy] = useState<'google' | 'github' | 'apple' | null>(null)
+  const [busy, setBusy] = useState<'google' | 'github' | 'gitlab' | 'apple' | null>(null)
+  // GitLab is opt-in and can point at a self-managed instance, so most
+  // deployments have no credentials for it — ask the server rather than
+  // offering a button that can only 503.
+  const [gitlabEnabled, setGitlabEnabled] = useState(false)
   const [err, setErr] = useState<string | null>(null)
   const [picker, setPicker] = useState(false)
 
   // AuthGate strips a successful fragment after consuming it. A failure
   // fragment looks like `#token=&companyId=&error=...` — surface that
   // so the user knows the previous attempt didn't take.
+  useEffect(() => {
+    let cancelled = false
+    void api.authProviders()
+      .then((r) => { if (!cancelled) setGitlabEnabled(r.providers.includes('gitlab')) })
+      .catch(() => { /* older server or offline — leave the button hidden */ })
+    return () => { cancelled = true }
+  }, [])
+
   useEffect(() => {
     const params = new URLSearchParams(location.hash.replace(/^#/, ''))
     const error = params.get('error')
@@ -93,7 +105,7 @@ export function AuthScreen() {
     }
   }
 
-  function go(provider: 'google' | 'github') {
+  function go(provider: 'google' | 'github' | 'gitlab') {
     setBusy(provider); setErr(null)
     if (isElectron && window.cumora?.auth) {
       // Open the user's real browser (Safari / Chrome) so they see the
@@ -223,6 +235,17 @@ export function AuthScreen() {
             <GitHubMark />
             {busy === 'github' ? t('auth.redirecting') : t('auth.continueWithGithub')}
           </button>
+          {gitlabEnabled && (
+            <button
+              type="button"
+              onClick={() => go('gitlab')}
+              disabled={busy !== null}
+              className="h-11 rounded-[10px] bg-[#fc6d26] hover:bg-[#e24329] text-white transition-colors flex items-center justify-center gap-3 text-[14px] font-medium disabled:opacity-60"
+            >
+              <GitLabMark />
+              {busy === 'gitlab' ? t('auth.redirecting') : t('auth.continueWithGitlab')}
+            </button>
+          )}
         </div>
         {err && (
           <div className="text-[12px] text-red-600 text-center max-w-full break-words">
@@ -325,6 +348,14 @@ function GoogleMark() {
       <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"/>
       <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"/>
       <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"/>
+    </svg>
+  )
+}
+
+function GitLabMark() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M12 21.4 8.7 11.2H15.3L12 21.4zM3.6 11.2 2.3 15.3a.9.9 0 0 0 .33 1L12 21.4 3.6 11.2zM3.6 11.2h5.1L6.5 4.4a.45.45 0 0 0-.86 0L3.6 11.2zM20.4 11.2l1.3 4.1a.9.9 0 0 1-.33 1L12 21.4l8.4-10.2zM20.4 11.2h-5.1l2.2-6.8a.45.45 0 0 1 .86 0l2.04 6.8z" />
     </svg>
   )
 }

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -62,6 +62,7 @@ export const en = {
   'auth.continueWithApple': 'Continue with Apple',
   'auth.continueWithGoogle': 'Continue with Google',
   'auth.continueWithGithub': 'Continue with GitHub',
+  'auth.continueWithGitlab': 'Continue with GitLab',
   'auth.signInToAccept': 'Sign in to accept this invite',
   // Local email + password — self-hosted servers with no OAuth provider.
   // ─── web landing (app.cumora.ai) ──────────────────────────────────

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -68,6 +68,7 @@ export const zhCN: Partial<Record<keyof typeof en, string>> = {
   'auth.continueWithApple': '使用 Apple 继续',
   'auth.continueWithGoogle': '使用 Google 继续',
   'auth.continueWithGithub': '使用 GitHub 继续',
+  'auth.continueWithGitlab': '使用 GitLab 继续',
   'auth.signInToAccept': '登录以接受这份邀请',
   // ─── 网页落地页（app.cumora.ai）───────────────────────────────────
   'web.desktopApp': 'Cumora 是一个桌面应用',

--- a/src/web/WebShell.tsx
+++ b/src/web/WebShell.tsx
@@ -109,9 +109,20 @@ function WebHandoff() {
  *  or as a suspended verdict (→ SuspendedScreen, also App.tsx). */
 function WebLanding() {
   const t = useT()
-  const [busy, setBusy] = useState<'google' | 'github' | null>(null)
+  const [busy, setBusy] = useState<'google' | 'github' | 'gitlab' | null>(null)
   const [err, setErr] = useState<string | null>(null)
+  // Same gating as AuthScreen: GitLab is opt-in, so only offer it when this
+  // deployment actually has credentials for it.
+  const [gitlabEnabled, setGitlabEnabled] = useState(false)
   const approvedEntry = new URLSearchParams(location.search).has('approved')
+
+  useEffect(() => {
+    let cancelled = false
+    void api.authProviders()
+      .then((r) => { if (!cancelled) setGitlabEnabled(r.providers.includes('gitlab')) })
+      .catch(() => { /* older server or offline — leave the button hidden */ })
+    return () => { cancelled = true }
+  }, [])
 
   useEffect(() => {
     const params = new URLSearchParams(location.hash.replace(/^#/, ''))
@@ -119,7 +130,7 @@ function WebLanding() {
     if (error) setErr(decodeURIComponent(error))
   }, [])
 
-  const go = (provider: 'google' | 'github') => {
+  const go = (provider: 'google' | 'github' | 'gitlab') => {
     setBusy(provider); setErr(null)
     const returnUrl = `${location.origin}${location.pathname}`
     location.assign(api.authStartUrl(provider, { returnUrl }))
@@ -157,6 +168,17 @@ function WebLanding() {
             <GitHubMark />
             {busy === 'github' ? t('auth.redirecting') : t('auth.continueWithGithub')}
           </button>
+          {gitlabEnabled && (
+            <button
+              type="button"
+              onClick={() => go('gitlab')}
+              disabled={busy !== null}
+              className="h-11 rounded-[10px] bg-[#fc6d26] hover:bg-[#e24329] text-white transition-colors flex items-center justify-center gap-3 text-[14px] disabled:opacity-60"
+            >
+              <GitLabMark />
+              {busy === 'gitlab' ? t('auth.redirecting') : t('auth.continueWithGitlab')}
+            </button>
+          )}
         </div>
         {err && (
           <div className="text-[12px] text-red-600 text-center max-w-full break-words">
@@ -197,6 +219,14 @@ function GoogleMark() {
       <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"/>
       <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"/>
       <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"/>
+    </svg>
+  )
+}
+
+function GitLabMark() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M12 21.4 8.7 11.2H15.3L12 21.4zM3.6 11.2 2.3 15.3a.9.9 0 0 0 .33 1L12 21.4 3.6 11.2zM3.6 11.2h5.1L6.5 4.4a.45.45 0 0 0-.86 0L3.6 11.2zM20.4 11.2l1.3 4.1a.9.9 0 0 1-.33 1L12 21.4l8.4-10.2zM20.4 11.2h-5.1l2.2-6.8a.45.45 0 0 1 .86 0l2.04 6.8z" />
     </svg>
   )
 }


### PR DESCRIPTION
Closes #65.

## Shape

The OAuth layer was already provider-shaped — authorize / token / userinfo URLs, scope, credentials — so GitLab mostly slots in. Endpoints derive from `GITLAB_BASE_URL` (default `https://gitlab.com`), so **a self-managed instance works through the same path**, which is the part @yuluo-yx asked about.

Scope is `read_user` — the narrowest one that grants the `/api/v4/user` read. `api` would hand us write access to the user's repositories for no reason.

## The part that needed care: the email

`NormalizedProfile.email` feeds `findOrCreateUserByProfile`'s cross-provider auto-link, which attaches a new identity to an **existing** account purely by matching the address. So the address has to be one the provider *attests to*, not merely one it reports — otherwise adding a provider adds an account-takeover primitive.

The existing providers both gate on that (`email_verified` for Google, the address being `verified` for GitHub). GitLab's equivalent is `confirmed_at`, which it sets when the user completes email confirmation. The profile is refused unless all three hold:

| check | why |
| --- | --- |
| `state === 'active'` | a blocked or deactivated user can still be holding a live token |
| `confirmed_at` is set | a self-managed instance can disable user confirmation entirely, leaving this null on an otherwise ordinary account |
| an email is present | `read_user` does not guarantee one is exposed |

Each refuses the login rather than guessing. The failure direction that matters here is "refuse", never "link to someone else's account".

`GITLAB_BASE_URL` is documented in `.env.example` as being trusted to attest its users' emails — the same trust Google and GitHub get — since pointing it at an instance you don't control would hand that instance the ability to claim accounts by email.

## One cleanup that prevents a half-added provider

The three `provider !== 'google' && provider !== 'github'` gates become one exported `WEB_OAUTH_PROVIDERS` set. Those chains have to be found and widened by hand for every new provider, and a missed one fails as a **404 on a button the UI already renders** — the same silent shape that made the Grok engine unreachable in #42. Apple stays out of the set deliberately: it signs in natively and never touches these routes.

## Why the button is gated

GitLab is opt-in, so most deployments will have no credentials for it. Rendering the button unconditionally — the way Google and GitHub are rendered — would show everyone a button that can only 503. So there's a small `GET /auth/providers` returning what this deployment actually has credentials for, and the GitLab button renders off that. **Google and GitHub rendering is unchanged**; I didn't refactor them.

A locale key is added in both `en` and `zh-CN` so the new button isn't the one untranslated string on the sign-in screen.

## Tests

7 cases in `server/src/__tests__/oauth-gitlab-profile.test.ts`, mirroring `oauth-github-email.test.ts` (mocked `fetch`, pool/redis torn down in `after`). They cover the happy path, lowercasing, the self-managed base URL, the username fallback — and every refusal path individually, since those are the security-relevant ones.

## What I could not verify

**I have no GitLab OAuth app and no self-managed instance, so the live redirect flow is untested.** What I did instead:

- read GitLab's [Users API](https://docs.gitlab.com/api/users/) docs to confirm `GET /user` returns `id`, `username`, `name`, `email`, `state`, `confirmed_at`, `avatar_url`
- read the [OAuth 2.0](https://docs.gitlab.com/api/oauth2/) and [OAuth provider](https://docs.gitlab.com/integration/oauth_provider/) docs to confirm the `/oauth/authorize` + `/oauth/token` paths and that `read_user` is the scope granting the `/user` read
- unit-tested the normalization against mocked responses

So the field contract rests on documentation, not on a round trip. Worth registering an app against gitlab.com once before merging — the callback URL is `<CUMORA_PUBLIC_ORIGIN>/api/auth/callback/gitlab`.

## Checks

`npm run lint`, `npm run typecheck`, `npm run server:typecheck` pass.

My sandbox has no Postgres/Redis, so the new test lands in the same env-dependent bucket as its sibling `oauth-github-email.test.ts` — both fail on a bare run, both pass with env present (10/10 together).
