### PR TITLE
fix(desktop): preserve Unicode CLI paths on Windows

### DIFF
--- a/electron/cli-path.cjs
+++ b/electron/cli-path.cjs
@@ -1,0 +1,31 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+const DEFAULT_WINDOWS_PATHEXT = '.COM;.EXE;.BAT;.CMD'
+
+/** Resolve a command without parsing `where.exe` output. `where` writes paths
+ *  in the active Windows code page, which corrupts non-ASCII directories when
+ *  Electron decodes stdout as UTF-8. Node's filesystem APIs preserve Unicode. */
+async function findWindowsCommand(bin, envPath, pathExt = process.env.PATHEXT ?? DEFAULT_WINDOWS_PATHEXT) {
+  const extensions = (pathExt || DEFAULT_WINDOWS_PATHEXT)
+    .split(';')
+    .map((ext) => ext.trim())
+    .filter(Boolean)
+    .map((ext) => ext.startsWith('.') ? ext : `.${ext}`)
+  const names = path.extname(bin) ? [bin] : [bin, ...extensions.map((ext) => `${bin}${ext}`)]
+
+  for (const rawDir of envPath.split(path.delimiter)) {
+    const trimmed = rawDir.trim()
+    const dir = trimmed.startsWith('"') && trimmed.endsWith('"') ? trimmed.slice(1, -1) : trimmed
+    if (!dir) continue
+    for (const name of names) {
+      const candidate = path.join(dir, name)
+      try {
+        if ((await fs.promises.stat(candidate)).isFile()) return candidate
+      } catch { /* next candidate */ }
+    }
+  }
+  return null
+}
+
+module.exports = { findWindowsCommand }

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -8,6 +8,7 @@ const http = require('node:http')
 const crypto = require('node:crypto')
 const { pathToFileURL } = require('node:url')
 const autoUpdater = require('./autoUpdater.cjs')
+const { findWindowsCommand } = require('./cli-path.cjs')
 
 const isDev = !app.isPackaged
 const DEV_URL = process.env.ELECTRON_RENDERER_URL || 'http://localhost:5180'
@@ -1439,9 +1440,13 @@ function spawnText(cmd, args, envPath) {
 }
 
 async function resolveCliPath(bin, envPath) {
-  const whichCmd = process.platform === 'win32' ? 'where' : 'which'
-  const fromWhich = (await spawnText(whichCmd, [bin], envPath)).split(/\r?\n/)[0]?.trim()
-  if (fromWhich) return fromWhich
+  if (process.platform === 'win32') {
+    const fromPath = await findWindowsCommand(bin, envPath ?? process.env.PATH ?? '')
+    if (fromPath) return fromPath
+  } else {
+    const fromWhich = (await spawnText('which', [bin], envPath)).split(/\r?\n/)[0]?.trim()
+    if (fromWhich) return fromWhich
+  }
   const home = os.homedir()
   const names = process.platform === 'win32' ? [bin, `${bin}.cmd`, `${bin}.exe`] : [bin]
   const dirs = [

--- a/server/src/__tests__/electron-cli-path.test.ts
+++ b/server/src/__tests__/electron-cli-path.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { delimiter, join } from 'node:path'
+import { test } from 'node:test'
+
+const require = createRequire(import.meta.url)
+const { findWindowsCommand } = require('../../../electron/cli-path.cjs') as {
+  findWindowsCommand: (bin: string, envPath: string, pathExt?: string) => Promise<string | null>
+}
+
+test('Windows CLI lookup preserves a Unicode PATH entry', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'cumora-cli-path-'))
+  try {
+    const unicodeDir = join(root, '工具目录')
+    const otherDir = join(root, 'other')
+    await mkdir(unicodeDir)
+    await mkdir(otherDir)
+    const command = join(unicodeDir, 'qwen.CMD')
+    await writeFile(command, '@echo off\r\n')
+
+    const envPath = [otherDir, `"${unicodeDir}"`].join(delimiter)
+    assert.equal(await findWindowsCommand('qwen', envPath, '.CMD;.EXE'), command)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary

- stop parsing localized `where.exe` output when detecting local CLIs on Windows
- resolve commands directly from `PATH` and `PATHEXT` with Node filesystem APIs, preserving Unicode directory names
- add regression coverage for a quoted, non-ASCII PATH entry

## Problem

Local desktop CLI discovery was introduced by #76 in commit [816180d](https://github.com/yetone/cumora/commit/816180d3751fbfed88cfa42c4c8401d9a18133f2). On Windows it called `where <bin>` and decoded every stdout buffer with `Buffer.toString('utf8')`.

`where.exe` writes paths using the active Windows code page. On systems such as CP936/GBK, a CLI installed under a directory containing Chinese or other non-ASCII characters therefore reached the renderer with replacement characters (`��`). ASCII-only paths were unaffected, which is why some engines displayed correctly while others did not.

## Fix

For Windows only, command lookup now walks the inherited search path in order and checks the extensionless name plus configured `PATHEXT` candidates through `fs.stat`. Node's filesystem APIs operate on Unicode paths, so there is no locale-dependent subprocess output to decode.

macOS and Linux keep the existing `which` path unchanged.

## Preview
<img width="1356" height="529" alt="image" src="https://github.com/user-attachments/assets/af99ae01-ff66-439a-b27a-b83dc40fdd1b" />

fix #89 

## Tests

- `npm run typecheck`
- `npm run server:typecheck`
- `npm run lint`
- `node --import tsx --test server/src/__tests__/electron-cli-path.test.ts`
- `node --import tsx --test server/src/__tests__/electron-cli-path.test.ts server/src/__tests__/electron-renderer-url.test.ts`
