### PR TITLE
fix(runtime): scope faces to JWT tenant

### DIFF
--- a/server/src/__integration__/runtime-server.test.ts
+++ b/server/src/__integration__/runtime-server.test.ts
@@ -274,6 +274,48 @@ test('[integration] runtime: /context rejects a stale production token after ten
   assert.deepEqual(r.body?.rows ?? [], [])
 })
 
+test('[integration] runtime: /faces requires a tenant-pinned token', async () => {
+  const { agentId } = await seedAgent()
+  const token = signAgentToken({ agentId, companyId: null })
+  const r = await call('/runtime/faces', { token, body: { participantIds: [agentId] } })
+  assert.equal(r.status, 403)
+  assert.match(String(r.body?.error ?? ''), /companyId claim required/i)
+})
+
+test('[integration] runtime: /faces returns participants only from the JWT tenant', async () => {
+  const caller = await seedAgent()
+  const otherTenant = await seedAgent()
+  await pool.query(
+    `UPDATE participants SET avatar_url = CASE id
+       WHEN $1 THEN 'https://cdn.example.test/caller.png'
+       WHEN $2 THEN 'https://cdn.example.test/other.png'
+     END
+     WHERE id = ANY($3::text[])`,
+    [caller.agentId, otherTenant.agentId, [caller.agentId, otherTenant.agentId]],
+  )
+
+  const r = await call('/runtime/faces', {
+    token: caller.token,
+    body: { participantIds: [caller.agentId, otherTenant.agentId] },
+  })
+
+  assert.equal(r.status, 200)
+  assert.deepEqual(
+    (r.body?.rows ?? []).map((row: { id: string; name: string; role: string | null; avatar_url: string | null }) => ({
+      id: row.id,
+      name: row.name,
+      role: row.role,
+      avatarUrl: row.avatar_url,
+    })),
+    [{
+      id: caller.agentId,
+      name: caller.agentId,
+      role: 'tester',
+      avatarUrl: 'https://cdn.example.test/caller.png',
+    }],
+  )
+})
+
 // ── identity pin: agentId comes from JWT, not request body ────────────
 
 test('[integration] runtime: /runs records the JWT subject, not whatever the body claims', async () => {

--- a/server/src/__tests__/agents-runtime-http-client.test.ts
+++ b/server/src/__tests__/agents-runtime-http-client.test.ts
@@ -141,6 +141,27 @@ test('loadContext: sends only conversation selectors because the JWT pins the te
   assert.deepEqual(requestBody, { conversationIds: ['convo-1'] })
 })
 
+test('loadFaces: sends only participant selectors because the JWT pins the tenant', async () => {
+  let requestBody: unknown
+  const stubFetch = ((async (_input: unknown, init?: RequestInit) => {
+    requestBody = JSON.parse(String(init?.body ?? 'null'))
+    return new Response(JSON.stringify({ rows: [] }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
+  }) as unknown) as typeof fetch
+  const client = new HttpRuntimeClient({
+    baseUrl: 'http://stub.invalid',
+    token: 'tenant-pinned-token',
+    fetchImpl: stubFetch,
+    timeoutMs: 1_000,
+  })
+
+  await client.loadFaces('company-from-call-site', ['participant-1'])
+
+  assert.deepEqual(requestBody, { participantIds: ['participant-1'] })
+})
+
 test('regression guard: loadInbox MUST still throw on fetch failure — turn cannot run without an inbox', async () => {
   // Symmetric defence — if someone "fixes" loadInbox to also swallow,
   // the turn would silently run with no inbox and the agent would

--- a/server/src/agents/runtime/client.ts
+++ b/server/src/agents/runtime/client.ts
@@ -218,9 +218,9 @@ export interface AgentRuntimeClient {
   /** Index of installed skills (name + description only — progressive
    *  disclosure; full SKILL.md loaded lazily). */
   loadSkillsIndex(agentId: string): Promise<SkillIndexEntry[]>
-  /** Participant avatar portraits — for every id passed in, returns
-   *  the public URL if a portrait exists. */
-  loadFaces(participantIds: string[]): Promise<FaceRow[]>
+  /** Participant avatar portraits within the authenticated tenant — ids are
+   *  selectors, not authorization, and must never cross company boundaries. */
+  loadFaces(companyId: string, participantIds: string[]): Promise<FaceRow[]>
 
   // === Identity (system prompt) ===
   /** Full system prompt incl. IDENTITY.md / SOUL.md, persona, global

--- a/server/src/agents/runtime/http-client.ts
+++ b/server/src/agents/runtime/http-client.ts
@@ -164,7 +164,7 @@ export class HttpRuntimeClient implements AgentRuntimeClient {
     return out.rows
   }
 
-  async loadFaces(participantIds: string[]): Promise<FaceRow[]> {
+  async loadFaces(_companyId: string, participantIds: string[]): Promise<FaceRow[]> {
     const out = await this.call<{ rows: FaceRow[] }>('POST', '/faces', { participantIds })
     return out.rows
   }

--- a/server/src/agents/runtime/inproc-client.ts
+++ b/server/src/agents/runtime/inproc-client.ts
@@ -481,14 +481,15 @@ export class InProcRuntimeClient implements AgentRuntimeClient {
     return loadSkillsIndexImpl(agentId)
   }
 
-  /** Avatar portraits for every participant id passed in. Returns rows
-   *  in arbitrary order; caller filters out missing/local URLs before
-   *  shipping them to the LLM. */
-  async loadFaces(participantIds: string[]): Promise<FaceRow[]> {
+  /** Avatar portraits for selected participants in the authenticated tenant.
+   *  Returns rows in arbitrary order; caller filters out missing/local URLs
+   *  before shipping them to the LLM. */
+  async loadFaces(companyId: string, participantIds: string[]): Promise<FaceRow[]> {
     if (participantIds.length === 0) return []
     const { rows } = await pool.query<FaceRow>(
-      `SELECT id, name, role, avatar_url FROM participants WHERE id = ANY($1::text[])`,
-      [participantIds],
+      `SELECT id, name, role, avatar_url FROM participants
+        WHERE company_id = $1 AND id = ANY($2::text[])`,
+      [companyId, participantIds],
     )
     return rows
   }

--- a/server/src/agents/runtime/server.ts
+++ b/server/src/agents/runtime/server.ts
@@ -275,9 +275,10 @@ runtimeRouter.get('/skills', withAgent(async (c, _req, res) => {
   res.json({ rows: await inprocClient.loadSkillsIndex(c.sub) })
 }))
 
-runtimeRouter.post('/faces', withAgent(async (_c, req, res) => {
+runtimeRouter.post('/faces', withAgent(async (c, req, res) => {
+  if (!c.companyId) { res.status(403).json({ error: 'companyId claim required' }); return }
   const body = req.body as { participantIds?: string[] } | undefined
-  const rows = await inprocClient.loadFaces(body?.participantIds ?? [])
+  const rows = await inprocClient.loadFaces(c.companyId, body?.participantIds ?? [])
   res.json({ rows })
 }))
 

--- a/server/src/agents/turn.ts
+++ b/server/src/agents/turn.ts
@@ -805,8 +805,8 @@ async function collectImageAttachments(items: InboxRow[]): Promise<Array<{ messa
  * Skips participants without an AI-generated portrait, and skips local URLs
  * when no PUBLIC_HOST is configured (OpenAI can't fetch localhost).
  */
-async function loadFaces(participantIds: string[]): Promise<Array<{ id: string; name: string; role: string | null; url: string }>> {
-  const rows = await runtime.loadFaces(participantIds)
+async function loadFaces(companyId: string, participantIds: string[]): Promise<Array<{ id: string; name: string; role: string | null; url: string }>> {
+  const rows = await runtime.loadFaces(companyId, participantIds)
   const out: Array<{ id: string; name: string; role: string | null; url: string }> = []
   for (const r of rows) {
     if (!r.avatar_url) continue
@@ -2259,7 +2259,7 @@ Mechanics:
     agentId,
     ...context.map((m) => m.author_id),
   ])]
-  const faces = await loadFaces(distinctSpeakers)
+  const faces = await loadFaces(persona.companyId, distinctSpeakers)
 
   // Build structured input — text wake prompt plus any image attachments as
   // input_image content items so vision-capable models can actually see them.


### PR DESCRIPTION
## Summary

- require a tenant-pinned runtime token for POST /runtime/faces
- bind participant portrait queries to the JWT company in the HTTP path and to the persona company in the in-process path
- keep the HTTP request body limited to participant selectors so callers cannot supply their own tenant identity
- add regression coverage for missing tenant claims and mixed-tenant participant IDs

## Security context

The authenticated faces endpoint previously discarded the verified claim and queried participants only by caller-supplied IDs. A valid Agent runtime token could therefore retrieve participant names, roles, and avatar URLs from other companies.

The tenant is now part of the AgentRuntimeClient loadFaces contract. The server derives it exclusively from the verified JWT claim, and the shared database read applies company_id before returning any selected participant.

## Validation

- [x] npx biome lint on all changed files
- [x] npm run lint
- [x] npm run typecheck
- [x] npm run server:typecheck
- [x] npm run guard:big-brain
- [x] npm run guard:llm-tracked
- [x] targeted agents-runtime-http-client unit suite: 12/12
- [ ] full npm test locally — requires the Postgres and Redis service environment supplied by CI
- [ ] npm run test:integration locally — project runner skipped because INTEGRATION_DATABASE_URL is not configured
- [x] GitHub Unit and Integration CI with Postgres and Redis services