### PR TITLE
fix(byoa): tell the operator when an engine CLI is too old, instead of its help text

### DIFF
--- a/server/src/__tests__/engine-argv-rejection.test.ts
+++ b/server/src/__tests__/engine-argv-rejection.test.ts
@@ -1,0 +1,80 @@
+/**
+ * An engine that rejects one of Cumora's own flags failed BEFORE doing any
+ * work, and the fix is a CLI update — not signing in, not waiting out a rate
+ * limit. The doctor has to say so, and the raw output actively hides it.
+ *
+ * Every fixture below is the real wording of the real binary, captured by
+ * feeding each CLI a flag it does not have.
+ *
+ * Run: node --import tsx --test server/src/__tests__/engine-argv-rejection.test.ts
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { argvRejection } from '../agents/computer/engine.js'
+
+const ESC = '\u001b'
+
+// `gemini -o stream-json` against 0.1.15: the whole help goes to stderr and the
+// cause is the LAST line. This is why a first-N-characters preview is useless
+// here — the banner fills the budget and the reason is cut off the end.
+const OLD_GEMINI = [
+  'gemini [options]',
+  '',
+  'Gemini CLI - Launch an interactive CLI, use -p/--prompt for non-interactive mode',
+  '',
+  'Options:',
+  '  -m, --model                     Model  [string] [default: "gemini-2.5-pro"]',
+  '  -p, --prompt                    Prompt. Appended to input on stdin (if any).  [string]',
+  '  -y, --yolo                      Automatically accept all actions?  [boolean] [default: false]',
+  '      --proxy                     Proxy for gemini client, like schema://user:password@host:port  [string]',
+  '  -v, --version                   Show version number  [boolean]',
+  '  -h, --help                      Show help  [boolean]',
+  '',
+  'Unknown argument: o',
+].join('\n')
+
+test('the cause is found below a full help dump', () => {
+  assert.equal(argvRejection(OLD_GEMINI), 'Unknown argument: o')
+})
+
+test('every engine Cumora drives is recognized in its own wording', () => {
+  for (const [raw, expected] of [
+    // claude and cursor-agent (commander)
+    ["error: unknown option '--output-format'", "unknown option '--output-format'"],
+    // codex (clap)
+    ["error: unexpected argument '--output-format' found", "unexpected argument '--output-format' found"],
+    // yargs, plural form
+    ['Unknown arguments: o, output-format', 'Unknown arguments: o, output-format'],
+  ] as const) {
+    assert.equal(argvRejection(raw), expected, raw)
+  }
+})
+
+test('the failures that are NOT a version problem stay unmatched', () => {
+  // These have their own remedies, and mislabelling them sends the operator off
+  // to reinstall a CLI that was fine.
+  for (const raw of [
+    "error: You've hit your usage limit. Try again in 3 hours.",
+    'Error: not logged in. Run `claude login`.',
+    'API key not valid. Please pass a valid API key.',
+    'error: connection reset by peer',
+    'process exited with code 137',
+    '',
+  ]) {
+    assert.equal(argvRejection(raw), null, raw)
+  }
+})
+
+test('ANSI colouring does not hide the line', () => {
+  assert.equal(argvRejection(`${ESC}[31mUnknown argument: o${ESC}[0m`), 'Unknown argument: o')
+})
+
+test('a CRLF stream is handled', () => {
+  assert.equal(argvRejection('banner\r\nUnknown argument: o\r\n'), 'Unknown argument: o')
+})
+
+test('the line is bounded so one long argv cannot flood the doctor', () => {
+  const long = `Unknown argument: ${'x'.repeat(500)}`
+  const got = argvRejection(long)
+  assert.ok(got && got.length <= 120)
+})

--- a/server/src/agents/computer/engine.ts
+++ b/server/src/agents/computer/engine.ts
@@ -3422,10 +3422,40 @@ export interface EngineHealth {
   wake: WakeHealth | null
 }
 
+/** How the engines Cumora drives word a rejected flag. Taken from the real
+ *  binaries, because the shapes differ more than they look:
+ *
+ *    claude / cursor-agent   error: unknown option '--x'
+ *    codex                   error: unexpected argument '--x' found
+ *    gemini 0.1.x            Unknown argument: o
+ *
+ *  Only the first two lead with `error:`, which is what `salientError` keys on.
+ *  Gemini prints its ENTIRE help to stderr and puts the cause on the LAST line,
+ *  so without this pattern the operator's diagnosis is 280 characters of usage
+ *  text with the reason cut off the end. */
+const ARGV_REJECTION_RE =
+  /\b(?:unknown (?:argument|option|flag)s?|unrecogni[sz]ed (?:argument|option)s?|unexpected argument|invalid option)\b[^\n]*/i
+
+/** The engine rejected one of OUR flags, so it failed before doing any work.
+ *
+ *  Worth separating from every other probe failure because the fix is
+ *  different in kind: not "sign in", not "wait out the rate limit", but "the
+ *  installed CLI is older than the flag set this adapter sends". Returns the
+ *  offending line, or null when the failure was something else. */
+export function argvRejection(raw: string): string | null {
+  const m = raw.replace(ANSI_RE, '').replace(/\r/g, '').match(ARGV_REJECTION_RE)
+  return m ? m[0].replace(/\s+/g, ' ').trim().slice(0, 120) : null
+}
+
 /** Pull the most informative line out of an engine's failure output. Engines bury
  *  the real cause (usage limit / not signed in / bad model) under a multi-line
  *  startup banner, often on a different stream — lead with the line that names it. */
 function salientError(raw: string): string {
+  // Ahead of the generic scan: an argv rejection can sit BELOW a whole help
+  // dump, and the fallback (first 280 chars of everything) would show the
+  // banner instead of the cause.
+  const rejected = argvRejection(raw)
+  if (rejected) return rejected
   const clean = raw.replace(ANSI_RE, '').replace(/\r/g, '')
   const m = clean.match(
     /((?:error|fatal)\b[:\- ].*|you'?ve hit your usage limit.*|usage limit.*|rate.?limit.*|quota.*|over(?:loaded|capacity).*|insufficient (?:credit|quota).*|unauthor\w*.*|forbidden.*|invalid (?:api )?key.*|not (?:logged in|authenticated|signed in).*|(?:please )?(?:sign|log) ?in.*|authentication .*)/i,
@@ -3473,7 +3503,16 @@ export async function runEngineDoctor(opts?: {
         // The real cause is often on STDOUT (e.g. codex prints "ERROR: You've hit
         // your usage limit" to stdout while stderr holds only the startup banner),
         // so search BOTH streams and surface the salient error line — not the banner.
-        return { ok: false, ms, detail: salientError(`${r.error ?? ''}\n${r.text ?? ''}`) || 'no output' }
+        const both = `${r.error ?? ''}\n${r.text ?? ''}`
+        const rejected = argvRejection(both)
+        // Name the fix. A red brain that reads "Unknown argument: o" tells an
+        // operator nothing; the same line plus the binary it came from says
+        // which CLI to update, and rules out the auth/quota causes they would
+        // otherwise go looking for first.
+        if (rejected) {
+          return { ok: false, ms, detail: `${rejected} — \`${adapter.bin}\` is older than the flags Cumora sends; update it` }
+        }
+        return { ok: false, ms, detail: salientError(both) || 'no output' }
       }
       return { ok: true, ms, detail: r.text.replace(ANSI_RE, '').trim().slice(0, 80) }
     }


### PR DESCRIPTION
`doctor` prints one line per brain. For an engine that rejected one of Cumora's own flags, that line is currently the least useful thing in the output.

`salientError()` keys on `error:` wording, which claude, cursor-agent and codex all use. Gemini 0.1.x does not — it prints its **entire help** to stderr and puts the cause on the last line:

```
gemini [options]

Gemini CLI - Launch an interactive CLI, use -p/--prompt for non-interactive mode

Options:
  -m, --model                     Model  [string] [default: "gemini-2.5-pro"]
  …
  -h, --help                      Show help  [boolean]

Unknown argument: o
```

Nothing matches, so the fallback takes the first 280 characters of everything — and what the operator sees is the banner, with the reason cut off the end.

## Why this deserves its own verdict

Every other red brain has one of a few remedies: sign in, wait out the rate limit, fix a model id. This one means the installed CLI predates the flag set the adapter sends, and no amount of re-authenticating will move it. Told "Unknown argument: o", an operator has no way to tell those apart — so they go looking for an auth problem that isn't there.

The doctor now says which, and names the binary:

```
Unknown argument: o — `gemini` is older than the flags Cumora sends; update it
```

## The wordings are real

`argvRejection()` is pinned against what each binary actually prints, captured by feeding it a flag it does not have — not copied from a man page:

| CLI | parser | output |
| --- | --- | --- |
| `claude`, `cursor-agent` | commander | `error: unknown option '--x'` |
| `codex` | clap | `error: unexpected argument '--x' found` |
| `gemini` 0.1.x | yargs | `Unknown argument: o` (after the full help) |

Plural (`Unknown arguments: o, output-format`) and `unrecognised/unrecognized` are covered too, since yargs emits the plural whenever more than one flag is rejected.

## The negative cases matter as much

A false positive sends someone to reinstall a CLI that was fine, so these must stay unmatched, and are tested: usage limits, `not logged in`, `API key not valid`, a connection reset, a bare `exit 137`, and empty output. Only the argv wording matches.

6 tests in `engine-argv-rejection.test.ts` (including ANSI-coloured and CRLF streams, and a length bound so one very long argv cannot flood the doctor line). 51/51 across the engine and guard test files locally; two sibling files need Postgres, so CI is the authority there.

Found while adding the Gemini adapter (#99) — 0.1.15 is what was on this machine, and its failure mode is what made the gap visible — but nothing here is Gemini-specific: the actionable verdict is new for every engine.
