### PR TITLE
fix(byoa): a plural "no sessions found" is a stale resume target too

### DIFF
--- a/server/src/__tests__/agents-computer-session-reset.test.ts
+++ b/server/src/__tests__/agents-computer-session-reset.test.ts
@@ -83,6 +83,44 @@ test('other stale-target phrasings are recognized', () => {
   }
 })
 
+test('a PLURAL miss is a stale resume target too', () => {
+  // gemini exits fatally on `--resume <uuid>` once its per-project chats dir is
+  // gone, and says so in the plural. Read as "not stale", the daemon keeps the
+  // dead id and hands it back on the next wake — and the one after that. The
+  // agent never runs again, which is worse than losing its context.
+  for (const phrase of [
+    'Error resuming session: No previous sessions found for this project.',
+    'Error: sessions not found',
+    'Error: invalid sessions',
+    'Error: those threads do not exist',
+  ]) {
+    assert.equal(isStaleResumeError(`local gemini failed (exit 1): ${phrase}`), true, phrase)
+  }
+})
+
+test('the singular phrasings every other engine uses still match', () => {
+  // The plural allowance must not have moved the boundary for anyone else.
+  for (const phrase of [
+    'No conversation found with session ID: abc',
+    'Error: session does not exist',
+    'Error: conversation no longer exists',
+  ]) {
+    assert.equal(isStaleResumeError(`local claude failed (exit 1): ${phrase}`), true, phrase)
+  }
+})
+
+test('a plural noun without failure wording is still not a diagnosis', () => {
+  // The guard that matters: "sessions" alone proves nothing. Only the paired
+  // failure wording does.
+  for (const phrase of [
+    'process exited with code 137',
+    'wrote 3 sessions to disk',
+    'listing sessions for this project',
+  ]) {
+    assert.equal(isStaleResumeError(`local gemini failed (exit 1): ${phrase}`), false, phrase)
+  }
+})
+
 test('an ordinary crash with no session wording is not a stale resume target', () => {
   assert.equal(isStaleResumeError('local claude failed (exit 143): process terminated by SIGTERM'), false)
 })

--- a/server/src/agents/computer/daemon.ts
+++ b/server/src/agents/computer/daemon.ts
@@ -569,12 +569,17 @@ const POISONED_BODY_RE = /no (?:low|high) surrogate|unpaired surrogate|lone surr
 // mid-turn engine death into a "stale resume target" and threw away the session
 // id that exists to recover the interrupted turn.
 const STALE_RESUME_RE = new RegExp([
-  // "No conversation found with session ID: …", "no such session"
-  String.raw`\bno (?:such )?(?:\w+ )?(?:conversation|session|thread)\b`,
+  // "No conversation found with session ID: …", "no such session",
+  // "No previous sessions found for this project" (gemini, when the whole
+  // chats dir is gone). The trailing `s?` is load-bearing: an engine that
+  // reports the miss in the PLURAL is saying the resume target is gone just as
+  // plainly as the singular, and without it the daemon kept the dead id and
+  // re-sent it every wake — a permanently wedged agent, not a degraded one.
+  String.raw`\bno (?:such )?(?:\w+ )?(?:conversation|session|thread)s?\b`,
   // "Session not found", "conversation no longer exists", "thread has expired"
-  String.raw`\b(?:conversation|session|thread)(?: id)?\b[^\n]{0,24}?\b(?:not found|no longer exists?|does not exist|doesn't exist|has expired|is expired|is invalid|is unknown)\b`,
+  String.raw`\b(?:conversation|session|thread)s?(?: id)?\b[^\n]{0,24}?\b(?:not found|no longer exists?|do(?:es)? not exist|doesn't exist|has expired|is expired|is invalid|is unknown)\b`,
   // "Invalid session id", "unknown conversation", "expired thread"
-  String.raw`\b(?:invalid|unknown|expired|stale|malformed) (?:\w+ )?(?:conversation|session|thread)\b`,
+  String.raw`\b(?:invalid|unknown|expired|stale|malformed) (?:\w+ )?(?:conversation|session|thread)s?\b`,
   // "could not resume", "unable to resume this conversation", "failed to resume"
   String.raw`\b(?:could ?n(?:o|')?t|cannot|can't|unable to|failed to)\b[^\n]{0,24}?\bresume\b`,
   // codex app-server's own wording


### PR DESCRIPTION
The daemon drops an agent's engine session id only when carrying it forward would keep failing. `STALE_RESUME_RE` decides that, and every noun in it was singular — `(?:conversation|session|thread)\b`. Against `No previous sessions found for this project.` the `\b` lands on the plural `s`, and the match fails.

## Why this is a real failure, not a tidy-up

That exact sentence is what Gemini CLI emits. From the shipped 0.57.0 bundle:

```js
static noSessionsFound() {
  return new _SessionError("NO_SESSIONS_FOUND", "No previous sessions found for this project.")
}
```

`gemini --resume <uuid>` resolves the id against a per-project chats dir. If that dir is gone (temp cleanup, a moved home, a fresh machine) the resume throws, and `resolveSessionId` only *degrades* to a new session when the arg was the literal `latest` — a UUID takes the fatal branch and the process exits.

Read as "not stale", the daemon keeps the dead id and hands it back on the next wake, and the one after that. The two failure directions are not symmetric:

- dropping a **live** session id → the agent loses its place in a running task (this is why the noun-only match was tightened in the first place)
- keeping a **dead** one → the agent never runs again

Verified against the current regex before changing it:

```
true   Invalid session identifier "abc-123". Searched for sessions in /tmp/chats.
false  No previous sessions found for this project.
false  Error resuming session: No previous sessions found for this project.
```

The singular sibling matches; the plural one does not.

## The change

`s?` is added only where failure wording is already required — after `no ...`, after `invalid|unknown|expired|stale|malformed ...`, and before `not found|no longer exists|...`. (`does not exist` also becomes `do(?:es)? not exist` so the plural subject reads.) The property the singular nouns were protecting is untouched: a bare mention of a session still proves nothing, which is what made the noun-only match wrong originally.

## Tests

Three cases in `agents-computer-session-reset.test.ts`, covering both directions:

- plural misses now reset (`No previous sessions found…`, `sessions not found`, `invalid sessions`, `those threads do not exist`)
- every singular phrasing other engines use still matches (no boundary moved)
- a plural noun **without** failure wording is still not a diagnosis (`wrote 3 sessions to disk`, `listing sessions for this project`)

14/14 in that file locally. The full unit suite needs Postgres, so CI is the authority there.

Groundwork for a Gemini CLI adapter (#75), but it stands on its own — any engine that reports the miss in the plural hits this today.
