### PR TITLE
fix(byoa): preserve Pi abort result across spawn race

### DIFF
--- a/server/src/__tests__/agents-computer-engine-pi.test.ts
+++ b/server/src/__tests__/agents-computer-engine-pi.test.ts
@@ -294,6 +294,29 @@ test('pi already-aborted run and json one-shot never spawn a child', { skip: IS_
   assert.deepEqual(await fakeLog(f), [], 'an already-cancelled owner must not launch pi')
 })
 
+test('pi abort during listener registration never dispatches a prompt or becomes an engine failure', { skip: IS_WIN }, async () => {
+  const f = await fixture()
+  const controller = new AbortController()
+  const addEventListener = controller.signal.addEventListener.bind(controller.signal)
+  Object.defineProperty(controller.signal, 'addEventListener', {
+    value: (...args: Parameters<typeof addEventListener>) => {
+      addEventListener(...args)
+      if (args[0] === 'abort') controller.abort()
+    },
+  })
+
+  const result = await getAdapter('pi').run({
+    home: f.home, prompt: 'must not be sent', env: f.env, model: null, fastModel: null,
+    resumeSessionId: null, onLog: () => {}, signal: controller.signal,
+  })
+  assert.equal(result.exitCode, 130)
+  assert.match(result.error ?? '', /aborted before start/)
+
+  await delay(100)
+  const commands = (await fakeLog(f)).map((entry) => entry.cmd).filter(Boolean)
+  assert.ok(!commands.some((command) => command?.type === 'prompt'), 'the cancelled turn must not reach session.send()')
+})
+
 test('pi forced stop signals an EOF-resistant child before the daemon can exit', { skip: IS_WIN }, async () => {
   const f = await fixture('ignore-eof')
   const session = getAdapter('pi').startSession?.({ home: f.home, env: f.env, model: null, fastModel: null, onLog: () => {} })

--- a/server/src/agents/computer/engine.ts
+++ b/server/src/agents/computer/engine.ts
@@ -3321,6 +3321,12 @@ class PiAdapter implements EngineAdapter {
     // listener above was installed.
     if (args.signal.aborted) onAbort()
     try {
+      // onAbort() tears the just-created session down, but send() would then
+      // report that dead session as a generic engine failure. Keep a cancelled
+      // turn classified as cancellation and never dispatch its prompt.
+      if (args.signal.aborted) {
+        return { exitCode: 130, error: 'engine turn aborted before start', sessionId: args.resumeSessionId ?? null }
+      }
       return await session.send(args.prompt)
     } finally {
       args.signal.removeEventListener('abort', onAbort)


### PR DESCRIPTION
## Summary

- short-circuit Pi run after listener installation when cancellation won the spawn-to-listener race
- return the normal aborted result instead of dispatching to an already-stopped session
- add a deterministic regression test that aborts during listener registration and proves no prompt reaches Pi

## Context

Focused follow-up to #106 for the valid post-merge Copilot review finding at https://github.com/yetone/cumora/pull/106#discussion_r3886550212. The child was already terminated safely, but the turn could still call session.send and be misclassified as a generic engine failure.

## Validation

- [x] Pi adapter tests (14 passed)
- [x] npm run typecheck
- [x] npm run server:typecheck
- [x] npm run lint (passes; one pre-existing informational finding)
- [x] npm run guard:big-brain
- [x] npm run guard:llm-tracked
- [x] Agent bundle build
- [x] git diff --check
- [x] GitHub PR checks (6/6)