### PR TITLE
release: v0.9.1 — per-computer engine detection

### DIFF
--- a/agent-cli/package.json
+++ b/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cumora",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Run Cumora agents on your own machine with Claude Code, Codex, Grok Build, Cursor Agent, OpenCode, or pi (BYOA).",
   "license": "MIT",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cumora",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cumora",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1045.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cumora",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "main": "electron/main.cjs",
   "bin": {


### PR DESCRIPTION
Ships the BYOA engine-detection fix (072d45d) to users.

## Why this bump exists

The Computers card's engine paths and versions are produced by the **daemon**, which reaches users through the `cumora` npm package. `Publish CLI` only fires on changes under `agent-cli/`, and 072d45d touched `server/src/agents/computer/` — so the fix is inert on the registry until this bump lands.

## What 072d45d fixed

The card showed engines scanned from whichever machine was running the desktop app, not from the computer the card describes. `isThisMachine()` fell back to `localComputerCount === 1` whenever the hostname did not match, so a single paired computer always claimed the local scan — painting the local laptop's engine versions onto a remote VPS's card.

Version probing moved to where the answer lives (`server/src/agents/computer/cli-version.ts`), running on the daemon's own machine. The renderer's PATH scan — `detect:local-clis`, its preload binding, its runtime type — is gone; nothing else consumed it.

## Compatibility

Daemons older than 0.9.1 report paths only. The card renders the path alone rather than inventing a version, so the degradation is honest rather than wrong.

## Verification on 072d45d

- CI green: guards + unit + integration, typecheck (server + client), both image builds
- 932 tests pass (8 new), lint and `vite build` clean
- Live probe against all 7 engines on a real machine returned correct versions, upstream versions, and update commands