### PR TITLE
fix(computer): refresh Windows supervisor on restart

### DIFF
--- a/server/src/__tests__/agents-computer-windows-service.test.ts
+++ b/server/src/__tests__/agents-computer-windows-service.test.ts
@@ -6,6 +6,7 @@ import {
   renderWindowsSupervisor,
   renderWindowsSupervisorLauncher,
   resolveNpx,
+  restartService,
   windowsScheduledTaskCommand,
   windowsScheduledTaskCreateArgs,
   windowsScheduledTaskQueryCommand,
@@ -16,6 +17,23 @@ import {
 test('Windows service resolves the executable command shim', () => {
   assert.equal(resolveNpx('win32', 'Z:\\missing\\node.exe'), 'npx.cmd')
   assert.equal(resolveNpx('linux', '/missing/node'), 'npx')
+})
+
+test('Windows restart refreshes an existing service definition', async () => {
+  const installedUrls: string[] = []
+
+  await restartService({
+    platform: 'win32',
+    isServiceInstalled: async () => true,
+    loadConfig: async () => ({
+      serverUrl: 'https://example.test',
+      computerId: 'comp-test',
+      deviceToken: 'token-test',
+    }),
+    installService: async (serverUrl) => { installedUrls.push(serverUrl) },
+  })
+
+  assert.deepEqual(installedUrls, ['https://example.test'])
 })
 
 test('Windows supervisor restarts the latest daemon with supervision enabled', () => {

--- a/server/src/agents/computer/daemon.ts
+++ b/server/src/agents/computer/daemon.ts
@@ -2955,26 +2955,41 @@ async function reloadService(): Promise<void> {
 /** `--restart`: a friendly wrapper so users don't have to remember
  *  `launchctl kickstart …`. Restarts the installed service (which relaunches on
  *  cumora@latest, so it's also the "apply the update now" button). */
-async function restartService(): Promise<void> {
-  if (!(await isServiceInstalled())) {
+interface RestartServiceHooks {
+  platform?: NodeJS.Platform
+  isServiceInstalled?: () => Promise<boolean>
+  loadConfig?: () => Promise<DaemonConfig | null>
+  installService?: (serverUrl: string) => Promise<void>
+  reloadService?: () => Promise<void>
+}
+
+export async function restartService(hooks: RestartServiceHooks = {}): Promise<void> {
+  const platform = hooks.platform ?? process.platform
+  const serviceInstalled = hooks.isServiceInstalled ?? isServiceInstalled
+  if (!(await serviceInstalled())) {
     console.log('[computer] service not installed — run: npx cumora@latest agent computer --install-service')
     return
   }
-  if (process.platform === 'darwin') {
+  if (platform === 'win32') {
+    const cfg = await (hooks.loadConfig ?? loadConfig)()
+    if (!cfg) throw new Error('pair this computer first: cumora agent computer --pair <code>')
+    await (hooks.installService ?? installService)(cfg.serverUrl)
+    console.log('[computer] Windows service refreshed and restarted — its supervisor now launches cumora@latest')
+  } else if (platform === 'darwin') {
     const uid = process.getuid?.() ?? 0
     try {
       await execFileP('launchctl', ['kickstart', '-k', `gui/${uid}/${SERVICE_LABEL}`])
     } catch {
-      await reloadService() // not currently loaded → load it
+      await (hooks.reloadService ?? reloadService)() // not currently loaded → load it
     }
-  } else if (process.platform === 'linux') {
-    await execFileP('systemctl', ['--user', 'restart', 'cumora'])
-  } else if (process.platform === 'win32') {
-    await reloadService()
+  } else if (platform === 'linux') {
+    await (hooks.reloadService ?? reloadService)()
   } else {
-    throw new Error(`--restart is not supported on ${process.platform}`)
+    throw new Error(`--restart is not supported on ${platform}`)
   }
-  console.log('[computer] service restarted — it relaunches on cumora@latest (also applies any pending update). Check: npx cumora@latest agent computer --status')
+  if (platform !== 'win32') {
+    console.log('[computer] service restarted — it relaunches on cumora@latest (also applies any pending update). Check: npx cumora@latest agent computer --status')
+  }
 }
 
 /** `--stop`: stop the background service NOW, without uninstalling it. The job is


### PR DESCRIPTION
## Summary

- Refresh the Windows Task Scheduler definition during `--restart`
- Ensure existing installations launch `cumora@latest` instead of a stale local `agent-cli\dist\cli.js`
- Add regression coverage for Windows service refresh behavior

## Root Cause

Windows `--restart` previously only restarted the existing supervisor. It did not regenerate the persisted Task Scheduler definition or supervisor script, allowing older local repository paths to remain active.

The original behavior was introduced in PR #71. PR #98 updated the headless launcher but did not address supervisor migration.

## Verification

- `npm run server:typecheck`
- Windows service tests: 8/8 passed
- Isolated E2E upgrade test: `0.6.0` -> `0.8.0` passed
- Configuration preserved
- Production daemon PID and configuration unchanged