### PR TITLE
feat(observability): measure how often a wake produces nothing

### DIFF
--- a/server/src/__integration__/wake-economics.test.ts
+++ b/server/src/__integration__/wake-economics.test.ts
@@ -1,0 +1,169 @@
+/**
+ * `getWakeEconomics` against a real Postgres.
+ *
+ * The query is the whole point of this file. It anti-joins agent_runs to
+ * messages over a time window and aggregates in SQL, and this repo has a
+ * documented history of a single mis-shaped query starving the pool — so it
+ * gets executed for real rather than reasoned about.
+ *
+ * The metric: a run is SILENT when the agent posted nothing into the
+ * conversation that woke it, within ten minutes of the run starting. Same
+ * definition @yetone used to publish the 26.3% group figure in #70, so the two
+ * numbers are comparable.
+ */
+import { after, before, beforeEach, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { randomUUID } from 'node:crypto'
+import { pool } from '../db/pool.js'
+import { getWakeEconomics } from '../agents/observability.js'
+import { ensureSchemaOnce, resetAllTables, seedCompanyWithAgent, teardownAll } from './_helpers.js'
+
+before(async () => { await ensureSchemaOnce() })
+beforeEach(async () => { await resetAllTables() })
+after(async () => { await teardownAll() })
+
+async function seedConvo(companyId: string, kind: 'group' | 'direct', members: string[]): Promise<string> {
+  const id = `conv-${randomUUID().slice(0, 8)}`
+  await pool.query(
+    `INSERT INTO conversations (id, kind, title, members, tag, company_id)
+       VALUES ($1, $2, $3, $4::jsonb, $5, $6)`,
+    [id, kind, `wake-econ ${kind}`, JSON.stringify(members), kind === 'direct' ? 'human' : 'group', companyId],
+  )
+  return id
+}
+
+/** A completed run that spent tokens, triggered by `convoId`. */
+async function seedRun(args: {
+  companyId: string; agentId: string; convoId: string; minutesAgo?: number; tokens?: number
+}): Promise<string> {
+  const id = `run-${randomUUID().slice(0, 8)}`
+  const tokens = args.tokens ?? 1000
+  await pool.query(
+    `INSERT INTO agent_runs
+       (id, agent_id, company_id, trigger, status, model,
+        input_tokens, cached_input_tokens, cache_creation_tokens, output_tokens, started_at)
+     VALUES ($1, $2, $3, $4::jsonb, 'completed', 'gpt-5.5',
+             $5, 0, 0, 100, NOW() - ($6::double precision * INTERVAL '1 minute'))`,
+    [id, args.agentId, args.companyId,
+     JSON.stringify({ source: 'message.new', conversationIds: [args.convoId] }),
+     tokens, args.minutesAgo ?? 5],
+  )
+  return id
+}
+
+/** A reply from `authorId`, offset from the run's start. */
+async function seedReply(args: {
+  companyId: string; convoId: string; authorId: string; minutesAgo: number
+}): Promise<void> {
+  await pool.query(
+    `INSERT INTO messages (id, conversation_id, author_id, kind, body, sequence, company_id, created_at)
+       VALUES ($1, $2, $3, 'text', 'on it', 1, $4, NOW() - ($5::double precision * INTERVAL '1 minute'))`,
+    [`m-${randomUUID().slice(0, 8)}`, args.convoId, args.authorId, args.companyId, args.minutesAgo],
+  )
+}
+
+const bucket = (e: Awaited<ReturnType<typeof getWakeEconomics>>, kind: string) =>
+  e.buckets.find((b) => b.conversationKind === kind)
+
+test('a run that produced no reply counts as silent', async () => {
+  const { companyId, agentId } = await seedCompanyWithAgent()
+  const convo = await seedConvo(companyId, 'group', [agentId])
+  await seedRun({ companyId, agentId, convoId: convo, minutesAgo: 5 })
+
+  const g = bucket(await getWakeEconomics({ companyId }), 'group')
+  assert.equal(g?.runs, 1)
+  assert.equal(g?.silentRuns, 1)
+  assert.equal(g?.silentRate, 1)
+  assert.ok((g?.silentSpendUsd ?? 0) > 0, 'a silent run still cost tokens')
+})
+
+test('a run whose agent replied inside the window is not silent', async () => {
+  const { companyId, agentId } = await seedCompanyWithAgent()
+  const convo = await seedConvo(companyId, 'group', [agentId])
+  await seedRun({ companyId, agentId, convoId: convo, minutesAgo: 5 })
+  await seedReply({ companyId, convoId: convo, authorId: agentId, minutesAgo: 4 })
+
+  const g = bucket(await getWakeEconomics({ companyId }), 'group')
+  assert.equal(g?.runs, 1)
+  assert.equal(g?.silentRuns, 0)
+  assert.equal(g?.silentSpendUsd, 0, 'an answered run contributes no silent spend')
+})
+
+test('a reply after the ten-minute window still counts as silent', async () => {
+  // The window is what makes the metric mean "this wake answered", rather than
+  // "the agent eventually said something in that room".
+  const { companyId, agentId } = await seedCompanyWithAgent()
+  const convo = await seedConvo(companyId, 'group', [agentId])
+  await seedRun({ companyId, agentId, convoId: convo, minutesAgo: 30 })
+  await seedReply({ companyId, convoId: convo, authorId: agentId, minutesAgo: 5 })
+
+  const g = bucket(await getWakeEconomics({ companyId }), 'group')
+  assert.equal(g?.silentRuns, 1)
+})
+
+test("another agent's reply does not rescue this run", async () => {
+  const { companyId, agentId } = await seedCompanyWithAgent()
+  const { agentId: peer } = await seedCompanyWithAgent({ companyId })
+  const convo = await seedConvo(companyId, 'group', [agentId, peer])
+  await seedRun({ companyId, agentId, convoId: convo, minutesAgo: 5 })
+  await seedReply({ companyId, convoId: convo, authorId: peer, minutesAgo: 4 })
+
+  const g = bucket(await getWakeEconomics({ companyId }), 'group')
+  assert.equal(g?.silentRuns, 1, 'silence is per-agent — the peer answering is exactly the waste being counted')
+})
+
+test('group and direct are reported separately', async () => {
+  // A DM legitimately answers far more often; averaging the two would hide the
+  // group number this exists to track.
+  const { companyId, agentId } = await seedCompanyWithAgent()
+  const group = await seedConvo(companyId, 'group', [agentId])
+  const dm = await seedConvo(companyId, 'direct', [agentId])
+  await seedRun({ companyId, agentId, convoId: group, minutesAgo: 5 })
+  await seedRun({ companyId, agentId, convoId: dm, minutesAgo: 5 })
+  await seedReply({ companyId, convoId: dm, authorId: agentId, minutesAgo: 4 })
+
+  const e = await getWakeEconomics({ companyId })
+  assert.equal(bucket(e, 'group')?.silentRate, 1)
+  assert.equal(bucket(e, 'direct')?.silentRate, 0)
+})
+
+test('a run that never reached the model is not counted at all', async () => {
+  // An orphaned 0-token row never spent a big brain; calling it a silent wake
+  // would inflate the very number this tracks.
+  const { companyId, agentId } = await seedCompanyWithAgent()
+  const convo = await seedConvo(companyId, 'group', [agentId])
+  await seedRun({ companyId, agentId, convoId: convo, minutesAgo: 5, tokens: 0 })
+
+  const e = await getWakeEconomics({ companyId })
+  assert.equal(bucket(e, 'group'), undefined)
+})
+
+test('another company never leaks in', async () => {
+  const mine = await seedCompanyWithAgent()
+  const theirs = await seedCompanyWithAgent()
+  const convo = await seedConvo(theirs.companyId, 'group', [theirs.agentId])
+  await seedRun({ companyId: theirs.companyId, agentId: theirs.agentId, convoId: convo, minutesAgo: 5 })
+
+  const e = await getWakeEconomics({ companyId: mine.companyId })
+  assert.deepEqual(e.buckets, [])
+})
+
+test('the window filters out older runs', async () => {
+  const { companyId, agentId } = await seedCompanyWithAgent()
+  const convo = await seedConvo(companyId, 'group', [agentId])
+  await seedRun({ companyId, agentId, convoId: convo, minutesAgo: 60 * 5 })
+
+  assert.deepEqual((await getWakeEconomics({ companyId, sinceHours: 1 })).buckets, [])
+  assert.equal(bucket(await getWakeEconomics({ companyId, sinceHours: 24 }), 'group')?.runs, 1)
+})
+
+test('agentId narrows to one agent', async () => {
+  const { companyId, agentId } = await seedCompanyWithAgent()
+  const { agentId: peer } = await seedCompanyWithAgent({ companyId })
+  const convo = await seedConvo(companyId, 'group', [agentId, peer])
+  await seedRun({ companyId, agentId, convoId: convo, minutesAgo: 5 })
+  await seedRun({ companyId, agentId: peer, convoId: convo, minutesAgo: 5 })
+
+  assert.equal(bucket(await getWakeEconomics({ companyId }), 'group')?.runs, 2)
+  assert.equal(bucket(await getWakeEconomics({ companyId, agentId }), 'group')?.runs, 1)
+})

--- a/server/src/__integration__/wake-economics.test.ts
+++ b/server/src/__integration__/wake-economics.test.ts
@@ -32,21 +32,27 @@ async function seedConvo(companyId: string, kind: 'group' | 'direct', members: s
   return id
 }
 
-/** A completed run that spent tokens, triggered by `convoId`. */
+/** A completed run triggered by `convoId`.
+ *
+ *  `tokens: 0` must mean a genuinely token-free run — EVERY token column zero,
+ *  not just the input one. The query's `(input + cached + output) > 0` filter is
+ *  what keeps an orphaned run out of the metric, so a fixture that leaves output
+ *  tokens behind silently tests the wrong thing. */
 async function seedRun(args: {
   companyId: string; agentId: string; convoId: string; minutesAgo?: number; tokens?: number
 }): Promise<string> {
   const id = `run-${randomUUID().slice(0, 8)}`
-  const tokens = args.tokens ?? 1000
+  const inputTokens = args.tokens ?? 1000
+  const outputTokens = inputTokens > 0 ? 100 : 0
   await pool.query(
     `INSERT INTO agent_runs
        (id, agent_id, company_id, trigger, status, model,
         input_tokens, cached_input_tokens, cache_creation_tokens, output_tokens, started_at)
      VALUES ($1, $2, $3, $4::jsonb, 'completed', 'gpt-5.5',
-             $5, 0, 0, 100, NOW() - ($6::double precision * INTERVAL '1 minute'))`,
+             $5, 0, 0, $6, NOW() - ($7::double precision * INTERVAL '1 minute'))`,
     [id, args.agentId, args.companyId,
      JSON.stringify({ source: 'message.new', conversationIds: [args.convoId] }),
-     tokens, args.minutesAgo ?? 5],
+     inputTokens, outputTokens, args.minutesAgo ?? 5],
   )
   return id
 }

--- a/server/src/__tests__/engine-stdin-safety.test.ts
+++ b/server/src/__tests__/engine-stdin-safety.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Guard: no raw `child.stdin.write()` in the engine adapters.
+ *
+ * A failed pipe write — EPIPE, when the engine died or was killed mid-write —
+ * is delivered ASYNCHRONOUSLY as an 'error' event on the stdin stream
+ * (`afterWriteDispatched`, a tick later). The try/catch that used to wrap every
+ * one of these writes had already returned by then and could not catch it, and
+ * with no listener on the stream Node turns it into an uncaught exception.
+ *
+ * It surfaced as a flaky `write EPIPE` in PiAdapter.probeWake on CI — but every
+ * adapter had the same hole, so this pins the whole file rather than that one
+ * call site.
+ *
+ * Run: node --import tsx --test server/src/__tests__/engine-stdin-safety.test.ts
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { PassThrough } from 'node:stream'
+
+const ENGINE = join(dirname(fileURLToPath(import.meta.url)), '..', 'agents', 'computer', 'engine.ts')
+
+/** Lines that write to a child's stdin directly, ignoring comments.
+ *
+ *  `writeStdin` itself is the one legitimate writer — it is the helper that
+ *  attaches the listener first — so its body is excluded by slicing it out
+ *  rather than by a broad pattern that could also hide a real offender. */
+function rawStdinWrites(source: string): string[] {
+  const start = source.indexOf('function writeStdin(')
+  let body = source
+  if (start >= 0) {
+    const end = source.indexOf('\n}', start)
+    body = source.slice(0, start) + (end >= 0 ? source.slice(end) : '')
+  }
+  return body.split('\n')
+    .map((l) => l.trim())
+    .filter((l) => !l.startsWith('//') && !l.startsWith('*'))
+    .filter((l) => /stdin[?!]?\.write\s*\(/.test(l))
+}
+
+test('every engine stdin write goes through the safe helper', () => {
+  const offenders = rawStdinWrites(readFileSync(ENGINE, 'utf8'))
+  assert.deepEqual(
+    offenders, [],
+    '\nA raw stdin write cannot be protected by try/catch — EPIPE arrives a tick\n' +
+    'later as a stream error and, unlistened, becomes an uncaught exception.\n' +
+    'Use writeStdin() instead:\n' + offenders.map((l) => `  ${l}`).join('\n'),
+  )
+})
+
+test('the matcher would catch a raw write', () => {
+  // Keeps the guard above from silently becoming a no-op.
+  assert.equal(rawStdinWrites('  child.stdin?.write("x")').length, 1)
+  assert.equal(rawStdinWrites('  this.child.stdin!.write(msg)').length, 1)
+  assert.equal(rawStdinWrites('  // child.stdin?.write("x") — explained in prose').length, 0)
+})
+
+test('an async stream write error escapes try/catch but not a listener', () => {
+  // The mechanism itself, so the reason for the guard is executable and not
+  // just an assertion in a comment.
+  return new Promise<void>((resolve, reject) => {
+    const stream = new PassThrough()
+    let caughtByTryCatch = false
+    let caughtByListener = false
+    stream.on('error', () => { caughtByListener = true })
+    try {
+      stream.write('x')
+      setImmediate(() => stream.emit('error', Object.assign(new Error('write EPIPE'), { code: 'EPIPE' })))
+    } catch { caughtByTryCatch = true }
+    setTimeout(() => {
+      try {
+        assert.equal(caughtByTryCatch, false, 'the try/catch cannot see an error delivered on a later tick')
+        assert.equal(caughtByListener, true, 'only a stream listener sees it')
+        resolve()
+      } catch (e) { reject(e) }
+    }, 50)
+  })
+})

--- a/server/src/agents/computer/engine.ts
+++ b/server/src/agents/computer/engine.ts
@@ -426,6 +426,39 @@ function failurePreview(args: {
   return detail ? `${prefix}\n${detail}`.slice(0, MAX_FAILURE_CHARS) : prefix
 }
 
+/** Write to an engine's stdin without letting a dead pipe crash the process.
+ *
+ *  Every stdin write in this file was wrapped in a try/catch whose comment said
+ *  the child's own error/close path would report the failure. That is not what
+ *  happens. A failed pipe write — EPIPE, when the engine died or was killed
+ *  mid-write — is delivered ASYNCHRONOUSLY as an 'error' event on the stdin
+ *  stream (`afterWriteDispatched`, a tick later), so the try/catch has already
+ *  returned and cannot catch it. With no listener on the stream, Node turns it
+ *  into an uncaught exception. It surfaced as a flaky `write EPIPE` failure in
+ *  PiAdapter.probeWake on CI, but every adapter had the same hole.
+ *
+ *  A dead engine is ordinary: the operator quit the CLI, a turn was aborted,
+ *  doctor tore its probe down. The child's own 'error'/'close' handlers already
+ *  report it, so the stream error is noise — it just must not be UNHANDLED.
+ *
+ *  Returns false when the write could not even be attempted, so callers that
+ *  care can bail; the ones that don't already fall through to their close path. */
+function writeStdin(child: ChildProcess, text: string, opts: { end?: boolean } = {}): boolean {
+  const stdin = child.stdin
+  if (!stdin) return false
+  // Attach once per stream — repeated writes must not stack listeners.
+  if (stdin.listenerCount('error') === 0) {
+    stdin.on('error', () => { /* reported by the child's own close/error path */ })
+  }
+  try {
+    stdin.write(text)
+    if (opts.end) stdin.end()
+    return true
+  } catch {
+    return false
+  }
+}
+
 function spawnEngine(
   bin: string,
   args: string[],
@@ -439,7 +472,7 @@ function spawnEngine(
       shell: spawnOpts.shell ?? false,
     })
     if (spawnOpts.stdinText != null) {
-      try { child.stdin?.write(spawnOpts.stdinText); child.stdin?.end() } catch { /* the 'error' handler resolves */ }
+      writeStdin(child, spawnOpts.stdinText, { end: true })
     }
     const onAbort = (): void => { child.kill('SIGTERM') }
     signal.addEventListener('abort', onAbort, { once: true })
@@ -563,7 +596,7 @@ function spawnCapture(
       shell: shell ?? false,
     })
     if (stdinText != null) {
-      try { child.stdin?.write(stdinText); child.stdin?.end() } catch { /* the 'error' handler resolves */ }
+      writeStdin(child, stdinText, { end: true })
     }
     const onAbort = (): void => { child.kill('SIGTERM') }
     signal.addEventListener('abort', onAbort, { once: true })
@@ -718,10 +751,8 @@ class ClaudeSession implements EngineSession {
         this.pendingTimer.unref?.()
       }
       const msg = JSON.stringify({ type: 'user', message: { role: 'user', content: [{ type: 'text', text: stripLoneSurrogates(prompt) }] } }) + '\n'
-      try {
-        this.child.stdin!.write(msg)
-      } catch (err) {
-        this.settle({ exitCode: 1, error: `failed to write turn to engine: ${err instanceof Error ? err.message : String(err)}`, sessionId: this.sid })
+      if (!writeStdin(this.child, msg)) {
+        this.settle({ exitCode: 1, error: 'failed to write turn to engine (stdin closed)', sessionId: this.sid })
       }
     })
   }
@@ -744,9 +775,7 @@ class ClaudeSession implements EngineSession {
     if (!this.pending || !this.alive) return
     while (this.steerQueue.length > 0) {
       const text = this.steerQueue.shift()!
-      try {
-        this.child.stdin!.write(JSON.stringify({ type: 'user', message: { role: 'user', content: [{ type: 'text', text: stripLoneSurrogates(text) }] } }) + '\n')
-      } catch { break }
+      if (!writeStdin(this.child, JSON.stringify({ type: 'user', message: { role: 'user', content: [{ type: 'text', text: stripLoneSurrogates(text) }] } }) + '\n')) break
     }
   }
 
@@ -1137,10 +1166,8 @@ class CodexSession implements EngineSession {
 
   steer(text: string): void {
     if (!this.alive || !text.trim() || !this.threadId || !this.activeTurnId || this.steerGate) return
-    try {
-      this.child.stdin!.write(JSON.stringify({ jsonrpc: '2.0', id: this.nextId(), method: 'turn/steer',
-        params: { threadId: this.threadId, expectedTurnId: this.activeTurnId, input: [{ type: 'text', text: stripLoneSurrogates(text) }] } }) + '\n')
-    } catch { /* best-effort */ }
+    writeStdin(this.child, JSON.stringify({ jsonrpc: '2.0', id: this.nextId(), method: 'turn/steer',
+      params: { threadId: this.threadId, expectedTurnId: this.activeTurnId, input: [{ type: 'text', text: stripLoneSurrogates(text) }] } }) + '\n')
   }
 
   stop(): void {
@@ -1152,11 +1179,11 @@ class CodexSession implements EngineSession {
   private nextId(): number { this.reqId += 1; return this.reqId }
   private req(method: string, params: Record<string, unknown>): number {
     const id = this.nextId()
-    try { this.child.stdin?.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n') } catch { /* die() handles */ }
+    writeStdin(this.child, JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n')
     return id
   }
   private notify(method: string, params: Record<string, unknown>): void {
-    try { this.child.stdin?.write(JSON.stringify({ jsonrpc: '2.0', method, params }) + '\n') } catch { /* die() handles */ }
+    writeStdin(this.child, JSON.stringify({ jsonrpc: '2.0', method, params }) + '\n')
   }
   private startTurn(prompt: string): void {
     if (this.threadId) {
@@ -1413,7 +1440,7 @@ class CodexAdapter implements EngineAdapter {
       let initialized = false
       let threadAcked = false
       const writeRpc = (msg: object) => {
-        try { child.stdin?.write(JSON.stringify(msg) + '\n') } catch { /* die path handles */ }
+        writeStdin(child, JSON.stringify(msg) + '\n')
       }
       // Kick off the handshake once the process is up. spawn() emits stdout
       // 'data' lazily — that's the point at which we know the child is alive
@@ -1615,7 +1642,7 @@ class GrokSession implements EngineSession {
   private nextId(): number { this.reqId += 1; return this.reqId }
   private req(method: string, params: Record<string, unknown>): number {
     const id = this.nextId()
-    try { this.child.stdin?.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n') } catch { /* die() */ }
+    writeStdin(this.child, JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n')
     return id
   }
 
@@ -1850,7 +1877,7 @@ class GrokAdapter implements EngineAdapter {
       const sessionId = 2
       let initialized = false
       const writeRpc = (msg: object) => {
-        try { child.stdin?.write(JSON.stringify(msg) + '\n') } catch { /* die */ }
+        writeStdin(child, JSON.stringify(msg) + '\n')
       }
       writeRpc({
         jsonrpc: '2.0', id: initId, method: 'initialize',
@@ -2099,7 +2126,7 @@ function spawnCursorStream(
       shell: opts.shell,
     })
     if (opts.stdinText != null) {
-      try { child.stdin?.write(opts.stdinText); child.stdin?.end() } catch { /* the 'error' handler resolves */ }
+      writeStdin(child, opts.stdinText, { end: true })
     }
     const onAbort = (): void => { child.kill('SIGTERM') }
     opts.signal.addEventListener('abort', onAbort, { once: true })
@@ -2872,7 +2899,7 @@ function spawnPiJson(
       shell: opts.shell,
     })
     if (opts.stdinText != null) {
-      try { child.stdin?.write(opts.stdinText); child.stdin?.end() } catch { /* the 'error' handler resolves */ }
+      writeStdin(child, opts.stdinText, { end: true })
     }
     const onAbort = (): void => { child.kill('SIGTERM') }
     opts.signal.addEventListener('abort', onAbort, { once: true })
@@ -3018,7 +3045,7 @@ class PiSession implements EngineSession {
   }
 
   private write(msg: object): boolean {
-    try { this.child.stdin!.write(`${JSON.stringify(msg)}\n`); return true } catch { return false }
+    return writeStdin(this.child, `${JSON.stringify(msg)}\n`)
   }
 
   private onStdout(buf: Buffer): void {
@@ -3186,7 +3213,7 @@ class PiAdapter implements EngineAdapter {
       args.signal.addEventListener('abort', onAbort, { once: true })
       let buf = ''
       let stderrTail = ''
-      try { child.stdin?.write(`${JSON.stringify({ id: 'doctor', type: 'get_state' })}\n`) } catch { /* close handler reports */ }
+      writeStdin(child, `${JSON.stringify({ id: 'doctor', type: 'get_state' })}\n`)
       child.stdout?.on('data', (b: Buffer) => {
         buf += b.toString('utf8')
         for (;;) {

--- a/server/src/agents/observability.ts
+++ b/server/src/agents/observability.ts
@@ -538,3 +538,154 @@ export async function getTriageEconomics(args: {
     recent,
   }
 }
+
+/** How long after a wake we still count a post as "this run answered".
+ *  Ten minutes is the window @yetone used to publish the 26.3% figure in #70;
+ *  keeping it identical is what makes this surface comparable to that number
+ *  rather than a second, differently-shaped statistic. */
+const SILENT_WINDOW_MS = 10 * 60_000
+
+export interface SilentWakeBucket {
+  /** 'group' | 'direct' — a DM legitimately answers far more often, so the two
+   *  must never be averaged into one rate. */
+  conversationKind: string
+  runs: number
+  silentRuns: number
+  silentRate: number
+  /** Big-brain spend on the silent runs, priced at query time from the stored
+   *  token counts (same rule as the triage ledger: tokens are real, prices are
+   *  live). */
+  silentSpendUsd: number
+}
+
+export interface WakeEconomics {
+  sinceHours: number
+  buckets: SilentWakeBucket[]
+  /** Any price used was a seed/fallback rather than an operator-supplied rate.
+   *  The RATIOS are measured either way; only the dollars are modelled. */
+  costEstimated: boolean
+}
+
+/** How often a wake produced nothing.
+ *
+ *  A run counts as SILENT when the agent posted no message into any of the
+ *  conversations that woke it, within SILENT_WINDOW_MS of the run starting.
+ *  That is the whole point of #70: a group message wakes every member, each
+ *  reasons over the same room, and most of them conclude it was not theirs —
+ *  after the big brain has already been paid.
+ *
+ *  This exists so that decision stops needing a hand-written query. The routing
+ *  change in #92 is meant to move this number; without a surface, "did it work"
+ *  is an argument rather than a measurement.
+ *
+ *  Deliberately NOT a counterfactual: it reports what happened, not what would
+ *  have been saved. The one modelled quantity is the dollar column, and
+ *  `costEstimated` says so. */
+export async function getWakeEconomics(args: {
+  companyId: string
+  agentId?: string | null
+  sinceHours?: number
+}): Promise<WakeEconomics> {
+  const sinceHours = Math.min(720, Math.max(1, args.sinceHours ?? 24))
+  const ms = sinceHours * 3_600_000
+  const agentFilter = args.agentId ? 'AND r.agent_id = $4' : ''
+  const params: unknown[] = [args.companyId, ms, SILENT_WINDOW_MS]
+  if (args.agentId) params.push(args.agentId)
+
+  // One aggregate, grouped in SQL — never a row per run in JS. Runs are reached
+  // through idx_agent_runs_company_started; the silence probe is an anti-join
+  // per (conversation, agent, window), which idx_messages_convo_created serves.
+  // Only runs that actually spent tokens are counted: an orphaned 0-token row
+  // never reached the model, so calling it a "silent wake" would inflate the
+  // very number this exists to track.
+  const { rows } = await pool.query<{
+    conversation_kind: string
+    runs: number
+    silent_runs: number
+    model: string | null
+    input_tokens: string
+    cached_tokens: string
+    cache_creation_tokens: string
+    output_tokens: string
+  }>(
+    `WITH run_convo AS (
+       SELECT r.id, r.agent_id, r.started_at, r.model,
+              r.input_tokens, r.cached_input_tokens, r.cache_creation_tokens, r.output_tokens,
+              (SELECT cid FROM jsonb_array_elements_text(r.trigger->'conversationIds') AS cid LIMIT 1) AS conversation_id
+         FROM agent_runs r
+        WHERE r.company_id = $1
+          AND r.started_at > NOW() - ($2::double precision * INTERVAL '1 millisecond')
+          AND (r.input_tokens + r.cached_input_tokens + r.output_tokens) > 0
+          ${agentFilter}
+     )
+     SELECT COALESCE(c.kind, 'group') AS conversation_kind,
+            rc.model,
+            count(*)::int AS runs,
+            count(*) FILTER (
+              WHERE NOT EXISTS (
+                SELECT 1 FROM messages m
+                 WHERE m.conversation_id = rc.conversation_id
+                   AND m.author_id = rc.agent_id
+                   AND m.created_at >= rc.started_at
+                   AND m.created_at < rc.started_at + ($3::double precision * INTERVAL '1 millisecond')
+              )
+            )::int AS silent_runs,
+            COALESCE(sum(rc.input_tokens) FILTER (WHERE NOT EXISTS (
+                SELECT 1 FROM messages m
+                 WHERE m.conversation_id = rc.conversation_id AND m.author_id = rc.agent_id
+                   AND m.created_at >= rc.started_at
+                   AND m.created_at < rc.started_at + ($3::double precision * INTERVAL '1 millisecond')
+            )), 0)::bigint AS input_tokens,
+            COALESCE(sum(rc.cached_input_tokens) FILTER (WHERE NOT EXISTS (
+                SELECT 1 FROM messages m
+                 WHERE m.conversation_id = rc.conversation_id AND m.author_id = rc.agent_id
+                   AND m.created_at >= rc.started_at
+                   AND m.created_at < rc.started_at + ($3::double precision * INTERVAL '1 millisecond')
+            )), 0)::bigint AS cached_tokens,
+            COALESCE(sum(rc.cache_creation_tokens) FILTER (WHERE NOT EXISTS (
+                SELECT 1 FROM messages m
+                 WHERE m.conversation_id = rc.conversation_id AND m.author_id = rc.agent_id
+                   AND m.created_at >= rc.started_at
+                   AND m.created_at < rc.started_at + ($3::double precision * INTERVAL '1 millisecond')
+            )), 0)::bigint AS cache_creation_tokens,
+            COALESCE(sum(rc.output_tokens) FILTER (WHERE NOT EXISTS (
+                SELECT 1 FROM messages m
+                 WHERE m.conversation_id = rc.conversation_id AND m.author_id = rc.agent_id
+                   AND m.created_at >= rc.started_at
+                   AND m.created_at < rc.started_at + ($3::double precision * INTERVAL '1 millisecond')
+            )), 0)::bigint AS output_tokens
+       FROM run_convo rc
+       LEFT JOIN conversations c ON c.id = rc.conversation_id
+      GROUP BY conversation_kind, rc.model`,
+    params,
+  )
+
+  const byKind = new Map<string, { runs: number; silent: number; usd: number }>()
+  let anyEstimated = false
+  for (const r of rows) {
+    const { usd, estimated } = effectiveCostUsd(r.model, {
+      inputTokens: Number(r.input_tokens),
+      cachedInputTokens: Number(r.cached_tokens),
+      cacheCreationTokens: Number(r.cache_creation_tokens),
+      outputTokens: Number(r.output_tokens),
+    })
+    if (estimated) anyEstimated = true
+    const cur = byKind.get(r.conversation_kind) ?? { runs: 0, silent: 0, usd: 0 }
+    cur.runs += r.runs
+    cur.silent += r.silent_runs
+    cur.usd += usd
+    byKind.set(r.conversation_kind, cur)
+  }
+
+  return {
+    sinceHours,
+    costEstimated: anyEstimated,
+    buckets: [...byKind].map(([conversationKind, v]) => ({
+      conversationKind,
+      runs: v.runs,
+      silentRuns: v.silent,
+      silentRate: v.runs > 0 ? v.silent / v.runs : 0,
+      silentSpendUsd: v.usd,
+    })).sort((a, b) => b.runs - a.runs),
+  }
+}

--- a/server/src/api/router.ts
+++ b/server/src/api/router.ts
@@ -9,7 +9,7 @@ import { createPoll, castVote, closePoll, PollError } from '../polls.js'
 import { env } from '../env.js'
 import { startConvene, getActiveConvene } from '../agents/convene.js'
 import { fetchImageBytes } from '../agents/image-fetcher.js'
-import { getTriageEconomics } from '../agents/observability.js'
+import { getTriageEconomics, getWakeEconomics } from '../agents/observability.js'
 import { BUSY_STATUS_LEASE_MS } from '../status.js'
 import { notifyMessage, computeMessageRecipients } from '../push.js'
 import { randomUUID, randomBytes, createHash, timingSafeEqual } from 'node:crypto'
@@ -4766,6 +4766,18 @@ api.get('/agents/observability/triage', async (req, res) => {
   const rawHours = Number(req.query.sinceHours ?? 24)
   const sinceHours = Math.max(1, Math.min(720, Number.isFinite(rawHours) ? rawHours : 24))
   res.json(await getTriageEconomics({ companyId: tenant, agentId, sinceHours }))
+})
+
+// How often does a wake produce nothing? A group message wakes every member and
+// most conclude it was not theirs — after the big brain has already been paid.
+// Split group vs direct, because a DM legitimately answers far more often and
+// averaging the two hides the number that matters.
+api.get('/agents/observability/wakes', async (req, res) => {
+  const { companyId: tenant } = await requireDevtools(req)
+  const agentId = typeof req.query.agentId === 'string' && req.query.agentId.trim() ? req.query.agentId.trim() : null
+  const rawHours = Number(req.query.sinceHours ?? 24)
+  const sinceHours = Math.max(1, Math.min(720, Number.isFinite(rawHours) ? rawHours : 24))
+  res.json(await getWakeEconomics({ companyId: tenant, agentId, sinceHours }))
 })
 
 // Universal LLM-spend ledger rollup by purpose × model × source. Answers the


### PR DESCRIPTION
Companion to #92, and to the decision @yetone described in #70.

## Why

In #70 you answered "is the waste real?" with a hand-written query: over three days, **26.3% of group wakes posted nothing** within ten minutes, against 17% for DMs. That number decided the shape of the fix — and it's the stated criterion for whether step two is worth its complexity:

> only if step one earns it … same silent-rate measurement, with completion rate not dropping

But nothing in the product can answer that question. It took SQL written by hand, once, by the one person positioned to write it. So #92 ships with no way to tell whether it worked, and every operator paying their own BYOA quota has no way to see this at all.

## What

`getWakeEconomics` makes it a surface, using **your definition verbatim** so the numbers stay comparable: a run is silent when the agent posted nothing into the conversation that woke it, within ten minutes of the run starting.

`GET /agents/observability/wakes?sinceHours=&agentId=` returns per-conversation-kind buckets: `runs`, `silentRuns`, `silentRate`, `silentSpendUsd`.

Shaped after `getTriageEconomics`, which already solved the same problems:

- aggregate in SQL, never a row per run in JS
- company-scoped and time-bounded on the indexed columns
- cost computed at query time from stored **token counts × current prices**, so a price change re-prices history — tokens are real, prices are live
- `costEstimated` says plainly when a rate was a seed rather than an operator price. None is configured today, so it will read `true`, and the dollars are modelled — exactly the caveat you made in the issue rather than something a reader has to rediscover

Two deliberate shapes:

- **Group and direct are separate, never averaged.** A DM legitimately answers far more often; one blended rate hides the group number this exists to track.
- **Runs that never reached the model (0 tokens) are excluded.** Counting an orphaned row as a silent wake would inflate the very metric.

It reports what happened, not what would have been saved — no counterfactual. The only modelled quantity is the dollar column, and the flag says so.

## About the query

The query is the risk here, and this repo has a documented outage from a single mis-shaped query starving the pool (the `idle.ts` seq-scan that took all 20 slots). **I have no Postgres locally**, so rather than reason about it I put it under the integration suite: 9 cases in `server/src/__integration__/wake-economics.test.ts` execute it against a real database in CI.

The cases that matter most:

- **a peer's reply does not rescue a silent run** — that *is* the waste being counted, and getting it wrong would make the metric read near-zero
- a reply *after* the ten-minute window still counts as silent, so the metric means "this wake answered", not "the agent eventually said something in that room"
- a 0-token run is absent entirely
- another company never leaks in
- `sinceHours` and `agentId` both narrow correctly

## Not included

No UI. `ObservabilityView` already renders the triage ledger and this would sit beside it, but placement is a design call and the API is what unblocks measuring #92. Happy to add the panel if you tell me where you want it.

No routing attribution either — "how many wakes did the router avoid" needs #92 merged and recording its decision, which is a follow-up rather than something to guess at now.

## Checks

`npm run lint`, `npm run typecheck`, `npm run server:typecheck` pass. The unit-suite failure set is byte-identical to `main`'s on my machine (the same 25 files that need Postgres/Redis).
