### PR TITLE
feat(agent-routing): wake only the named agents when a message is addressed

### DIFF
--- a/server/src/__tests__/agents-routing.test.ts
+++ b/server/src/__tests__/agents-routing.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Message-level routing (#70).
+ *
+ * Narrowing a wake is the one mistake that is SILENT: an agent that should have
+ * answered and was never woken leaves no reply, no typing indicator, and no
+ * agent_runs row. So these tests spend most of their weight on the paths that
+ * must NOT narrow, not on the happy one.
+ *
+ * Run: node --import tsx --test server/src/__tests__/agents-routing.test.ts
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { buildRouteRequest, parseRoute, recipientsForRoute } from '../agents/routing.js'
+
+const ROOM = ['nova-12', 'iris-9', 'atlas-7']
+
+// ── when the model is not even asked ─────────────────────────────────────────
+
+test('@all is never narrowed', () => {
+  const r = buildRouteRequest({ body: '@all standup in 5 @nova-12', conversationKind: 'group', candidates: ROOM, targets: ['nova-12'] })
+  assert.equal(r.mode, 'each')
+  assert.equal(r.instructions, undefined, 'a broadcast must not cost a model call')
+})
+
+test('a message that names nobody is never narrowed', () => {
+  // The important one: narrowing with no targets would wake no one at all.
+  const r = buildRouteRequest({ body: 'can someone take the Q3 deck?', conversationKind: 'group', candidates: ROOM, targets: [] })
+  assert.equal(r.mode, 'each')
+  assert.equal(r.instructions, undefined)
+})
+
+test('a DM is never narrowed', () => {
+  const r = buildRouteRequest({ body: 'hey @nova-12', conversationKind: 'direct', candidates: ['nova-12'], targets: ['nova-12'] })
+  assert.equal(r.mode, 'each')
+})
+
+test('naming the whole room costs no model call', () => {
+  const r = buildRouteRequest({ body: '@nova-12 @iris-9 @atlas-7 thoughts?', conversationKind: 'group', candidates: ROOM, targets: ROOM })
+  assert.equal(r.mode, 'each')
+  assert.equal(r.instructions, undefined, 'there is nothing to save')
+})
+
+test('a named subset is the only case that asks the model', () => {
+  const r = buildRouteRequest({ body: '@nova-12 draft the launch email', conversationKind: 'group', candidates: ROOM, targets: ['nova-12'] })
+  assert.equal(r.mode, undefined)
+  assert.match(r.instructions ?? '', /responseMode/)
+  assert.match(r.input ?? '', /nova-12/)
+  assert.match(r.input ?? '', /iris-9, atlas-7/, 'the model should see who else would be woken')
+})
+
+// ── parsing: anything unexpected means "change nothing" ───────────────────────
+
+test('an explicit me is honoured', () => {
+  assert.equal(parseRoute('{"responseMode": "me"}'), 'me')
+})
+
+test('each, unknown modes, junk and empty all read as each', () => {
+  for (const raw of [
+    '{"responseMode": "each"}',
+    '{"responseMode": "one-of-us"}',   // step two, not wired — must not narrow yet
+    '{"responseMode": "nonsense"}',
+    'the model wrote prose instead',
+    '',
+  ]) {
+    assert.equal(parseRoute(raw), 'each', `should not narrow on: ${JSON.stringify(raw)}`)
+  }
+})
+
+test('me is found inside a fenced or chatty completion', () => {
+  assert.equal(parseRoute('```json\n{"responseMode": "me", "why": "direct request"}\n```'), 'me')
+})
+
+// ── the narrowing rule itself ────────────────────────────────────────────────
+
+test('me narrows to the named agents', () => {
+  assert.deepEqual(recipientsForRoute('me', ROOM, ['nova-12']), ['nova-12'])
+})
+
+test('each leaves the room untouched', () => {
+  assert.deepEqual(recipientsForRoute('each', ROOM, ['nova-12']), ROOM)
+})
+
+test('a target who is not a candidate never shrinks the room to nothing', () => {
+  // Named someone who is muted out, departed, or is the author themselves.
+  assert.deepEqual(recipientsForRoute('me', ROOM, ['someone-else']), ROOM)
+})
+
+test('only the candidate targets survive when some are not in the room', () => {
+  assert.deepEqual(recipientsForRoute('me', ROOM, ['nova-12', 'ghost-1']), ['nova-12'])
+})
+
+test('one-of-us does not narrow yet', () => {
+  // Step two in the issue; wiring it needs a lease, so it must be inert here.
+  assert.deepEqual(recipientsForRoute('one-of-us', ROOM, ['nova-12']), ROOM)
+})

--- a/server/src/__tests__/engine-stdin-safety.test.ts
+++ b/server/src/__tests__/engine-stdin-safety.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Guard: no raw `child.stdin.write()` in the engine adapters.
+ *
+ * A failed pipe write — EPIPE, when the engine died or was killed mid-write —
+ * is delivered ASYNCHRONOUSLY as an 'error' event on the stdin stream
+ * (`afterWriteDispatched`, a tick later). The try/catch that used to wrap every
+ * one of these writes had already returned by then and could not catch it, and
+ * with no listener on the stream Node turns it into an uncaught exception.
+ *
+ * It surfaced as a flaky `write EPIPE` in PiAdapter.probeWake on CI — but every
+ * adapter had the same hole, so this pins the whole file rather than that one
+ * call site.
+ *
+ * Run: node --import tsx --test server/src/__tests__/engine-stdin-safety.test.ts
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { PassThrough } from 'node:stream'
+
+const ENGINE = join(dirname(fileURLToPath(import.meta.url)), '..', 'agents', 'computer', 'engine.ts')
+
+/** Lines that write to a child's stdin directly, ignoring comments.
+ *
+ *  `writeStdin` itself is the one legitimate writer — it is the helper that
+ *  attaches the listener first — so its body is excluded by slicing it out
+ *  rather than by a broad pattern that could also hide a real offender. */
+function rawStdinWrites(source: string): string[] {
+  const start = source.indexOf('function writeStdin(')
+  let body = source
+  if (start >= 0) {
+    const end = source.indexOf('\n}', start)
+    body = source.slice(0, start) + (end >= 0 ? source.slice(end) : '')
+  }
+  return body.split('\n')
+    .map((l) => l.trim())
+    .filter((l) => !l.startsWith('//') && !l.startsWith('*'))
+    .filter((l) => /stdin[?!]?\.write\s*\(/.test(l))
+}
+
+test('every engine stdin write goes through the safe helper', () => {
+  const offenders = rawStdinWrites(readFileSync(ENGINE, 'utf8'))
+  assert.deepEqual(
+    offenders, [],
+    '\nA raw stdin write cannot be protected by try/catch — EPIPE arrives a tick\n' +
+    'later as a stream error and, unlistened, becomes an uncaught exception.\n' +
+    'Use writeStdin() instead:\n' + offenders.map((l) => `  ${l}`).join('\n'),
+  )
+})
+
+test('the matcher would catch a raw write', () => {
+  // Keeps the guard above from silently becoming a no-op.
+  assert.equal(rawStdinWrites('  child.stdin?.write("x")').length, 1)
+  assert.equal(rawStdinWrites('  this.child.stdin!.write(msg)').length, 1)
+  assert.equal(rawStdinWrites('  // child.stdin?.write("x") — explained in prose').length, 0)
+})
+
+test('an async stream write error escapes try/catch but not a listener', () => {
+  // The mechanism itself, so the reason for the guard is executable and not
+  // just an assertion in a comment.
+  return new Promise<void>((resolve, reject) => {
+    const stream = new PassThrough()
+    let caughtByTryCatch = false
+    let caughtByListener = false
+    stream.on('error', () => { caughtByListener = true })
+    try {
+      stream.write('x')
+      setImmediate(() => stream.emit('error', Object.assign(new Error('write EPIPE'), { code: 'EPIPE' })))
+    } catch { caughtByTryCatch = true }
+    setTimeout(() => {
+      try {
+        assert.equal(caughtByTryCatch, false, 'the try/catch cannot see an error delivered on a later tick')
+        assert.equal(caughtByListener, true, 'only a stream listener sees it')
+        resolve()
+      } catch (e) { reject(e) }
+    }, 50)
+  })
+})

--- a/server/src/agents/computer/engine.ts
+++ b/server/src/agents/computer/engine.ts
@@ -426,6 +426,39 @@ function failurePreview(args: {
   return detail ? `${prefix}\n${detail}`.slice(0, MAX_FAILURE_CHARS) : prefix
 }
 
+/** Write to an engine's stdin without letting a dead pipe crash the process.
+ *
+ *  Every stdin write in this file was wrapped in a try/catch whose comment said
+ *  the child's own error/close path would report the failure. That is not what
+ *  happens. A failed pipe write — EPIPE, when the engine died or was killed
+ *  mid-write — is delivered ASYNCHRONOUSLY as an 'error' event on the stdin
+ *  stream (`afterWriteDispatched`, a tick later), so the try/catch has already
+ *  returned and cannot catch it. With no listener on the stream, Node turns it
+ *  into an uncaught exception. It surfaced as a flaky `write EPIPE` failure in
+ *  PiAdapter.probeWake on CI, but every adapter had the same hole.
+ *
+ *  A dead engine is ordinary: the operator quit the CLI, a turn was aborted,
+ *  doctor tore its probe down. The child's own 'error'/'close' handlers already
+ *  report it, so the stream error is noise — it just must not be UNHANDLED.
+ *
+ *  Returns false when the write could not even be attempted, so callers that
+ *  care can bail; the ones that don't already fall through to their close path. */
+function writeStdin(child: ChildProcess, text: string, opts: { end?: boolean } = {}): boolean {
+  const stdin = child.stdin
+  if (!stdin) return false
+  // Attach once per stream — repeated writes must not stack listeners.
+  if (stdin.listenerCount('error') === 0) {
+    stdin.on('error', () => { /* reported by the child's own close/error path */ })
+  }
+  try {
+    stdin.write(text)
+    if (opts.end) stdin.end()
+    return true
+  } catch {
+    return false
+  }
+}
+
 function spawnEngine(
   bin: string,
   args: string[],
@@ -439,7 +472,7 @@ function spawnEngine(
       shell: spawnOpts.shell ?? false,
     })
     if (spawnOpts.stdinText != null) {
-      try { child.stdin?.write(spawnOpts.stdinText); child.stdin?.end() } catch { /* the 'error' handler resolves */ }
+      writeStdin(child, spawnOpts.stdinText, { end: true })
     }
     const onAbort = (): void => { child.kill('SIGTERM') }
     signal.addEventListener('abort', onAbort, { once: true })
@@ -563,7 +596,7 @@ function spawnCapture(
       shell: shell ?? false,
     })
     if (stdinText != null) {
-      try { child.stdin?.write(stdinText); child.stdin?.end() } catch { /* the 'error' handler resolves */ }
+      writeStdin(child, stdinText, { end: true })
     }
     const onAbort = (): void => { child.kill('SIGTERM') }
     signal.addEventListener('abort', onAbort, { once: true })
@@ -718,10 +751,8 @@ class ClaudeSession implements EngineSession {
         this.pendingTimer.unref?.()
       }
       const msg = JSON.stringify({ type: 'user', message: { role: 'user', content: [{ type: 'text', text: stripLoneSurrogates(prompt) }] } }) + '\n'
-      try {
-        this.child.stdin!.write(msg)
-      } catch (err) {
-        this.settle({ exitCode: 1, error: `failed to write turn to engine: ${err instanceof Error ? err.message : String(err)}`, sessionId: this.sid })
+      if (!writeStdin(this.child, msg)) {
+        this.settle({ exitCode: 1, error: 'failed to write turn to engine (stdin closed)', sessionId: this.sid })
       }
     })
   }
