### PR TITLE
feat(agents): tell an agent when a message @-mentions it by name

### DIFF
--- a/server/src/__tests__/scheduler-mentions.test.ts
+++ b/server/src/__tests__/scheduler-mentions.test.ts
@@ -1,0 +1,73 @@
+/**
+ * `mentionedAgentIds` — the deterministic "this message names you" signal.
+ *
+ * It reuses the exact-token rule `shouldDeliverToMutedAgent` already uses, so
+ * "addressed to" means one thing everywhere. It is a PROMPT signal only: the
+ * recipient set is unchanged, deliberately. Narrowing the fan-out to mentioned
+ * agents is unsafe — a mentioned BYOA agent with a closed laptop has its wake
+ * deferred while the peers who would have covered were never woken, and an
+ * excluded peer who posts anything else auto-acks its read cursor to NOW
+ * (`cumora reply`), putting the human's message permanently behind the cursor.
+ *
+ * Run: node --import tsx --test server/src/__tests__/scheduler-mentions.test.ts
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mentionedAgentIds, shouldDeliverToMutedAgent } from '../agents/scheduler.js'
+
+const MEMBERS = ['nova-12', 'iris-9', 'atlas-7']
+
+test('an exact mention selects that agent', () => {
+  assert.deepEqual(mentionedAgentIds('please check this @nova-12', MEMBERS), ['nova-12'])
+})
+
+test('mentions are case-insensitive', () => {
+  assert.deepEqual(mentionedAgentIds('ping @NOVA-12, please', MEMBERS), ['nova-12'])
+})
+
+test('several mentions all come back, in member order', () => {
+  assert.deepEqual(mentionedAgentIds('@atlas-7 and @nova-12 pair on this', MEMBERS), ['nova-12', 'atlas-7'])
+})
+
+test('an unmentioned room yields nobody', () => {
+  assert.deepEqual(mentionedAgentIds('ordinary room chatter', MEMBERS), [])
+})
+
+test('a longer id is not matched by a shorter one', () => {
+  // The trap `shouldDeliverToMutedAgent` already guards: @nova-123 must not
+  // read as a mention of nova-12.
+  assert.deepEqual(mentionedAgentIds('this is for @nova-123', MEMBERS), [])
+})
+
+test('an email address is not a mention', () => {
+  assert.deepEqual(mentionedAgentIds('mail nova@nova-12 about it', MEMBERS), [])
+})
+
+test('@all is not an individual mention', () => {
+  // @all is a broadcast, handled separately in the prompt; it must not read as
+  // naming any particular agent.
+  assert.deepEqual(mentionedAgentIds('@all standup in 5', MEMBERS), [])
+})
+
+test('an empty body mentions nobody', () => {
+  assert.deepEqual(mentionedAgentIds('', MEMBERS), [])
+})
+
+test('it agrees with the muted-delivery rule on the same inputs', () => {
+  // One definition of "addressed to me" across delivery and prompting — if
+  // these ever disagree, an agent could be told a message is theirs by one rule
+  // and denied it by the other.
+  for (const body of [
+    'please check this @nova-12',
+    'ping @NOVA-12, please',
+    'this is for @nova-123',
+    'mail nova@nova-12 about it',
+    'ordinary room chatter',
+  ]) {
+    assert.equal(
+      mentionedAgentIds(body, ['nova-12']).length > 0,
+      shouldDeliverToMutedAgent({ agentId: 'nova-12', conversationKind: 'group', body, quotedAuthorId: null }),
+      `disagreement on: ${body}`,
+    )
+  }
+})

--- a/server/src/__tests__/scheduler-mentions.test.ts
+++ b/server/src/__tests__/scheduler-mentions.test.ts
@@ -11,9 +11,21 @@
  *
  * Run: node --import tsx --test server/src/__tests__/scheduler-mentions.test.ts
  */
-import { test } from 'node:test'
+import { after, test } from 'node:test'
 import assert from 'node:assert/strict'
 import { mentionedAgentIds, shouldDeliverToMutedAgent } from '../agents/scheduler.js'
