### PR TITLE
fix(agents): label manual brief telemetry

### DIFF
--- a/server/src/__tests__/agents-wake-classify.test.ts
+++ b/server/src/__tests__/agents-wake-classify.test.ts
@@ -15,7 +15,11 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 
-import { classifyWake, renderBriefedManualWakeContext } from '../agents/turn-wake.js'
+import {
+  classifyWake,
+  describeWakeBackgroundBrief,
+  renderBriefedManualWakeContext,
+} from '../agents/turn-wake.js'
 
 const brief = { source: 'kanban', title: 'A board card was assigned to you', body: 'card id: card-1' }
 
@@ -46,6 +50,23 @@ test('a briefed manual wake is not misfiled as a background scan', () => {
   assert.equal(w.backgroundScan, false)
   assert.equal(w.idle, false)
   assert.equal(w.pollUpdate, false)
+})
+
+test('source-less manual brief stays manual in run and audit metadata', () => {
+  assert.deepEqual(describeWakeBackgroundBrief({
+    trigger: 'manual',
+    backgroundBrief: { title: 'Take ownership', body: 'card id: card-1' },
+  }), {
+    source: 'manual',
+    title: 'Take ownership',
+  })
+  assert.deepEqual(describeWakeBackgroundBrief({
+    trigger: 'background_scan',
+    backgroundBrief: { title: '', body: 'scan result' },
+  }), {
+    source: 'scanner',
+    title: 'Background scan',
+  })
 })
 
 test('idle only counts as an idle wake when the inbox is actually empty', () => {

--- a/server/src/agents/turn-wake.ts
+++ b/server/src/agents/turn-wake.ts
@@ -41,6 +41,24 @@ export function classifyWake(options: AgentTurnOptions, inboxCount: number): {
   }
 }
 
+/** Normalize the audit/run metadata shared by synthetic scans and deliberate
+ * manual briefs. The storage field predates manual briefs and is still named
+ * `backgroundScan`, so its fallback values must preserve the trigger kind or a
+ * source-less manual assignment is misleadingly recorded as a scanner run. */
+export function describeWakeBackgroundBrief(
+  options: AgentTurnOptions,
+): { source: string; title: string } | undefined {
+  const brief = options.backgroundBrief
+  if (!brief || (options.trigger !== 'manual' && options.trigger !== 'background_scan')) {
+    return undefined
+  }
+  const manual = options.trigger === 'manual'
+  return {
+    source: brief.source || (manual ? 'manual' : 'scanner'),
+    title: brief.title || (manual ? 'Assigned work' : 'Background scan'),
+  }
+}
+
 /** Render a deliberate manual brief without hiding chat that happened to arrive
  * in the same debounce window. The old empty-inbox-only copy said the inbox was
  * empty unconditionally, which could make a valid DM disappear behind a card

--- a/server/src/agents/turn.ts
+++ b/server/src/agents/turn.ts
@@ -114,7 +114,11 @@ interface InboxRow {
   quoted: QuotedSummary | null
 }
 
-import { classifyWake, renderBriefedManualWakeContext } from './turn-wake.js'
+import {
+  classifyWake,
+  describeWakeBackgroundBrief,
+  renderBriefedManualWakeContext,
+} from './turn-wake.js'
 import { mentionedAgentIds } from './scheduler.js'
 
 export interface AgentTurnOptions {
@@ -1574,6 +1578,7 @@ export async function runAgentTurn(agentId: string, options: AgentTurnOptions = 
   const isBackgroundScanWake = wake.backgroundScan
   const isPollUpdateWake = wake.pollUpdate
   const isBriefedManualWake = wake.briefedManual
+  const wakeBriefMetadata = describeWakeBackgroundBrief(options)
   if (inbox.length === 0 && !wake.survivesEmptyInbox) return
 
   const fingerprint = isIdleWake
@@ -1615,12 +1620,7 @@ export async function runAgentTurn(agentId: string, options: AgentTurnOptions = 
       source: options.trigger ?? 'scheduler',
       conversationIds: convoIds,
       idle: isIdleWake ? { reason: options.idleReason ?? 'idle heartbeat' } : undefined,
-      backgroundScan: (isBackgroundScanWake || isBriefedManualWake)
-        ? {
-            source: options.backgroundBrief?.source ?? 'scanner',
-            title: options.backgroundBrief?.title ?? 'Background scan',
-          }
-        : undefined,
+      backgroundScan: wakeBriefMetadata,
       pollUpdate: isPollUpdateWake && options.pollBrief
         ? {
             messageId: options.pollBrief.messageId,
@@ -1858,10 +1858,9 @@ export async function runAgentTurn(agentId: string, options: AgentTurnOptions = 
         messageIds: inbox.map((m) => m.id),
         messages: inbox.map(traceInboxMessage),
         idleReason: isIdleWake ? options.idleReason ?? 'idle heartbeat' : undefined,
-        backgroundBrief: (isBackgroundScanWake || isBriefedManualWake)
+        backgroundBrief: wakeBriefMetadata
           ? {
-              source: options.backgroundBrief?.source ?? 'scanner',
-              title: options.backgroundBrief?.title ?? 'Background scan',
+              ...wakeBriefMetadata,
               body: traceText(options.backgroundBrief?.body ?? ''),
             }
           : undefined,


### PR DESCRIPTION
## Summary

- derive brief telemetry defaults from the actual wake trigger
- record source-less manual briefs as `manual` / `Assigned work` instead of `scanner` / `Background scan`
- keep existing background-scan defaults and add pure regression coverage

## Context

Follow-up to #104. Copilot submitted this valid suppressed review finding after #104 had already merged and its post-merge Build had completed.

## Validation

- [x] Wake classification/metadata tests (16 passed)
- [x] `npm run lint` (passes; one pre-existing informational finding)
- [x] `npm run server:typecheck`
- [x] `git diff --check`
- [x] GitHub PR checks (6/6)