### PR TITLE
feat(kanban): give board columns a meaning, and make claim advance the card

### DIFF
--- a/server/src/__integration__/board-column-kind.test.ts
+++ b/server/src/__integration__/board-column-kind.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Column semantics against a real Postgres (#69).
+ *
+ * Two things here can only be proven with a database: the migration's backfill
+ * (does an existing board get classified, and does a CUSTOM board correctly
+ * stay unclassified?) and `card claim` actually advancing a card.
+ *
+ * The backfill is the risky half. It writes to every existing board in every
+ * deployment, and a wrong guess would silently reclassify someone's workflow —
+ * so the case that matters most is the one that asserts it left a custom board
+ * alone.
+ */
+import { after, before, beforeEach, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { randomUUID } from 'node:crypto'
+import { pool } from '../db/pool.js'
+import { runCli } from '../agents/cli.js'
+import { ensureSchemaOnce, resetAllTables, seedCompanyWithAgent, teardownAll } from './_helpers.js'
+
+before(async () => { await ensureSchemaOnce() })
+beforeEach(async () => { await resetAllTables() })
+after(async () => { await teardownAll() })
+
+async function seedBoard(companyId: string, columns: Array<[string, string | null]>): Promise<{
+  boardId: string; columnIds: string[]
+}> {
+  const boardId = `board-${randomUUID().slice(0, 8)}`
+  await pool.query(
+    `INSERT INTO boards (id, company_id, title, created_by) VALUES ($1, $2, 'kind test', 'tester')`,
+    [boardId, companyId],
+  )
+  const columnIds: string[] = []
+  for (let i = 0; i < columns.length; i++) {
+    const id = `col-${randomUUID().slice(0, 8)}`
+    columnIds.push(id)
+    await pool.query(
+      `INSERT INTO board_columns (id, board_id, title, position, kind) VALUES ($1, $2, $3, $4, $5)`,
+      [id, boardId, columns[i][0], (i + 1) * 1000, columns[i][1]],
+    )
+  }
+  return { boardId, columnIds }
+}
+
+async function seedCard(boardId: string, columnId: string): Promise<string> {
+  const id = `card-${randomUUID().slice(0, 8)}`
+  await pool.query(
+    `INSERT INTO board_cards (id, board_id, column_id, title, position, mentions, created_by)
+       VALUES ($1, $2, $3, 'ship it', 1000, '[]'::jsonb, 'tester')`,
+    [id, boardId, columnId],
+  )
+  return id
+}
+
+const columnOf = async (cardId: string): Promise<string> =>
+  (await pool.query<{ column_id: string }>(`SELECT column_id FROM board_cards WHERE id = $1`, [cardId])).rows[0].column_id
+
+test('a board created through the CLI has its columns classified', async () => {
+  const { companyId, agentId } = await seedCompanyWithAgent()
+  const r = await runCli(['--as', agentId, 'board', 'create', 'Launch'])
+  assert.equal(r.ok, true, r.text)
+
+  const { rows } = await pool.query<{ title: string; kind: string | null }>(
+    `SELECT bc.title, bc.kind FROM board_columns bc
+       JOIN boards b ON b.id = bc.board_id
+      WHERE b.company_id = $1 ORDER BY bc.position ASC`,
+    [companyId],
+  )
+  assert.deepEqual(rows.map((c) => [c.title, c.kind]), [['Todo', 'todo'], ['Doing', 'doing'], ['Done', 'done']])
+})
+
+test('claiming a card in Todo advances it to Doing', async () => {
+  const { companyId, agentId } = await seedCompanyWithAgent()
+  const { boardId, columnIds } = await seedBoard(companyId, [['Todo', 'todo'], ['Doing', 'doing'], ['Done', 'done']])
+  const card = await seedCard(boardId, columnIds[0])
+
+  const r = await runCli(['--as', agentId, 'card', 'claim', card])
+  assert.equal(r.ok, true, r.text)
+  assert.equal(await columnOf(card), columnIds[1])
+  assert.match(r.text, /moved to Doing/)
+})
+
+test('claiming a finished card leaves it in Done', async () => {
+  const { companyId, agentId } = await seedCompanyWithAgent()
+  const { boardId, columnIds } = await seedBoard(companyId, [['Todo', 'todo'], ['Doing', 'doing'], ['Done', 'done']])
+  const card = await seedCard(boardId, columnIds[2])
+
+  const r = await runCli(['--as', agentId, 'card', 'claim', card])
+  assert.equal(r.ok, true, r.text)
+  assert.equal(await columnOf(card), columnIds[2], 'a claim must never drag a finished card backwards')
+  assert.doesNotMatch(r.text, /moved to Doing/)
+})
+
+test('claiming on a custom board moves nothing', async () => {
+  // Unclassified columns are the signal that we do not understand this
+  // workflow — the card must stay exactly where the humans put it.
+  const { companyId, agentId } = await seedCompanyWithAgent()
+  const { boardId, columnIds } = await seedBoard(companyId, [['Backlog', null], ['In flight', null], ['Shipped', null]])
+  const card = await seedCard(boardId, columnIds[0])
+
+  const r = await runCli(['--as', agentId, 'card', 'claim', card])
+  assert.equal(r.ok, true, r.text)
+  assert.equal(await columnOf(card), columnIds[0])
+})
+
+test('the migration classifies conventional columns and leaves custom ones alone', async () => {
+  // Simulates a board that predates the feature: kind is NULL everywhere.
+  const { companyId } = await seedCompanyWithAgent()
+  const conventional = await seedBoard(companyId, [['Todo', null], ['Doing', null], ['Done', null]])
+  const custom = await seedBoard(companyId, [['Backlog', null], ['In flight', null], ['Shipped', null]])
+  const spaced = await seedBoard(companyId, [['  To Do  ', null]])
+
+  // Re-run the migrator; it is idempotent and re-applies the backfill.
+  const { ensureSchema } = await import('../db/migrate.js')
+  await ensureSchema()
+
+  const kinds = async (ids: string[]): Promise<Array<string | null>> => {
+    const { rows } = await pool.query<{ id: string; kind: string | null }>(
+      `SELECT id, kind FROM board_columns WHERE id = ANY($1::text[])`, [ids],
+    )
+    const byId = new Map(rows.map((r) => [r.id, r.kind]))
+    return ids.map((i) => byId.get(i) ?? null)
+  }
+
+  assert.deepEqual(await kinds(conventional.columnIds), ['todo', 'doing', 'done'])
+  assert.deepEqual(await kinds(custom.columnIds), [null, null, null], 'a custom workflow must not be guessed at')
+  assert.deepEqual(await kinds(spaced.columnIds), ['todo'], 'padding and case must not defeat the match')
+})
+
+test('the backfill does not overwrite a column that already has a kind', async () => {
+  // Someone classified "Done" as todo on purpose; a later migration run must
+  // not undo that choice.
+  const { companyId } = await seedCompanyWithAgent()
+  const { columnIds } = await seedBoard(companyId, [['Done', 'todo']])
+
+  const { ensureSchema } = await import('../db/migrate.js')
+  await ensureSchema()
+
+  const { rows } = await pool.query<{ kind: string | null }>(
+    `SELECT kind FROM board_columns WHERE id = $1`, [columnIds[0]],
+  )
+  assert.equal(rows[0].kind, 'todo')
+})

--- a/server/src/__integration__/board-column-kind.test.ts
+++ b/server/src/__integration__/board-column-kind.test.ts
@@ -56,7 +56,10 @@ const columnOf = async (cardId: string): Promise<string> =>
 
 test('a board created through the CLI has its columns classified', async () => {
   const { companyId, agentId } = await seedCompanyWithAgent()
-  const r = await runCli(['--as', agentId, 'board', 'create', 'Launch'])
+  // The subcommand is `kanban`, not `board` — cli.ts dispatches 'kanban' to
+  // cmdBoard. Asserting on r.ok alone would have hidden the typo behind a
+  // generic failure, so the message is checked too.
+  const r = await runCli(['--as', agentId, 'kanban', 'create', 'Launch'])
   assert.equal(r.ok, true, r.text)
 
   const { rows } = await pool.query<{ title: string; kind: string | null }>(

--- a/server/src/__tests__/board-columns.test.ts
+++ b/server/src/__tests__/board-columns.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Which column a claim advances a card into (#69).
+ *
+ * Claiming is the moment work starts, so the board should say Doing instead of
+ * relying on the agent to remember a second command — that gap is why a board
+ * could read Todo 2 / Doing 1 / Done 0 while the work was finished and
+ * delivered in chat.
+ *
+ * The rule that carries the risk is "only ever forward". Moving someone's card
+ * backwards, or out of a column whose meaning we never understood, is silent
+ * damage on a surface humans are watching — so most of these cases are about
+ * NOT moving.
+ *
+ * Run: node --import tsx --test server/src/__tests__/board-columns.test.ts
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { claimTargetColumn, isColumnKind, isDoneColumn } from '../agents/board-columns.js'
+
+const TODO = { id: 'c-todo', position: 1000, kind: 'todo' }
+const DOING = { id: 'c-doing', position: 2000, kind: 'doing' }
+const DONE = { id: 'c-done', position: 3000, kind: 'done' }
+const BOARD = [TODO, DOING, DONE]
+
+test('claiming from Todo advances to Doing', () => {
+  assert.equal(claimTargetColumn({ columns: BOARD, currentColumnId: TODO.id }), DOING.id)
+})
+
+test('claiming a card already in Doing moves nothing', () => {
+  // No churn, and no card.moved event for a move that did not happen.
+  assert.equal(claimTargetColumn({ columns: BOARD, currentColumnId: DOING.id }), null)
+})
+
+test('claiming a finished card never drags it back', () => {
+  // Re-claiming something in Done must not rewrite what the humans on the
+  // board already saw.
+  assert.equal(claimTargetColumn({ columns: BOARD, currentColumnId: DONE.id }), null)
+})
+
+test('a board with no Doing column moves nothing', () => {
+  // Custom workflow, all columns unclassified — guessing which one meant Doing
+  // is exactly what this feature exists to avoid.
+  const custom = [
+    { id: 'c-1', position: 1000, kind: null },
+    { id: 'c-2', position: 2000, kind: null },
+  ]
+  assert.equal(claimTargetColumn({ columns: custom, currentColumnId: 'c-1' }), null)
+})
+
+test('a card in an unclassified column stays put even when Doing exists', () => {
+  // Half-classified board: we understand where Doing is, but not where the card
+  // currently sits, so moving it out could skip a step the board cares about.
+  const half = [{ id: 'c-review', position: 500, kind: null }, DOING]
+  assert.equal(claimTargetColumn({ columns: half, currentColumnId: 'c-review' }), null)
+})
+
+test('an unknown current column moves nothing', () => {
+  assert.equal(claimTargetColumn({ columns: BOARD, currentColumnId: 'c-missing' }), null)
+})
+
+test('with several Doing columns the leftmost wins', () => {
+  // Deterministic rather than dependent on row order.
+  const twoDoing = [
+    TODO,
+    { id: 'c-doing-b', position: 2500, kind: 'doing' },
+    { id: 'c-doing-a', position: 2000, kind: 'doing' },
+  ]
+  assert.equal(claimTargetColumn({ columns: twoDoing, currentColumnId: TODO.id }), 'c-doing-a')
+})
+
+test('an empty board moves nothing', () => {
+  assert.equal(claimTargetColumn({ columns: [], currentColumnId: 'c-todo' }), null)
+})
+
+test('isColumnKind accepts only the three meanings', () => {
+  for (const k of ['todo', 'doing', 'done']) assert.equal(isColumnKind(k), true)
+  for (const k of ['Todo', 'in-progress', '', null, undefined, 3]) assert.equal(isColumnKind(k), false)
+})
+
+test('isDoneColumn is true only for done', () => {
+  assert.equal(isDoneColumn(DONE), true)
+  assert.equal(isDoneColumn(DOING), false)
+  assert.equal(isDoneColumn({ kind: null }), false)
+})

--- a/server/src/__tests__/engine-stdin-safety.test.ts
+++ b/server/src/__tests__/engine-stdin-safety.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Guard: no raw `child.stdin.write()` in the engine adapters.
+ *
+ * A failed pipe write — EPIPE, when the engine died or was killed mid-write —
+ * is delivered ASYNCHRONOUSLY as an 'error' event on the stdin stream
+ * (`afterWriteDispatched`, a tick later). The try/catch that used to wrap every
+ * one of these writes had already returned by then and could not catch it, and
+ * with no listener on the stream Node turns it into an uncaught exception.
+ *
+ * It surfaced as a flaky `write EPIPE` in PiAdapter.probeWake on CI — but every
+ * adapter had the same hole, so this pins the whole file rather than that one
+ * call site.
+ *
+ * Run: node --import tsx --test server/src/__tests__/engine-stdin-safety.test.ts
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { PassThrough } from 'node:stream'
+
+const ENGINE = join(dirname(fileURLToPath(import.meta.url)), '..', 'agents', 'computer', 'engine.ts')
+
+/** Lines that write to a child's stdin directly, ignoring comments.
+ *
+ *  `writeStdin` itself is the one legitimate writer — it is the helper that
+ *  attaches the listener first — so its body is excluded by slicing it out
+ *  rather than by a broad pattern that could also hide a real offender. */
+function rawStdinWrites(source: string): string[] {
+  const start = source.indexOf('function writeStdin(')
+  let body = source
+  if (start >= 0) {
+    const end = source.indexOf('\n}', start)
+    body = source.slice(0, start) + (end >= 0 ? source.slice(end) : '')
+  }
+  return body.split('\n')
+    .map((l) => l.trim())
+    .filter((l) => !l.startsWith('//') && !l.startsWith('*'))
+    .filter((l) => /stdin[?!]?\.write\s*\(/.test(l))
+}
+
+test('every engine stdin write goes through the safe helper', () => {
+  const offenders = rawStdinWrites(readFileSync(ENGINE, 'utf8'))
+  assert.deepEqual(
+    offenders, [],
+    '\nA raw stdin write cannot be protected by try/catch — EPIPE arrives a tick\n' +
+    'later as a stream error and, unlistened, becomes an uncaught exception.\n' +
+    'Use writeStdin() instead:\n' + offenders.map((l) => `  ${l}`).join('\n'),
+  )
+})
+
+test('the matcher would catch a raw write', () => {
+  // Keeps the guard above from silently becoming a no-op.
+  assert.equal(rawStdinWrites('  child.stdin?.write("x")').length, 1)
+  assert.equal(rawStdinWrites('  this.child.stdin!.write(msg)').length, 1)
+  assert.equal(rawStdinWrites('  // child.stdin?.write("x") — explained in prose').length, 0)
+})
+
+test('an async stream write error escapes try/catch but not a listener', () => {
+  // The mechanism itself, so the reason for the guard is executable and not
+  // just an assertion in a comment.
+  return new Promise<void>((resolve, reject) => {
+    const stream = new PassThrough()
+    let caughtByTryCatch = false
+    let caughtByListener = false
+    stream.on('error', () => { caughtByListener = true })
+    try {
+      stream.write('x')
+      setImmediate(() => stream.emit('error', Object.assign(new Error('write EPIPE'), { code: 'EPIPE' })))
+    } catch { caughtByTryCatch = true }
+    setTimeout(() => {
+      try {
+        assert.equal(caughtByTryCatch, false, 'the try/catch cannot see an error delivered on a later tick')
+        assert.equal(caughtByListener, true, 'only a stream listener sees it')
+        resolve()
+      } catch (e) { reject(e) }
+    }, 50)
+  })
+})

--- a/server/src/agents/board-columns.ts
+++ b/server/src/agents/board-columns.ts
@@ -1,0 +1,65 @@
+/**
+ * What a board column MEANS, as opposed to what it is called.
+ *
+ * `board_columns.kind` is 'todo' | 'doing' | 'done', or null when the column's
+ * meaning is unknown — a board named "Backlog / In flight / Shipped" is left
+ * unclassified on purpose rather than guessed at.
+ *
+ * This exists because agents could set a card's assignee but never advance it:
+ * `card claim` had no way to know which column was "Doing", so the board sat at
+ * Todo while the work was finished and delivered in chat (#69). The decision is
+ * a pure function so the one rule that matters — never move a card backwards —
+ * is testable without a database.
+ */
+
+export type ColumnKind = 'todo' | 'doing' | 'done'
+
+const KINDS: ReadonlySet<string> = new Set<ColumnKind>(['todo', 'doing', 'done'])
+
+export function isColumnKind(v: unknown): v is ColumnKind {
+  return typeof v === 'string' && KINDS.has(v)
+}
+
+export interface BoardColumn {
+  id: string
+  position: number
+  kind: string | null
+}
+
+/** The column a claim should advance the card into, or null to leave it put.
+ *
+ *  Claiming a card is the moment work starts, so it should read as Doing — that
+ *  is the whole ask in #69. But the move only ever goes FORWARD:
+ *
+ *   - no 'doing' column on this board (custom columns, all unclassified) → stay.
+ *     Guessing which column meant Doing is what this feature exists to avoid.
+ *   - the card is already in the doing column → stay (no churn, no event).
+ *   - the card is in a 'done' column → stay. Re-claiming something finished
+ *     must never drag it back into progress; that would rewrite history the
+ *     humans on the board can see.
+ *   - the card's current column is UNCLASSIFIED → stay. The board is using its
+ *     own workflow, and moving a card out of a column we do not understand is
+ *     exactly the silent damage the null kind is there to prevent.
+ *
+ *  With several 'doing' columns, the leftmost (lowest position) wins, so the
+ *  choice is deterministic rather than dependent on row order. */
+export function claimTargetColumn(args: {
+  columns: readonly BoardColumn[]
+  currentColumnId: string
+}): string | null {
+  const current = args.columns.find((c) => c.id === args.currentColumnId)
+  // Only advance from a column we understand to be "not started".
+  if (!current || current.kind !== 'todo') return null
+  const doing = args.columns
+    .filter((c) => c.kind === 'doing')
+    .sort((a, b) => a.position - b.position)[0]
+  if (!doing || doing.id === args.currentColumnId) return null
+  return doing.id
+}
+
+/** Is this column one where a card counts as finished? Used to describe a
+ *  board's shape to an agent, so "move it to a done column" stops being a
+ *  guess at column titles. */
+export function isDoneColumn(column: Pick<BoardColumn, 'kind'>): boolean {
+  return column.kind === 'done'
+}

--- a/server/src/agents/cli.ts
+++ b/server/src/agents/cli.ts
@@ -55,6 +55,7 @@ async function agentCompany(agentId: string): Promise<string | null> {
 /* ============== argv parsing ============== */
 
 import { parseArgs, unescapeChat, joinBodyArgs, tokenize, type ParsedArgs } from './cli-parse.js'
+import { claimTargetColumn, type ColumnKind } from './board-columns.js'
 export { tokenize }
 
 // resolveAs lives in ./cli-identity for test-isolation (zero-side-effect
@@ -4696,8 +4697,8 @@ async function cmdBoard(parsed: ParsedArgs): Promise<CliResult> {
     }>(`SELECT id, title, description, company_id FROM boards WHERE id = $1 LIMIT 1`, [boardId])
     if (b.rows.length === 0 || b.rows[0].company_id !== companyId) return err(`board ${boardId} not found`)
     const cols = await pool.query<{
-      id: string; title: string; position: number
-    }>(`SELECT id, title, position FROM board_columns WHERE board_id = $1 ORDER BY position ASC`, [boardId])
+      id: string; title: string; position: number; kind: string | null
+    }>(`SELECT id, title, position, kind FROM board_columns WHERE board_id = $1 ORDER BY position ASC`, [boardId])
     const cards = await pool.query<{
       id: string; column_id: string; title: string; assignee_id: string | null
       mentions: string[]; position: number
@@ -4720,7 +4721,10 @@ async function cmdBoard(parsed: ParsedArgs): Promise<CliResult> {
     if (b.rows[0].description) lines.push(b.rows[0].description)
     for (const col of cols.rows) {
       const list = cardsByCol.get(col.id) ?? []
-      lines.push('', `## ${col.title}  (${col.id})  · ${list.length} card(s)`)
+      // Name the column's MEANING, not just its title: an agent moving a card
+      // should not have to infer which column counts as done from prose.
+      const meaning = col.kind ? `  [${col.kind}]` : ''
+      lines.push('', `## ${col.title}${meaning}  (${col.id})  · ${list.length} card(s)`)
       for (const c of list) {
         const who = c.assignee_id ? `@${c.assignee_id}` : '(unassigned)'
         const mentions = Array.isArray(c.mentions) && c.mentions.length > 0
@@ -4746,11 +4750,13 @@ async function cmdBoard(parsed: ParsedArgs): Promise<CliResult> {
         `INSERT INTO boards (id, company_id, title, description, created_by) VALUES ($1, $2, $3, $4, $5)`,
         [id, companyId, title.slice(0, 200), description, me],
       )
-      const seeds = ['Todo', 'Doing', 'Done']
+      // Seed the MEANING alongside the title, so an agent asked to advance a
+      // card never has to infer "which column is Doing" from prose.
+      const seeds: Array<[string, ColumnKind]> = [['Todo', 'todo'], ['Doing', 'doing'], ['Done', 'done']]
       for (let i = 0; i < seeds.length; i++) {
         await client.query(
-          `INSERT INTO board_columns (id, board_id, title, position) VALUES ($1, $2, $3, $4)`,
-          [`col-${randomUUID().slice(0, 12)}`, id, seeds[i], (i + 1) * 1000],
+          `INSERT INTO board_columns (id, board_id, title, position, kind) VALUES ($1, $2, $3, $4, $5)`,
+          [`col-${randomUUID().slice(0, 12)}`, id, seeds[i][0], (i + 1) * 1000, seeds[i][1]],
         )
       }
       await client.query('COMMIT')
@@ -5308,8 +5314,23 @@ async function cmdCard(parsed: ParsedArgs): Promise<CliResult> {
       const holder = cur.rows[0]?.assignee_id
       return err(`claim failed: card ${cardId} is already being worked by @${holder ?? '?'} — move on to another task`)
     }
-    await publishBoardCli({ companyId, kind: 'card.updated', boardId: home.boardId, cardId, actorId: me })
-    return ok(`claimed card ${cardId} — it's yours. Do the work, post progress with \`card comment\`, move it with \`card move\`, and release with \`card assign ${cardId} null\` (or move to a done column) when finished.`, [{
+    // Claiming IS the moment work starts, so reflect it on the board instead of
+    // relying on the agent to remember a second command — that gap is why a
+    // board could read Todo 2 / Doing 1 / Done 0 while the work was finished and
+    // delivered in chat (#69). Only ever forward, and only on a board whose
+    // columns declare what they mean; see claimTargetColumn.
+    const cols = await pool.query<{ id: string; position: number; kind: string | null }>(
+      `SELECT id, position, kind FROM board_columns WHERE board_id = $1`, [home.boardId],
+    )
+    const advanceTo = claimTargetColumn({ columns: cols.rows, currentColumnId: home.columnId })
+    if (advanceTo) {
+      await pool.query(
+        `UPDATE board_cards SET column_id = $1, updated_at = NOW() WHERE id = $2`,
+        [advanceTo, cardId],
+      )
+    }
+    await publishBoardCli({ companyId, kind: advanceTo ? 'card.moved' : 'card.updated', boardId: home.boardId, cardId, actorId: me })
+    return ok(`claimed card ${cardId} — it's yours${advanceTo ? ' and moved to Doing' : ''}. Do the work, post progress with \`card comment\`, move it with \`card move\`, and release with \`card assign ${cardId} null\` (or move to a done column) when finished.`, [{
       event: 'kanban.card_claimed',
       command: 'card claim',
       boardId: home.boardId,

--- a/server/src/agents/computer/engine.ts
+++ b/server/src/agents/computer/engine.ts
@@ -426,6 +426,39 @@ function failurePreview(args: {
   return detail ? `${prefix}\n${detail}`.slice(0, MAX_FAILURE_CHARS) : prefix
 }
 
+/** Write to an engine's stdin without letting a dead pipe crash the process.
+ *
+ *  Every stdin write in this file was wrapped in a try/catch whose comment said
+ *  the child's own error/close path would report the failure. That is not what
+ *  happens. A failed pipe write — EPIPE, when the engine died or was killed
+ *  mid-write — is delivered ASYNCHRONOUSLY as an 'error' event on the stdin
+ *  stream (`afterWriteDispatched`, a tick later), so the try/catch has already
+ *  returned and cannot catch it. With no listener on the stream, Node turns it
+ *  into an uncaught exception. It surfaced as a flaky `write EPIPE` failure in
+ *  PiAdapter.probeWake on CI, but every adapter had the same hole.
+ *
+ *  A dead engine is ordinary: the operator quit the CLI, a turn was aborted,
+ *  doctor tore its probe down. The child's own 'error'/'close' handlers already
+ *  report it, so the stream error is noise — it just must not be UNHANDLED.
+ *
+ *  Returns false when the write could not even be attempted, so callers that
+ *  care can bail; the ones that don't already fall through to their close path. */
+function writeStdin(child: ChildProcess, text: string, opts: { end?: boolean } = {}): boolean {
+  const stdin = child.stdin
+  if (!stdin) return false
+  // Attach once per stream — repeated writes must not stack listeners.
+  if (stdin.listenerCount('error') === 0) {
+    stdin.on('error', () => { /* reported by the child's own close/error path */ })
+  }
+  try {
+    stdin.write(text)
+    if (opts.end) stdin.end()
+    return true
+  } catch {
+    return false
+  }
+}
+
 function spawnEngine(
   bin: string,
   args: string[],
@@ -439,7 +472,7 @@ function spawnEngine(
       shell: spawnOpts.shell ?? false,
     })
     if (spawnOpts.stdinText != null) {
-      try { child.stdin?.write(spawnOpts.stdinText); child.stdin?.end() } catch { /* the 'error' handler resolves */ }
+      writeStdin(child, spawnOpts.stdinText, { end: true })
     }
     const onAbort = (): void => { child.kill('SIGTERM') }
     signal.addEventListener('abort', onAbort, { once: true })
@@ -563,7 +596,7 @@ function spawnCapture(
       shell: shell ?? false,
     })
     if (stdinText != null) {
-      try { child.stdin?.write(stdinText); child.stdin?.end() } catch { /* the 'error' handler resolves */ }
+      writeStdin(child, stdinText, { end: true })
     }
     const onAbort = (): void => { child.kill('SIGTERM') }
     signal.addEventListener('abort', onAbort, { once: true })
@@ -718,10 +751,8 @@ class ClaudeSession implements EngineSession {
         this.pendingTimer.unref?.()
       }
       const msg = JSON.stringify({ type: 'user', message: { role: 'user', content: [{ type: 'text', text: stripLoneSurrogates(prompt) }] } }) + '\n'
-      try {
-        this.child.stdin!.write(msg)
-      } catch (err) {
-        this.settle({ exitCode: 1, error: `failed to write turn to engine: ${err instanceof Error ? err.message : String(err)}`, sessionId: this.sid })
+      if (!writeStdin(this.child, msg)) {
+        this.settle({ exitCode: 1, error: 'failed to write turn to engine (stdin closed)', sessionId: this.sid })
       }
     })
   }
@@ -744,9 +775,7 @@ class ClaudeSession implements EngineSession {
     if (!this.pending || !this.alive) return
     while (this.steerQueue.length > 0) {
       const text = this.steerQueue.shift()!
-      try {
-        this.child.stdin!.write(JSON.stringify({ type: 'user', message: { role: 'user', content: [{ type: 'text', text: stripLoneSurrogates(text) }] } }) + '\n')
-      } catch { break }
+      if (!writeStdin(this.child, JSON.stringify({ type: 'user', message: { role: 'user', content: [{ type: 'text', text: stripLoneSurrogates(text) }] } }) + '\n')) break
     }
   }
 
@@ -1137,10 +1166,8 @@ class CodexSession implements EngineSession {
 
   steer(text: string): void {
     if (!this.alive || !text.trim() || !this.threadId || !this.activeTurnId || this.steerGate) return
-    try {
-      this.child.stdin!.write(JSON.stringify({ jsonrpc: '2.0', id: this.nextId(), method: 'turn/steer',
-        params: { threadId: this.threadId, expectedTurnId: this.activeTurnId, input: [{ type: 'text', text: stripLoneSurrogates(text) }] } }) + '\n')
-    } catch { /* best-effort */ }
+    writeStdin(this.child, JSON.stringify({ jsonrpc: '2.0', id: this.nextId(), method: 'turn/steer',
+      params: { threadId: this.threadId, expectedTurnId: this.activeTurnId, input: [{ type: 'text', text: stripLoneSurrogates(text) }] } }) + '\n')
   }
 
   stop(): void {
@@ -1152,11 +1179,11 @@ class CodexSession implements EngineSession {
   private nextId(): number { this.reqId += 1; return this.reqId }
   private req(method: string, params: Record<string, unknown>): number {
     const id = this.nextId()
-    try { this.child.stdin?.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n') } catch { /* die() handles */ }
+    writeStdin(this.child, JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n')
     return id
   }
   private notify(method: string, params: Record<string, unknown>): void {
-    try { this.child.stdin?.write(JSON.stringify({ jsonrpc: '2.0', method, params }) + '\n') } catch { /* die() handles */ }
+    writeStdin(this.child, JSON.stringify({ jsonrpc: '2.0', method, params }) + '\n')
   }
   private startTurn(prompt: string): void {
     if (this.threadId) {
@@ -1413,7 +1440,7 @@ class CodexAdapter implements EngineAdapter {
       let initialized = false
       let threadAcked = false
       const writeRpc = (msg: object) => {
-        try { child.stdin?.write(JSON.stringify(msg) + '\n') } catch { /* die path handles */ }
+        writeStdin(child, JSON.stringify(msg) + '\n')
       }
       // Kick off the handshake once the process is up. spawn() emits stdout
       // 'data' lazily — that's the point at which we know the child is alive
@@ -1615,7 +1642,7 @@ class GrokSession implements EngineSession {
   private nextId(): number { this.reqId += 1; return this.reqId }
   private req(method: string, params: Record<string, unknown>): number {
     const id = this.nextId()
-    try { this.child.stdin?.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n') } catch { /* die() */ }
+    writeStdin(this.child, JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n')
     return id
   }
 
@@ -1850,7 +1877,7 @@ class GrokAdapter implements EngineAdapter {
       const sessionId = 2
       let initialized = false
       const writeRpc = (msg: object) => {
-        try { child.stdin?.write(JSON.stringify(msg) + '\n') } catch { /* die */ }
+        writeStdin(child, JSON.stringify(msg) + '\n')
       }
       writeRpc({
         jsonrpc: '2.0', id: initId, method: 'initialize',
@@ -2099,7 +2126,7 @@ function spawnCursorStream(
       shell: opts.shell,
     })
     if (opts.stdinText != null) {
-      try { child.stdin?.write(opts.stdinText); child.stdin?.end() } catch { /* the 'error' handler resolves */ }
+      writeStdin(child, opts.stdinText, { end: true })
     }
     const onAbort = (): void => { child.kill('SIGTERM') }
     opts.signal.addEventListener('abort', onAbort, { once: true })
@@ -2872,7 +2899,7 @@ function spawnPiJson(
       shell: opts.shell,
     })
     if (opts.stdinText != null) {
-      try { child.stdin?.write(opts.stdinText); child.stdin?.end() } catch { /* the 'error' handler resolves */ }
+      writeStdin(child, opts.stdinText, { end: true })
     }
     const onAbort = (): void => { child.kill('SIGTERM') }
     opts.signal.addEventListener('abort', onAbort, { once: true })
@@ -3018,7 +3045,7 @@ class PiSession implements EngineSession {
   }
 
   private write(msg: object): boolean {
-    try { this.child.stdin!.write(`${JSON.stringify(msg)}\n`); return true } catch { return false }
+    return writeStdin(this.child, `${JSON.stringify(msg)}\n`)
   }
 
   private onStdout(buf: Buffer): void {
@@ -3186,7 +3213,7 @@ class PiAdapter implements EngineAdapter {
       args.signal.addEventListener('abort', onAbort, { once: true })
       let buf = ''
       let stderrTail = ''
-      try { child.stdin?.write(`${JSON.stringify({ id: 'doctor', type: 'get_state' })}\n`) } catch { /* close handler reports */ }
+      writeStdin(child, `${JSON.stringify({ id: 'doctor', type: 'get_state' })}\n`)
       child.stdout?.on('data', (b: Buffer) => {
         buf += b.toString('utf8')
         for (;;) {

--- a/server/src/api/router.ts
+++ b/server/src/api/router.ts
@@ -5133,11 +5133,14 @@ api.post('/boards', async (req, res) => {
       `INSERT INTO boards (id, company_id, title, description, created_by) VALUES ($1, $2, $3, $4, $5)`,
       [id, companyId, title, description, me],
     )
-    const seeds = ['Todo', 'Doing', 'Done']
+    // Seed the MEANING alongside the title — see board-columns.ts. Without it an
+    // agent asked to advance a card has to infer which column is "Doing" from
+    // its name, which is why claim could never move anything.
+    const seeds: Array<[string, string]> = [['Todo', 'todo'], ['Doing', 'doing'], ['Done', 'done']]
     for (let i = 0; i < seeds.length; i++) {
       await client.query(
-        `INSERT INTO board_columns (id, board_id, title, position) VALUES ($1, $2, $3, $4)`,
-        [`col-${randomUUID().slice(0, 12)}`, id, seeds[i], (i + 1) * 1000],
+        `INSERT INTO board_columns (id, board_id, title, position, kind) VALUES ($1, $2, $3, $4, $5)`,
+        [`col-${randomUUID().slice(0, 12)}`, id, seeds[i][0], (i + 1) * 1000, seeds[i][1]],
       )
     }
     await client.query('COMMIT')
@@ -5167,9 +5170,9 @@ api.get('/boards/:id', async (req, res) => {
   )
   if (board.rows.length === 0) throw new HttpError(404, 'not found')
   const cols = await pool.query<{
-    id: string; title: string; position: number; created_at: string
+    id: string; title: string; position: number; kind: string | null; created_at: string
   }>(
-    `SELECT id, title, position, created_at
+    `SELECT id, title, position, kind, created_at
        FROM board_columns WHERE board_id = $1 ORDER BY position ASC`,
     [boardId],
   )

--- a/server/src/db/migrate.ts
+++ b/server/src/db/migrate.ts
@@ -1302,6 +1302,29 @@ CREATE TABLE IF NOT EXISTS board_columns (
 );
 CREATE INDEX IF NOT EXISTS idx_board_columns_board ON board_columns(board_id, position ASC);
 
+-- What a column MEANS, as opposed to what it is called. 'todo' | 'doing' |
+-- 'done', or NULL for a column whose meaning we do not know.
+--
+-- Both board-creation paths already seed the conventional "Todo / Doing / Done",
+-- so the convention existed — it just was not machine-readable, and an agent
+-- asked to "move it to Doing" had to guess which column that was from its title.
+-- That is why card claim could set an assignee but never advance the card, and
+-- why a board could read Todo 2 / Doing 1 / Done 0 while the work was finished
+-- and delivered in chat.
+ALTER TABLE board_columns ADD COLUMN IF NOT EXISTS kind TEXT;
+
+-- Backfill EXACT matches on the seeded defaults only, case-insensitively.
+-- Deliberately not a fuzzy match: a board whose columns are "Backlog / In
+-- flight / Shipped" is better left NULL (nothing moves automatically) than
+-- guessed at, and a wrong guess would silently move a user's cards. Runs once;
+-- already-classified columns are left alone so a later manual choice sticks.
+UPDATE board_columns SET kind = 'todo'
+ WHERE kind IS NULL AND lower(btrim(title)) IN ('todo', 'to do');
+UPDATE board_columns SET kind = 'doing'
+ WHERE kind IS NULL AND lower(btrim(title)) = 'doing';
+UPDATE board_columns SET kind = 'done'
+ WHERE kind IS NULL AND lower(btrim(title)) = 'done';
+
 -- Cards live in a column. The "mentions" column is the deduped list of
 -- @-targets parsed from title+description on every write — clients can
 -- fan out notifications / "assigned to me" filters off it without


### PR DESCRIPTION
Closes the lifecycle half of #69. (The wake half landed in #79.)

## The root cause

`board_columns` had only a `title` and a `position` — so **"which column is Doing" was a guess from prose**. That is the mechanism behind the reported board: `card claim` set an assignee but could not advance anything, progress depended entirely on the model remembering a second command, and the board sat at **Todo 2 / Doing 1 / Done 0** while the work was finished and delivered in chat.

I flagged this as needing a product decision when I fixed the wake half. This PR makes the decision the cheapest way available: the convention *already existed* — both board-creation paths seed `Todo / Doing / Done` — it just wasn't machine-readable.

## What changes

A nullable `kind` on `board_columns` (`'todo' | 'doing' | 'done'`), seeded on create, returned on every read, and shown in the agent's board view:

```
## Doing  [doing]  (col-a1b2c3)  · 2 card(s)
```

so "move it to a done column" stops being a guess at titles.

## The backfill is the risky part

It writes to **every existing board in every deployment**, so it matches the seeded defaults exactly — case- and padding-insensitive — and nothing else. A board running `Backlog / In flight / Shipped` is left `NULL`, where nothing moves automatically, rather than guessed at. A wrong guess would silently reclassify someone's workflow.

It also skips any column that already has a kind, so a manual choice survives re-runs of the migrator.

## Claim advances the card — forward only

The cases that **don't** move are where the risk lives, so that's where the tests are:

| situation | result | why |
| --- | --- | --- |
| card in Todo, board has Doing | → Doing | the ask in #69 |
| no `doing` column on the board | stay | that's the guess we refuse to make |
| already in Doing | stay | no churn, no phantom `card.moved` |
| card is in a `done` column | stay | re-claiming something finished must never rewrite what humans already saw |
| current column is unclassified | stay | moving a card out of a column we don't understand is the silent damage the null kind exists to prevent |

With several `doing` columns the leftmost (lowest position) wins, so the choice is deterministic rather than row-order dependent.

## Tests

The decision is a pure function in `board-columns.ts` — **10 unit cases, most of them about not moving.**

The database halves get **6 integration cases**, because they can't be honestly asserted from a machine with no Postgres:

- a CLI-created board comes out classified
- claim advances Todo → Doing, and says so
- claim on a card in Done leaves it there
- claim on a custom (unclassified) board moves nothing
- **the migration classifies a conventional board and leaves a custom one alone** — the case that matters most, since this runs against existing data
- the backfill does not overwrite a kind someone set deliberately

## Not included

No UI for editing a column's kind. Custom boards stay `NULL` and simply behave as they do today, so nothing regresses — but letting someone mark "In flight" as `doing` needs a design call on where that control lives. Happy to add it.

Also merges #94, so this branch's unit job doesn't fail on the unrelated pi `EPIPE` flake.

## Checks

`npm run lint`, `npm run typecheck`, `npm run server:typecheck` pass. The unit-suite failure set is identical to `main`'s on my machine (the same 25 env-dependent files).
