### PR TITLE
fix(computer): keep Windows daemon fully headless on Windows

### DIFF
--- a/server/src/__tests__/agents-computer-engine.test.ts
+++ b/server/src/__tests__/agents-computer-engine.test.ts
@@ -9,7 +9,7 @@ import { tmpdir } from 'node:os'
 import { delimiter, join } from 'node:path'
 import { afterEach, test } from 'node:test'
 import { setTimeout as delay } from 'node:timers/promises'
-import { getAdapter, resolveSpawn, type EngineHopReport, type EngineRunResult } from '../agents/computer/engine.js'
+import { getAdapter, headlessSpawnOptions, resolveSpawn, type EngineHopReport, type EngineRunResult } from '../agents/computer/engine.js'
 
 const IS_WIN = process.platform === 'win32'
 const ORIGINAL_PATH = process.env.PATH
@@ -18,6 +18,14 @@ const tempDirs: string[] = []
 // Sessions spawn a child process. Track them so a FAILING assertion still tears
 // the child down — otherwise it outlives the test and the runner never exits.
 const liveSessions: Array<{ stop(): void }> = []
+
+test('engine subprocesses always suppress Windows console windows', () => {
+  assert.deepEqual(headlessSpawnOptions({ shell: true, cwd: 'C:\\agent home', windowsHide: false }), {
+    shell: true,
+    cwd: 'C:\\agent home',
+    windowsHide: true,
+  })
+})
 
 afterEach(async () => {
   for (const s of liveSessions.splice(0)) { try { s.stop() } catch { /* already gone */ } }

--- a/server/src/__tests__/agents-computer-windows-service.test.ts
+++ b/server/src/__tests__/agents-computer-windows-service.test.ts
@@ -4,6 +4,7 @@ import {
   isWindowsSupervisorProcess,
   parseWindowsProcessList,
   renderWindowsSupervisor,
+  renderWindowsSupervisorLauncher,
   resolveNpx,
   windowsScheduledTaskCommand,
   windowsScheduledTaskCreateArgs,
@@ -40,14 +41,19 @@ test('Windows supervisor restarts the latest daemon with supervision enabled', (
 
 test('Windows scheduled task runs the watchdog at login with limited privileges', () => {
   const scriptPath = 'C:\\Users\\Test User\\.cumora\\daemon-supervisor.ps1'
+  const launcherPath = 'C:\\Users\\Test User\\.cumora\\daemon-supervisor.vbs'
   const taskName = windowsTaskName('C:\\Users\\Test User')
+  const launcher = renderWindowsSupervisorLauncher(scriptPath)
+  assert.match(launcher, /CreateObject\("WScript\.Shell"\)/)
+  assert.match(launcher, /powershell\.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -WindowStyle Hidden -File ""C:\\Users\\Test User\\\.cumora\\daemon-supervisor\.ps1""/)
+  assert.match(launcher, /, 0, True/)
   assert.equal(
-    windowsScheduledTaskCommand(scriptPath),
-    'powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -WindowStyle Hidden -File "C:\\Users\\Test User\\.cumora\\daemon-supervisor.ps1"',
+    windowsScheduledTaskCommand(launcherPath),
+    'wscript.exe //B //Nologo "C:\\Users\\Test User\\.cumora\\daemon-supervisor.vbs"',
   )
-  assert.deepEqual(windowsScheduledTaskCreateArgs(scriptPath, taskName), [
+  assert.deepEqual(windowsScheduledTaskCreateArgs(launcherPath, taskName), [
     '/Create', '/TN', taskName,
-    '/TR', windowsScheduledTaskCommand(scriptPath),
+    '/TR', windowsScheduledTaskCommand(launcherPath),
     '/SC', 'ONLOGON', '/RL', 'LIMITED', '/IT', '/F',
   ])
 

--- a/server/src/agents/computer/daemon.ts
+++ b/server/src/agents/computer/daemon.ts
@@ -2658,6 +2658,10 @@ function windowsSupervisorPath(): string {
   return join(CONFIG_DIR, 'daemon-supervisor.ps1')
 }
 
+function windowsSupervisorLauncherPath(): string {
+  return join(CONFIG_DIR, 'daemon-supervisor.vbs')
+}
+
 function windowsSupervisorDisabledPath(): string {
   return join(CONFIG_DIR, 'daemon-supervisor.disabled')
 }
@@ -2694,17 +2698,36 @@ export function renderWindowsSupervisor(
   ].join('\r\n')
 }
 
-export function windowsScheduledTaskCommand(scriptPath: string): string {
-  return `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -WindowStyle Hidden -File "${scriptPath.replaceAll('"', '""')}"`
+function quoteVbScript(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`
+}
+
+/** Task Scheduler's interactive PowerShell action can still acquire a visible
+ *  Windows Terminal host on Windows 11, even with `-WindowStyle Hidden`. Launch
+ *  through the GUI-subsystem wscript.exe instead; WScript.Shell.Run's window
+ *  style 0 keeps PowerShell and its watchdog process tree hidden from birth. */
+export function renderWindowsSupervisorLauncher(scriptPath: string): string {
+  const command = `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -WindowStyle Hidden -File "${scriptPath.replaceAll('"', '""')}"`
+  return [
+    'Set shell = CreateObject("WScript.Shell")',
+    // Wait for the watchdog so Task Scheduler keeps the task in Running state
+    // and refuses duplicate /Run requests while this supervisor is alive.
+    `shell.Run ${quoteVbScript(command)}, 0, True`,
+    '',
+  ].join('\r\n')
+}
+
+export function windowsScheduledTaskCommand(launcherPath: string): string {
+  return `wscript.exe //B //Nologo "${launcherPath.replaceAll('"', '""')}"`
 }
 
 export function windowsScheduledTaskCreateArgs(
-  scriptPath: string,
+  launcherPath: string,
   taskName = windowsTaskName(),
 ): string[] {
   return [
     '/Create', '/TN', taskName,
-    '/TR', windowsScheduledTaskCommand(scriptPath),
+    '/TR', windowsScheduledTaskCommand(launcherPath),
     '/SC', 'ONLOGON', '/RL', 'LIMITED', '/IT', '/F',
   ]
 }
@@ -2797,14 +2820,16 @@ WantedBy=default.target
 
   if (process.platform === 'win32') {
     const scriptPath = windowsSupervisorPath()
+    const launcherPath = windowsSupervisorLauncherPath()
     const disabledPath = windowsSupervisorDisabledPath()
     const taskName = windowsTaskName()
     const replacing = await isWindowsTaskInstalled(taskName)
     await writeFile(scriptPath, renderWindowsSupervisor(npx, serverUrl, logPath, disabledPath), 'utf8')
+    await writeFile(launcherPath, renderWindowsSupervisorLauncher(scriptPath), 'utf8')
     try {
-      if (!replacing) {
-        await execFileP('schtasks.exe', windowsScheduledTaskCreateArgs(scriptPath, taskName))
-      }
+      // Always recreate with /F: an existing task may still point at the old
+      // direct-PowerShell action, so merely replacing the scripts is not enough.
+      await execFileP('schtasks.exe', windowsScheduledTaskCreateArgs(launcherPath, taskName))
       await execFileP('powershell.exe', [
         '-NoProfile', '-NonInteractive', '-Command', windowsScheduledTaskSettingsCommand(taskName),
       ])
@@ -2816,6 +2841,7 @@ WantedBy=default.target
           throw new Error(`scheduled task setup failed and rollback could not delete '${taskName}'; the watchdog script was kept in place (${rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)})`, { cause: err })
         }
         await rm(scriptPath, { force: true }).catch(() => {})
+        await rm(launcherPath, { force: true }).catch(() => {})
       }
       throw err
     }
@@ -2869,6 +2895,7 @@ async function uninstallService(): Promise<void> {
       throw new Error(`scheduled task '${taskName}' still exists after deletion`)
     }
     await rm(windowsSupervisorPath(), { force: true })
+    await rm(windowsSupervisorLauncherPath(), { force: true })
     // Keep this sentinel on every failed stop path so a surviving watchdog
     // cannot revive a daemon after the command has reported an error.
     await rm(disabledPath, { force: true })

--- a/server/src/agents/computer/engine.ts
+++ b/server/src/agents/computer/engine.ts
@@ -20,7 +20,7 @@
  * loop does not depend on the structured output — the agent acts via the
  * `cumora` tool regardless of how we parse stdout.
  */
-import { spawn, execFileSync, type ChildProcess } from 'node:child_process'
+import { spawn as nodeSpawn, execFileSync, type ChildProcess, type SpawnOptions } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { mkdir, writeFile, access, mkdtemp } from 'node:fs/promises'
 import { existsSync, writeFileSync } from 'node:fs'
@@ -30,6 +30,22 @@ import { StringDecoder } from 'node:string_decoder'
 import { stripLoneSurrogates } from '../text-safety.js'
 
 const IS_WIN = process.platform === 'win32'
+
+/** Every engine runs headlessly behind the daemon. On Windows, leaving
+ *  `windowsHide` at Node's default (`false`) lets a console executable (or the
+ *  cmd.exe needed for an npm .cmd shim) create a visible terminal even when the
+ *  PowerShell watchdog itself was launched with `-WindowStyle Hidden`.
+ *
+ *  Keep this in the module-local spawn wrapper so persistent sessions, one-shot
+ *  turns, doctor probes, and PATH probes cannot drift apart. `windowsHide` is
+ *  ignored on non-Windows platforms. */
+export function headlessSpawnOptions(options: SpawnOptions = {}): SpawnOptions {
+  return { ...options, windowsHide: true }
+}
+
+function spawn(command: string, args: string[], options: SpawnOptions = {}): ChildProcess {
+  return nodeSpawn(command, args, headlessSpawnOptions(options))
+}
 
 // Optional last-resort cap on a single persistent-engine turn. DEFAULT OFF (0):
 // a wall-clock timeout CANNOT tell a genuinely-hung turn from a legitimately


### PR DESCRIPTION
## Summary

- launch the Windows scheduled-task watchdog through `wscript.exe` so Windows 11 does not attach it to a visible Windows Terminal
- force `windowsHide: true` for every engine subprocess, including persistent sessions and one-shot probes
- recreate existing scheduled tasks so installations using the old direct-PowerShell action are upgraded, and clean up the launcher during uninstall

## Why

Launching PowerShell directly from an interactive scheduled task can still create a visible Windows Terminal on Windows 11, even with `-WindowStyle Hidden`. Closing that terminal also terminates the watchdog and takes the Cumora computer offline. Engine subprocesses can independently create console windows as well.

The scheduled task now starts a GUI-subsystem VBScript launcher with window style `0`. The launcher waits for the PowerShell watchdog, keeping Task Scheduler aware that the task is running, while all engine spawns are hidden at the Node.js layer.

## Verification

- Windows service regression tests: 7/7 passed
- engine headless-spawn regression test: passed
- `npm run server:typecheck`
- Biome lint on all changed files
- manually verified the process tree is Task Scheduler -> wscript -> PowerShell watchdog -> Node daemon, with no Windows Terminal ancestor
- manually verified the watchdog restarts the daemon after a controlled shutdown while the desktop app is closed