+import { pool } from '../db/pool.js'
+
+after(async () => {
+  // scheduler.ts transitively imports redis.ts which opens connections — without
+  // this the runner never exits and CI cancels the job rather than failing it.
+  try { await pool.end() } catch { /* ignore */ }
+  try {
+    const { redis, sub } = await import('../redis.js')
+    redis.disconnect()
+    sub.disconnect()
+  } catch { /* ignore */ }
+})
 
 const MEMBERS = ['nova-12', 'iris-9', 'atlas-7']
 

--- a/server/src/agents/scheduler.ts
+++ b/server/src/agents/scheduler.ts
@@ -635,6 +635,27 @@ export function shouldDeliverToMutedAgent(args: {
   return mention.test(args.body)
 }
 
+/** Which of `agentMemberIds` this message explicitly @-mentions.
+ *
+ *  Same token rule as {@link shouldDeliverToMutedAgent} — an exact `@id`, not a
+ *  prefix and not an email — so "addressed to" means one thing everywhere.
+ *
+ *  This is a PROMPT signal, never a delivery decision. Narrowing the wake to
+ *  the mentioned agents looks tempting and is not safe: a mentioned BYOA agent
+ *  whose laptop is closed has its wake deferred, and the peers who would have
+ *  covered were never woken — so the room stays silent. Worse, an excluded peer
+ *  who posts anything else in that room auto-acks their read cursor to NOW
+ *  (`cumora reply`), which puts the human's message permanently BEHIND the
+ *  cursor: not deferred, gone. So every member still wakes, and the mention only
+ *  tells them who it was for.
+ *
+ *  Exported for tests. */
+export function mentionedAgentIds(body: string, agentMemberIds: readonly string[]): string[] {
+  if (!body) return []
+  return agentMemberIds.filter((id) =>
+    new RegExp(`(^|[^\\w@])@${escapeRegex(id)}(?![\\w-])`, 'i').test(body))
+}
+
 /** Exported for tests — pulled out of `wake` so the wake-policy is
  *  easy to assert on. Fire-and-forget per recipient. */
 function renderTriageNote(verdict: InboxTriageVerdict): string {

--- a/server/src/agents/turn.ts
+++ b/server/src/agents/turn.ts
@@ -115,6 +115,7 @@ interface InboxRow {
 }
 
 import { classifyWake } from './turn-wake.js'
+import { mentionedAgentIds } from './scheduler.js'
 
 export interface AgentTurnOptions {
   /** Why this turn was started. Message-driven turns remain the default. */
@@ -631,6 +632,18 @@ function renderContext(
       // quote target keep treating it as a general group message and
       // chime in unprompted; this puts the address signal in the
       // glance-zone of the wake prompt.
+      // An exact @-mention of the viewer is the strongest "this one is yours"
+      // signal a room carries, and it was only ever visible as raw text inside
+      // the body. Surface it in the same glance-zone as the quote tag below.
+      //
+      // Only the POSITIVE case is tagged. The mirror ("addressed to X — not
+      // you") would need the conversation's member list to tell a real
+      // participant from a stray @token, and the two errors are not
+      // symmetric: a wrong "not you" can silence the whole room, while a wrong
+      // "YOU" only costs one extra reply.
+      if (viewerAgentId && !m.is_self && mentionedAgentIds(m.body ?? '', [viewerAgentId]).length > 0) {
+        line += `  ↦ @-mentioned YOU`
+      }
       if (m.quoted_message_id && m.quoted && !m.is_self) {
         if (viewerAgentId && m.quoted.authorId === viewerAgentId) {
           line += `  ↦ addressed to YOU (quote-reply)`


### PR DESCRIPTION
Toward #70 — but **not** the routing change it proposes. I went looking to implement that and found it isn't safe; the analysis is below and I've posted it on the issue. This PR ships the one piece that survived review.

## What this does

A quote-reply already gets an address tag in the wake prompt, with a comment explaining why:

> in groups, a quote-reply is a soft 1:1 address. Agents who aren't the quote target keep treating it as a general group message and chime in unprompted; this puts the address signal in the glance-zone of the wake prompt.

```
↦ addressed to Nova (quote-reply — not you; stay quiet unless your angle differs)
```

An explicit `@`-mention is the same kind of address and had **no tag at all** — it was visible only as raw text inside the message body. This adds `↦ @-mentioned YOU` in the same glance-zone.

`mentionedAgentIds` reuses the exact-token rule `shouldDeliverToMutedAgent` already uses (no prefix match, no email match), so "addressed to" means one thing in delivery and in prompting. One test asserts the two agree on the same inputs, so they can't drift.

**Only the positive case is tagged.** The mirror — "addressed to X, not you" — needs the conversation's member list to tell a real participant from a stray `@token`, and the two errors are not symmetric: a wrong "not you" can silence the whole room, a wrong "YOU" costs one extra reply. Deferred rather than guessed.

**The recipient set is unchanged.**

## Why I did not narrow the fan-out

I first confirmed the waste is real: `scheduler.ts` selects recipients purely by membership, and the message body reaches that loop at exactly one point — inside the muted-agent branch, which can only *add* a recipient back. So `@nova draft the launch email` in a 5-agent room wakes all four non-author agents identically, each paying an embedding call plus 1–2 full big-brain hops before deciding to stay silent.

Then I tried to break the obvious fix — wake only the mentioned agents — and it breaks two ways:

**1. A deferred wake has no backstop.** A mentioned BYOA agent whose operator's laptop is closed has its wake deferred at `scheduler.ts:367`. Every other agent was excluded by the mention gate. The room stays silent: no reply, no typing indicator, no `agent_runs` row — one `console.log` line is the only trace.

**2. Excluded peers don't "catch it later" — they can lose it permanently.** This is the part I had assumed my way past. `cumora reply` auto-acks the poster's cursor:

```ts
// Posting auto-acks me on this conversation (I clearly saw the messages I'm replying to)
INSERT INTO conversation_reads (user_id, conversation_id, last_read_at) VALUES ($1, $2, NOW())
  ON CONFLICT ... DO UPDATE SET last_read_at = NOW()
```

and unread is `ROW(mm.created_at, mm.id) > ROW(co.lr_at, co.lr_id)`. So a peer who was excluded from the wake, and who posts anything else in that room while mid-turn on an earlier message, jumps their cursor past the human's message. It is then **behind the cursor — not deferred, gone.**

There's also a correction to the issue's premise worth recording: it says triage "short-circuits human group messages to actionable=true" and that `responseMode` is produced but unconsumed. For human messages the triage model is **never called at all**, and `triage-core.ts` says that's deliberate — *"A HUMAN message is sacred — DM or group: NEVER gate it … strictly SAFER — a misbehaving gate can no longer drop a human on the floor."* So wiring `responseMode` up for this case means re-introducing a gate that was removed on purpose.

The "cheap yield before the big brain" variant fails for a different reason: at T=0 every agent evaluates byte-identical room state in which nobody has claimed anything yet, so they can all honestly conclude "someone should take this, and I have no evidence it's me" — and the room goes silent. The saving *is* the drop.

That's why this PR changes the prompt and not the routing: a wrong signal here is recoverable (the model can still speak), where a wrong routing decision is silent.

## Tests

9 cases in `server/src/__tests__/scheduler-mentions.test.ts`, including the traps the existing muted-delivery test already guards (`@nova-123` must not match `nova-12`, `nova@nova-12` is not a mention), that `@all` is not an individual mention, and the cross-check against `shouldDeliverToMutedAgent`.

## Checks

`npm run lint`, `npm run typecheck`, `npm run server:typecheck` pass. I also verified there's no runtime import cycle: `scheduler.ts` imports `turn.ts` type-only, so the new value import from `turn.ts` resolves cleanly (checked by loading both modules in order).

No Postgres/Redis in my sandbox, so the new test sits in the same env-dependent bucket as its neighbours; it passes with env present.
