### PR TITLE
test(runtime): cover stale tenant token lifecycle

### DIFF
--- a/server/src/__integration__/_helpers.ts
+++ b/server/src/__integration__/_helpers.ts
@@ -66,6 +66,7 @@ const TABLES_TO_WIPE: readonly string[] = [
   'agent_log',
   'company_members',
   'participants',
+  'computers',
   'users',
   'companies',
 ]

--- a/server/src/__integration__/runtime-server.test.ts
+++ b/server/src/__integration__/runtime-server.test.ts
@@ -27,7 +27,8 @@ import assert from 'node:assert/strict'
 import { createServer, type Server } from 'node:http'
 import { randomUUID } from 'node:crypto'
 import { ensureSchemaOnce, resetAllTables, teardownAll } from './_helpers.js'
-import { signAgentToken } from '../agents/runtime/jwt.js'
+import { mintAgentRuntimeToken } from '../agents/computer/registry.js'
+import { signAgentToken, verifyAgentToken } from '../agents/runtime/jwt.js'
 import { pool } from '../db/pool.js'
 
 let server: Server
@@ -92,6 +93,26 @@ async function seedAgent(): Promise<{ agentId: string; companyId: string; token:
   )
   const token = signAgentToken({ agentId, companyId })
   return { agentId, companyId, token }
+}
+
+async function mintAssignedAgentRuntimeToken(args: {
+  agentId: string
+  companyId: string
+}): Promise<string> {
+  const computerId = `comp-${randomUUID().slice(0, 8)}`
+  await pool.query(
+    `INSERT INTO computers (id, company_id, name, kind, available_engines, status)
+       VALUES ($1, $2, $3, 'local', '["codex"]'::jsonb, 'online')`,
+    [computerId, args.companyId, `Computer ${computerId}`],
+  )
+  await pool.query(
+    `UPDATE participants SET computer_id = $1, engine = 'codex'
+      WHERE id = $2 AND company_id = $3`,
+    [computerId, args.agentId, args.companyId],
+  )
+  const minted = await mintAgentRuntimeToken({ computerId, agentId: args.agentId })
+  assert.ok(minted, 'the production BYOA path should mint a token for an assigned agent')
+  return minted.token
 }
 
 async function seedContextConversation(opts: {
@@ -208,25 +229,44 @@ test('[integration] runtime: /context enforces tenant and conversation membershi
   )
 })
 
-test('[integration] runtime: /context binds authorization to the JWT companyId', async () => {
-  const claimedTenant = await seedAgent()
-  const actualTenant = await seedAgent()
+test('[integration] runtime: /context rejects a stale production token after tenant reassignment', async () => {
+  const originalTenant = await seedAgent()
+  const currentTenant = await seedAgent()
+  const staleToken = await mintAssignedAgentRuntimeToken(originalTenant)
+
+  // Model a real stale-credential lifecycle without fabricating JWT claims:
+  // the BYOA path minted the token while the agent belonged to tenant A, then
+  // an administrative data migration moved that globally-unique agent id to
+  // tenant B. The old token remains cryptographically valid until it expires.
+  const moved = await pool.query(
+    `UPDATE participants
+        SET company_id = $1, computer_id = NULL, engine = NULL
+      WHERE id = $2 AND company_id = $3`,
+    [currentTenant.companyId, originalTenant.agentId, originalTenant.companyId],
+  )
+  assert.equal(moved.rowCount, 1)
+  const staleClaims = verifyAgentToken(staleToken)
+  assert.equal(staleClaims.sub, originalTenant.agentId)
+  assert.equal(staleClaims.companyId, originalTenant.companyId)
+
   const crossTenantId = await seedContextConversation({
-    companyId: actualTenant.companyId,
-    members: [actualTenant.agentId],
-    authorId: actualTenant.agentId,
-    body: 'mismatched-claim-private',
-  })
-  // Simulate a stale or incorrectly minted but validly signed token. The old
-  // query ignored companyId and authorized solely from sub + the target row,
-  // so it returned this conversation from actualTenant.
-  const mismatchedToken = signAgentToken({
-    agentId: actualTenant.agentId,
-    companyId: claimedTenant.companyId,
+    companyId: currentTenant.companyId,
+    members: [originalTenant.agentId, currentTenant.agentId],
+    authorId: currentTenant.agentId,
+    body: 'post-move-private',
   })
 
+  const { rows: currentAgentRows } = await pool.query<{ company_id: string }>(
+    `SELECT company_id FROM participants WHERE id = $1 AND kind = 'agent'`,
+    [originalTenant.agentId],
+  )
+  assert.deepEqual(currentAgentRows, [{ company_id: currentTenant.companyId }])
+
+  // The pre-fix query joined the requesting agent to the conversation's
+  // company instead of the JWT company. It therefore accepted this current
+  // tenant-B membership even though the still-valid token is pinned to A.
   const r = await call('/runtime/context', {
-    token: mismatchedToken,
+    token: staleToken,
     body: { conversationIds: [crossTenantId] },
   })
 


### PR DESCRIPTION
## Summary

- replace the fabricated mismatched-JWT setup with a stale credential lifecycle minted by the production BYOA token path
- move the globally unique agent identity from tenant A to tenant B after issuance, then prove the still-valid tenant-A token cannot read a valid tenant-B conversation
- clear seeded computers between integration cases

## Why

The current schema enforces globally unique agent IDs, so the earlier duplicate-ID premise cannot be constructed on the latest code. The previous regression instead called the low-level signer with mismatched claims. This version exercises a schema-valid state transition and the production minting function. The pre-fix context query would return the tenant-B row because it joined the requesting agent to the conversation company instead of the JWT company.

## Validation

- [x] npx biome lint server/src/__integration__/_helpers.ts server/src/__integration__/runtime-server.test.ts
- [x] npm run lint
- [x] npm run typecheck
- [x] npm run server:typecheck
- [x] npm run guard:big-brain
- [x] npm run guard:llm-tracked
- [x] GitHub Unit tests
- [x] GitHub Integration tests with Postgres and Redis services

## Local environment note

- npm test could not complete locally because this host lacks the required OPENAI_API_KEY and Redis service; GitHub Unit tests passed in the project service environment.
- npm run test:integration skipped locally because INTEGRATION_DATABASE_URL is not configured; GitHub Integration tests passed.