@@ -744,9 +775,7 @@ class ClaudeSession implements EngineSession {
     if (!this.pending || !this.alive) return
     while (this.steerQueue.length > 0) {
       const text = this.steerQueue.shift()!
-      try {
-        this.child.stdin!.write(JSON.stringify({ type: 'user', message: { role: 'user', content: [{ type: 'text', text: stripLoneSurrogates(text) }] } }) + '\n')
-      } catch { break }
+      if (!writeStdin(this.child, JSON.stringify({ type: 'user', message: { role: 'user', content: [{ type: 'text', text: stripLoneSurrogates(text) }] } }) + '\n')) break
     }
   }
 
@@ -1137,10 +1166,8 @@ class CodexSession implements EngineSession {
 
   steer(text: string): void {
     if (!this.alive || !text.trim() || !this.threadId || !this.activeTurnId || this.steerGate) return
-    try {
-      this.child.stdin!.write(JSON.stringify({ jsonrpc: '2.0', id: this.nextId(), method: 'turn/steer',
-        params: { threadId: this.threadId, expectedTurnId: this.activeTurnId, input: [{ type: 'text', text: stripLoneSurrogates(text) }] } }) + '\n')
-    } catch { /* best-effort */ }
+    writeStdin(this.child, JSON.stringify({ jsonrpc: '2.0', id: this.nextId(), method: 'turn/steer',
+      params: { threadId: this.threadId, expectedTurnId: this.activeTurnId, input: [{ type: 'text', text: stripLoneSurrogates(text) }] } }) + '\n')
   }
 
   stop(): void {
@@ -1152,11 +1179,11 @@ class CodexSession implements EngineSession {
   private nextId(): number { this.reqId += 1; return this.reqId }
   private req(method: string, params: Record<string, unknown>): number {
     const id = this.nextId()
-    try { this.child.stdin?.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n') } catch { /* die() handles */ }
+    writeStdin(this.child, JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n')
     return id
   }
   private notify(method: string, params: Record<string, unknown>): void {
-    try { this.child.stdin?.write(JSON.stringify({ jsonrpc: '2.0', method, params }) + '\n') } catch { /* die() handles */ }
+    writeStdin(this.child, JSON.stringify({ jsonrpc: '2.0', method, params }) + '\n')
   }
   private startTurn(prompt: string): void {
     if (this.threadId) {
@@ -1413,7 +1440,7 @@ class CodexAdapter implements EngineAdapter {
       let initialized = false
       let threadAcked = false
       const writeRpc = (msg: object) => {
-        try { child.stdin?.write(JSON.stringify(msg) + '\n') } catch { /* die path handles */ }
+        writeStdin(child, JSON.stringify(msg) + '\n')
       }
       // Kick off the handshake once the process is up. spawn() emits stdout
       // 'data' lazily — that's the point at which we know the child is alive
@@ -1615,7 +1642,7 @@ class GrokSession implements EngineSession {
   private nextId(): number { this.reqId += 1; return this.reqId }
   private req(method: string, params: Record<string, unknown>): number {
     const id = this.nextId()
-    try { this.child.stdin?.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n') } catch { /* die() */ }
+    writeStdin(this.child, JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n')
     return id
   }
 
@@ -1850,7 +1877,7 @@ class GrokAdapter implements EngineAdapter {
       const sessionId = 2
       let initialized = false
       const writeRpc = (msg: object) => {
-        try { child.stdin?.write(JSON.stringify(msg) + '\n') } catch { /* die */ }
+        writeStdin(child, JSON.stringify(msg) + '\n')
       }
       writeRpc({
         jsonrpc: '2.0', id: initId, method: 'initialize',
@@ -2099,7 +2126,7 @@ function spawnCursorStream(
       shell: opts.shell,
     })
     if (opts.stdinText != null) {
-      try { child.stdin?.write(opts.stdinText); child.stdin?.end() } catch { /* the 'error' handler resolves */ }
+      writeStdin(child, opts.stdinText, { end: true })
     }
     const onAbort = (): void => { child.kill('SIGTERM') }
     opts.signal.addEventListener('abort', onAbort, { once: true })
@@ -2872,7 +2899,7 @@ function spawnPiJson(
       shell: opts.shell,
     })
     if (opts.stdinText != null) {
-      try { child.stdin?.write(opts.stdinText); child.stdin?.end() } catch { /* the 'error' handler resolves */ }
+      writeStdin(child, opts.stdinText, { end: true })
     }
     const onAbort = (): void => { child.kill('SIGTERM') }
     opts.signal.addEventListener('abort', onAbort, { once: true })
@@ -3018,7 +3045,7 @@ class PiSession implements EngineSession {
   }
 
   private write(msg: object): boolean {
-    try { this.child.stdin!.write(`${JSON.stringify(msg)}\n`); return true } catch { return false }
+    return writeStdin(this.child, `${JSON.stringify(msg)}\n`)
   }
 
   private onStdout(buf: Buffer): void {
@@ -3186,7 +3213,7 @@ class PiAdapter implements EngineAdapter {
       args.signal.addEventListener('abort', onAbort, { once: true })
       let buf = ''
       let stderrTail = ''
-      try { child.stdin?.write(`${JSON.stringify({ id: 'doctor', type: 'get_state' })}\n`) } catch { /* close handler reports */ }
+      writeStdin(child, `${JSON.stringify({ id: 'doctor', type: 'get_state' })}\n`)
       child.stdout?.on('data', (b: Buffer) => {
         buf += b.toString('utf8')
         for (;;) {

--- a/server/src/agents/llm-ledger.ts
+++ b/server/src/agents/llm-ledger.ts
@@ -59,6 +59,9 @@ export type LlmCallPurpose =
   | 'completion-verify'
   | 'steer-summary'
   | 'convene-decision'
+  // One decision per MESSAGE rather than per agent — it exists to avoid N
+  // big-brain turns, so its own cost belongs next to theirs in the rollup.
+  | 'message-routing'
   // One-shot utilities (rare per call, but unaccounted before this ledger).
   | 'palette'
   | 'gender'

--- a/server/src/agents/model-policy.ts
+++ b/server/src/agents/model-policy.ts
@@ -26,6 +26,7 @@ export type ModelPurpose =
   | 'agenda'
   | 'palette'
   | 'gender'
+  | 'message-routing'
 
 const REAL_TASK_PURPOSES: ReadonlySet<ModelPurpose> = new Set<ModelPurpose>([
   'agent-turn',

--- a/server/src/agents/routing.ts
+++ b/server/src/agents/routing.ts
@@ -1,0 +1,126 @@
+/**
+ * Message-level routing: does an ordinary human group message need EVERY agent
+ * in the room to wake up, or is it addressed at specific people?
+ *
+ * Today the scheduler picks recipients purely by membership, so a five-agent
+ * room pays five big-brain turns for `@nova draft the launch email` — and
+ * production measures ~26% of group wakes producing no reply at all.
+ *
+ * The decision is deliberately shaped so the model has the SMALLEST possible
+ * job. Targets are derived deterministically (an exact @mention, a quote-reply)
+ * — the cerebellum only says whether the message is aimed at those people
+ * ("me") or at the room ("each"). It never picks who.
+ *
+ * Everything here fails OPEN. Narrowing a wake is the one mistake that is
+ * silent: an agent that should have answered and was never woken leaves no
+ * reply, no typing indicator, and no agent_runs row. So every uncertainty —
+ * no targets, an @all, a model error, an unparseable answer — resolves to
+ * today's full fan-out.
+ */
+import type { ResponseMode } from './triage-core.js'
+
+/** `@all` is a broadcast: it must never be narrowed, whatever else the message
+ *  says. Same token rule the turn prompt uses to tag a broadcast. */
+const ALL_MENTION_RE = /(?<![\w@])@all(?![\w-])/i
+
+export interface RouteRequest {
+  /** Set when the answer is known WITHOUT a model call. */
+  mode?: ResponseMode
+  /** Set when a model call is needed. */
+  instructions?: string
+  input?: string
+}
+
+/** Decide the route, or build the request that decides it.
+ *
+ *  `candidates` is the set of agents the scheduler would wake today;
+ *  `targets` is the deterministically-addressed subset of them. */
+export function buildRouteRequest(args: {
+  body: string
+  conversationKind: string
+  candidates: readonly string[]
+  targets: readonly string[]
+}): RouteRequest {
+  // A broadcast is for everyone, by definition.
+  if (ALL_MENTION_RE.test(args.body)) return { mode: 'each' }
+  // A DM has one recipient; there is nothing to narrow and the existing
+  // human-DM triage note already covers it.
+  if (args.conversationKind === 'direct') return { mode: 'each' }
+  // Nothing to narrow TO. This is the important one: if the message names
+  // nobody, narrowing would wake no one at all.
+  if (args.targets.length === 0) return { mode: 'each' }
+  // Narrowing saves nothing when the targets already are the whole room.
+  if (args.targets.length >= args.candidates.length) return { mode: 'each' }
+
+  return {
+    instructions: [
+      'You route ONE message in a team chat where some teammates are AI agents.',
+      'The message explicitly names one or more agents. Decide whether it is aimed at THEM, or at the room.',
+      'Answer "me" when the named agents are the ones expected to act or reply — a direct request, an assignment, a question put to them.',
+      'Answer "each" when the whole room is still expected to engage — an open question that merely cites someone, a broadcast, a roll call, a request for several independent opinions.',
+      'When you are unsure, answer "each". Waking an extra agent costs tokens; failing to wake the right one loses the message.',
+      'Respond ONLY with a single JSON object: {"responseMode": "me"|"each"}.',
+    ].join('\n'),
+    input: [
+      `Named agents: ${args.targets.join(', ')}`,
+      `Other agents in the room: ${args.candidates.filter((c) => !args.targets.includes(c)).join(', ') || '(none)'}`,
+      '',
+      'Message:',
+      args.body.slice(0, 2000),
+    ].join('\n'),
+  }
+}
+
+/** Parse the router's answer. Anything unexpected — malformed JSON, a mode we
+ *  don't know, an empty completion — reads as `each`, i.e. change nothing. */
+export function parseRoute(raw: string): ResponseMode {
+  const match = raw.match(/"responseMode"\s*:\s*"(me|each|one-of-us)"/i)
+  const mode = match?.[1]?.toLowerCase()
+  return mode === 'me' ? 'me' : 'each'
+}
+
+/** The recipients to actually wake. Separated from the model call so the
+ *  narrowing rule itself is testable without one.
+ *
+ *  Returns `candidates` unchanged unless the route is `me` AND every target is
+ *  a real candidate — a target that is not in the wake set (departed, muted out,
+ *  the author themselves) must never shrink the room to nothing. */
+export function recipientsForRoute(
+  mode: ResponseMode,
+  candidates: readonly string[],
+  targets: readonly string[],
+): string[] {
+  if (mode !== 'me') return [...candidates]
+  const narrowed = targets.filter((t) => candidates.includes(t))
+  return narrowed.length > 0 ? narrowed : [...candidates]
+}
+
+/** Run the router on the cloud SMALL model. Returns `each` — i.e. today's
+ *  behaviour — on any failure, including a model that is rate-limited or down.
+ *  Tracked so the call lands in llm_calls with purpose='message-routing' and
+ *  its cost is visible next to the turns it is meant to save. */
+export async function routeMessage(args: {
+  companyId: string | null
+  body: string
+  conversationKind: string
+  candidates: readonly string[]
+  targets: readonly string[]
+}): Promise<ResponseMode> {
+  const req = buildRouteRequest(args)
+  if (req.mode) return req.mode
+  try {
+    const { getTrackedLlmClient } = await import('./llm-ledger.js')
+    const { supportModel } = await import('./model-policy.js')
+    const client = await getTrackedLlmClient({ purpose: 'message-routing', companyId: args.companyId })
+    const r = await client.responses.create({
+      model: supportModel(),
+      instructions: req.instructions,
+      input: req.input ?? '',
+      max_output_tokens: 200,
+    })
+    return parseRoute(r.output_text ?? '')
+  } catch (err) {
+    console.warn(`[routing] router unavailable; waking everyone: ${err instanceof Error ? err.message : String(err)}`)
+    return 'each'
+  }
+}

--- a/server/src/agents/scheduler.ts
+++ b/server/src/agents/scheduler.ts
@@ -32,6 +32,7 @@ import { deliver as deliverWake, deliverSteer, type PollWakeBrief } from './runt
 import { inprocClient, isAgentBusy } from './runtime/inproc-client.js'
 import { classifyInboxTriage, type InboxTriageVerdict } from './inbox-triage.js'
 import type { AgentTurnOptions } from './turn.js'
+import { recipientsForRoute, routeMessage } from './routing.js'
 import { Semaphore } from '../concurrency.js'
 
 /** Bounds how many recipients the wake fan-out triages + wakes at once
@@ -599,6 +600,40 @@ async function wake(payload: MessageNewEvent): Promise<void> {
     const dropped = agentRecipients.length - recipients.length
     if (dropped > 0) {
       console.warn(`[scheduler] turn-rate floor: dropped ${dropped} agent-driven wake(s) in ${conversationId} (over ${AGENT_TURN_RATE_PER_MINUTE}/min)`)
+    }
+  }
+
+  // ROUTING (#70). A human message that explicitly NAMES agents is usually for
+  // them, and waking the rest of the room costs a full big-brain turn each to
+  // reach "not mine" — production measures ~26% of group wakes replying with
+  // nothing. Ask the cerebellum ONCE per message (not once per agent) whether the
+  // named agents are the intended audience, and narrow only then.
+  //
+  // Deliberately conservative, because narrowing is the one mistake that is
+  // SILENT — a agent that should have answered and was never woken leaves no
+  // reply, no typing indicator, no agent_runs row. So this only ever runs for a
+  // human-authored group message with a real named subset, and every uncertainty
+  // (@all, no targets, a model error, an unparseable answer) keeps today's full
+  // fan-out. See routing.ts.
+  if (!authorIsAgent && (conversation?.kind ?? 'group') !== 'direct' && recipients.length > 1) {
+    const targets = [
+      ...mentionedAgentIds(messageBody, recipients),
+      ...(quotedAuthorId && recipients.includes(quotedAuthorId) ? [quotedAuthorId] : []),
+    ]
+    const uniqueTargets = [...new Set(targets)]
+    if (uniqueTargets.length > 0) {
+      const mode = await routeMessage({
+        companyId: payload.companyId ?? null,
+        body: messageBody,
+        conversationKind: conversation?.kind ?? 'group',
+        candidates: recipients,
+        targets: uniqueTargets,
+      })
+      const routed = recipientsForRoute(mode, recipients, uniqueTargets)
+      if (routed.length !== recipients.length) {
+        console.log(`[scheduler] routed ${conversationId} to ${routed.join(', ')} (mode=${mode}, ${recipients.length - routed.length} wake(s) avoided)`)
+      }
+      recipients = routed
     }
   }
 


### PR DESCRIPTION
Implements **step one** of the plan @yetone laid out in #70. Thanks for measuring it against production — the 26.3% is what makes this worth doing, and it's the metric that says whether it worked.

## What changes

One cerebellum call **per message** (not per agent) decides whether a message that explicitly names agents is aimed at them or at the room.

Targets are **deterministic** — an exact `@mention` (the same token rule `shouldDeliverToMutedAgent` uses, so "addressed to" means one thing everywhere) or a quote-reply. The model never picks who; it only answers `me` or `each`.

Today the scheduler picks recipients purely by membership: the message body reaches that loop at exactly one point, inside the muted-agent branch, which can only *add* a recipient back.

## Everything fails open

Narrowing is the one mistake that is **silent** — an agent that should have answered and was never woken leaves no reply, no typing indicator, and no `agent_runs` row. So today's full fan-out is kept whenever:

| case | why |
| --- | --- |
| `@all` in the body | a broadcast is for everyone, by definition |
| a DM | one recipient; nothing to narrow |
| **no agent named** | narrowing here would wake **nobody** |
| the named set is already the whole room | nothing to save |
| a named agent isn't a candidate (departed, muted out, the author) | must never shrink the room to nothing |
| router errors / rate-limited / junk / non-`me` answer | including `one-of-us`, which is step two and stays **inert** until it has the lease it needs |

The first four are answered **without a model call at all**, so the router only runs for the case it can actually help: a human naming a subset of a group.

## Cost accounting

The call is tracked under a new purpose `message-routing`, registered in both `ModelPurpose` and `LlmCallPurpose`, so it lands in `llm_calls` next to the turns it exists to remove. It's a support-model call — `guard:big-brain` and `guard:llm-tracked` both pass.

## Tests

13 cases in `server/src/__tests__/agents-routing.test.ts`. Most of the weight is on the paths that must **not** narrow, not the happy one — including that `one-of-us` is inert, that an unparseable or chatty completion reads as `each`, and that a named non-candidate leaves the room intact.

Pure functions, no DB/Redis handles: it exits cleanly on a bare `node --test` run, which I checked explicitly this time after #88's unit job hung on exactly that.

## Known gap, stated rather than hidden

If the only named agent is a **BYOA agent whose operator's laptop is closed**, its wake is deferred and nobody else was woken. That's the backstop question from the issue thread — it needs a lease, which step one deliberately doesn't have. If you'd rather not carry that risk at all in step one, the cheap version is to skip narrowing when every target is BYOA; say the word and I'll add it.

Two smaller things I did not do, on purpose: assignee and DM-counterpart targets (the issue lists them, but neither applies to a chat message the way mention/quote do), and any change to `triage-core.ts`'s human short-circuit — the `actionable: true` guarantee for human messages is untouched, so the gate still cannot drop a human. Routing narrows *who wakes*; it never decides *whether the message is actionable*.

## Checks

`npm run lint`, `npm run typecheck`, `npm run server:typecheck`, `npm run guard:big-brain`, `npm run guard:llm-tracked` all pass. The scheduler-adjacent suites (`scheduler-low-pri-budget`, `scheduler-mentions`, `agents-inbox-triage`, `model-policy`) pass with env present.
