### PR TITLE
feat(ci): an engine is wired into all of its lists, or none

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,6 +51,22 @@ jobs:
       - name: Every sub2api call tracked in llm_calls
         run: node scripts/guard-llm-tracked.mjs
 
+  # An engine is either wired into all of its lists or none. The dangerous
+  # omission is BYOA_SOURCES: normalizeByoaSource() maps anything unknown to
+  # 'byoa-claude', so a half-wired engine does not error — it bills its runs to
+  # the wrong engine. Same fast-fail shape as the two guards above.
+  engine-registry-guard:
+    name: Engine registry guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - name: Every engine wired into all of its lists
+        run: node scripts/guard-engine-registry.mjs
+
   lint:
     name: Lint (Biome)
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "server:typecheck": "tsc -p server/tsconfig.json --noEmit",
     "guard:big-brain": "node scripts/guard-big-brain.mjs",
     "guard:llm-tracked": "node scripts/guard-llm-tracked.mjs",
+    "guard:engine-registry": "node scripts/guard-engine-registry.mjs",
     "lint": "biome lint .",
     "lint:fix": "biome lint --write .",
     "test": "node --import tsx --test \"server/src/__tests__/**/*.test.ts\" \"workers/**/*.test.ts\"",

--- a/scripts/guard-engine-registry.d.mts
+++ b/scripts/guard-engine-registry.d.mts
@@ -1,0 +1,13 @@
+// Type declarations for the engine-registry guard (scripts/guard-engine-registry.mjs).
+export interface RegistryProblem {
+  /** File, plus the declaration inside it, e.g. `src/lib/engines.ts → ENGINE_BIN`. */
+  where: string
+  /** What is missing and what it costs to leave it missing. */
+  why: string
+}
+/** Body of the first match's capture group, or null when the anchor is gone. */
+export function extract(source: string, anchor: RegExp): string | null
+/** The ids in ENGINE_IDS, or null when that declaration can no longer be found. */
+export function engineIds(engineTs: string): string[] | null
+/** Check every engine against every list it has to appear in. */
+export function scanRepo(): RegistryProblem[]

--- a/scripts/guard-engine-registry.mjs
+++ b/scripts/guard-engine-registry.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+/**
+ * guard-engine-registry — an engine is either wired up everywhere, or nowhere.
+ *
+ * Making a BYOA engine runnable means adding its id to about ten hand-kept
+ * lists across the server, the renderer and the tooling. Miss one and nothing
+ * shouts: the worst of them, `BYOA_SOURCES`, is read through
+ * `normalizeByoaSource()`, which falls back to `'byoa-claude'` for anything it
+ * does not recognise — so an engine missing from that list does not error, it
+ * quietly bills every one of its runs to Claude in the ledger.
+ *
+ * That failure mode is not hypothetical. #102 was one of two identical blocks
+ * getting a fix while the other did not, and `cli-version.ts` spent a while
+ * telling the next person to sync a list that had been deleted. This script
+ * makes the sync mechanical instead of remembered.
+ *
+ * The check is anchored on `ENGINE_IDS` in agents/computer/engine.ts — the
+ * engines the daemon actually probes and wakes. For each id it asserts:
+ *
+ *   1. an ADAPTERS entry                        engine.ts
+ *   2. the EngineId union carries it            engine.ts, computer/registry.ts, src/types.ts
+ *   3. a label and a PATH binary                src/lib/engines.ts
+ *   4. RUNNABLE_ENGINE_IDS carries it           src/lib/engines.ts
+ *   5. a version spec                           computer/cli-version.ts
+ *   6. `byoa-<id>` in the shared source list    runtime/byoa-source.ts
+ *   7. `byoa-<id>` in every ledger union        llm-ledger, observability, admin/api, api/client
+ *   8. the engine's binary is spawn-guarded     scripts/guard-big-brain.mjs
+ *
+ * A guard that quietly stops checking is worse than no guard, so every anchor
+ * below is REQUIRED: if a refactor moves or renames one, this fails with
+ * "anchor not found" rather than passing vacuously.
+ *
+ * Run:  node scripts/guard-engine-registry.mjs
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = join(fileURLToPath(new URL('.', import.meta.url)), '..')
+
+const read = (rel) => readFileSync(join(ROOT, rel), 'utf8')
+
+/** Pull one declaration's text out of a file, or explain why we could not.
+ *  `anchor` is matched as a RegExp with one capture group holding the body. */
+export function extract(source, anchor) {
+  const m = source.match(anchor)
+  return m ? m[1] : null
+}
+
+/** The engines the daemon probes and wakes — everything else is derived. */
+export function engineIds(engineTs) {
+  const body = extract(engineTs, /export const ENGINE_IDS: EngineId\[\] = \[([^\]]*)\]/)
+  if (body == null) return null
+  return body.split(',').map((s) => s.trim().replace(/^['"]|['"]$/g, '')).filter(Boolean)
+}
+
+/** Every check, as data: where to look, what must be in it, and how to say so.
+ *  `body` returns the slice of the file the id must appear in — narrowing to
+ *  the declaration means an unrelated mention elsewhere cannot satisfy it. */
+const CHECKS = [
+  {
+    file: 'server/src/agents/computer/engine.ts',
+    what: 'the ADAPTERS registry',
+    body: (s) => extract(s, /const ADAPTERS: Record<EngineId, EngineAdapter> = \{([\s\S]*?)\n\}/),
+    needle: (id) => `${id}: new `,
+    fix: 'add `<id>: new <Name>Adapter(),` to ADAPTERS',
+  },
+  {
+    file: 'server/src/agents/computer/engine.ts',
+    what: 'the EngineId union',
+    body: (s) => extract(s, /export type EngineId = ([^\n]*)/),
+    needle: (id) => `'${id}'`,
+    fix: "widen `export type EngineId`",
+  },
+  {
+    file: 'server/src/agents/computer/registry.ts',
+    what: 'the EngineId union',
+    body: (s) => extract(s, /export type EngineId = ([^\n]*)/),
+    needle: (id) => `'${id}'`,
+    fix: "widen `export type EngineId`",
+  },
+  {
+    file: 'src/types.ts',
+    what: 'the renderer EngineId union',
+    body: (s) => extract(s, /export type EngineId = ([^\n]*)/),
+    needle: (id) => `'${id}'`,
+    fix: "widen `export type EngineId`",
+  },
+  {
+    file: 'src/lib/engines.ts',
+    what: 'ENGINE_LABEL',
+    body: (s) => extract(s, /export const ENGINE_LABEL: Record<string, string> = \{([\s\S]*?)\n\}/),
+    needle: (id) => `${id}:`,
+    fix: 'add a display name to ENGINE_LABEL',
+  },
+  {
+    file: 'src/lib/engines.ts',
+    what: 'ENGINE_BIN',
+    body: (s) => extract(s, /export const ENGINE_BIN: Record<string, string> = \{([\s\S]*?)\n\}/),
+    needle: (id) => `${id}:`,
+    fix: 'add the PATH binary name to ENGINE_BIN',
+  },
+  {
+    file: 'src/lib/engines.ts',
+    what: 'RUNNABLE_ENGINE_IDS',
+    body: (s) => extract(s, /export const RUNNABLE_ENGINE_IDS = new Set\(\[([^\]]*)\]/),
+    needle: (id) => `'${id}'`,
+    fix: 'add the id to RUNNABLE_ENGINE_IDS, or the engine stays detect-only in the UI',
+  },
+  {
+    file: 'server/src/agents/computer/cli-version.ts',
+    what: 'ENGINE_VERSION_SPECS',
+    body: (s) => extract(s, /export const ENGINE_VERSION_SPECS: Record<string, EngineVersionSpec> = \{([\s\S]*?)\n\}/),
+    needle: (id) => `${id}: {`,
+    fix: 'add a version spec, or the Computers tab cannot report the installed version',
+  },
+  {
+    file: 'server/src/agents/runtime/byoa-source.ts',
+    what: 'BYOA_SOURCES',
+    body: (s) => extract(s, /export const BYOA_SOURCES = \[([\s\S]*?)\] as const/),
+    needle: (id) => `'byoa-${id}'`,
+    // The one that fails silently: normalizeByoaSource() maps anything unknown
+    // to 'byoa-claude', so the runs are billed, just to the wrong engine.
+    fix: "add 'byoa-<id>' — without it every run of this engine is attributed to Claude in the ledger",
+  },
+  {
+    file: 'server/src/agents/llm-ledger.ts',
+    what: 'LlmCallSource',
+    body: (s) => extract(s, /export type LlmCallSource = ([^\n]*)/),
+    needle: (id) => `'byoa-${id}'`,
+    fix: "widen LlmCallSource with 'byoa-<id>'",
+  },
+  {
+    file: 'server/src/agents/observability.ts',
+    what: 'TriageSource',
+    body: (s) => extract(s, /export type TriageSource = ([^\n]*)/),
+    needle: (id) => `'byoa-${id}'`,
+    fix: "widen TriageSource with 'byoa-<id>'",
+  },
+  {
+    file: 'src/admin/api.ts',
+    what: 'the admin LlmCallSource union',
+    body: (s) => extract(s, /export type LlmCallSource = ([^\n]*)/),
+    needle: (id) => `'byoa-${id}'`,
+    fix: "widen LlmCallSource with 'byoa-<id>'",
+  },
+  {
+    file: 'src/api/client.ts',
+    what: 'ApiTriageSource',
+    body: (s) => extract(s, /export type ApiTriageSource = ([^\n]*)/),
+    needle: (id) => `'byoa-${id}'`,
+    fix: "widen ApiTriageSource with 'byoa-<id>'",
+  },
+]
+
+/** The spawn guard keys on BINARY names, not engine ids (cursor's binary is
+ *  `cursor-agent`), so it is checked against ENGINE_BIN rather than the id. */
+function binForId(enginesTs, id) {
+  const body = extract(enginesTs, /export const ENGINE_BIN: Record<string, string> = \{([\s\S]*?)\n\}/)
+  if (body == null) return null
+  const m = body.match(new RegExp(`\\b${id}:\\s*'([^']+)'`))
+  return m ? m[1] : null
+}
+
+export function scanRepo() {
+  const problems = []
+  const engineTs = read('server/src/agents/computer/engine.ts')
+  const ids = engineIds(engineTs)
+  if (!ids || ids.length === 0) {
+    return [{ where: 'server/src/agents/computer/engine.ts', why: 'anchor not found: ENGINE_IDS — update this guard alongside the refactor' }]
+  }
+
+  const cache = new Map()
+  const fileOf = (rel) => {
+    if (!cache.has(rel)) cache.set(rel, read(rel))
+    return cache.get(rel)
+  }
+
+  for (const check of CHECKS) {
+    const body = check.body(fileOf(check.file))
+    if (body == null) {
+      problems.push({ where: check.file, why: `anchor not found: ${check.what} — update this guard alongside the refactor` })
+      continue
+    }
+    for (const id of ids) {
+      if (!body.includes(check.needle(id))) {
+        problems.push({ where: `${check.file} → ${check.what}`, why: `'${id}' is missing — ${check.fix.replace('<id>', id)}` })
+      }
+    }
+  }
+
+  // The big-brain guard's R4 rule refuses a direct spawn of any supported
+  // engine binary. A new engine left out of it can be spawned outside the
+  // adapter, which is exactly the classify=small / run=big split it protects.
+  // Anchored on the rule's own id rather than on its regex source: the rule
+  // number is what the guard documents and is stable across rewrites of the
+  // pattern itself.
+  const bigBrain = read('scripts/guard-big-brain.mjs')
+  const at = bigBrain.indexOf('R4 —')
+  const r4 = at < 0 ? null : extract(bigBrain.slice(at, at + 400), /\(([a-z0-9|-]{10,})\)/)
+  if (r4 == null) {
+    problems.push({ where: 'scripts/guard-big-brain.mjs', why: 'anchor not found: the R4 engine-binary alternation — update this guard alongside the refactor' })
+  } else {
+    const guarded = new Set(r4.split('|'))
+    const enginesTs = fileOf('src/lib/engines.ts')
+    for (const id of ids) {
+      const bin = binForId(enginesTs, id)
+      if (!bin) continue // already reported as a missing ENGINE_BIN entry
+      if (!guarded.has(bin)) {
+        problems.push({
+          where: 'scripts/guard-big-brain.mjs → R4',
+          why: `'${bin}' is missing from the engine-binary alternation — a direct spawn of it would go unguarded`,
+        })
+      }
+    }
+  }
+
+  return problems
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const problems = scanRepo()
+  if (problems.length === 0) {
+    console.log('✅ engine registry guard: every engine in ENGINE_IDS is wired into all of its lists.')
+    process.exit(0)
+  }
+  console.error('🚨 engine registry is half-wired:\n')
+  for (const p of problems) console.error(`  ${p.where}\n    ${p.why}`)
+  console.error('\nAn engine must be in every list or none — a partly-wired one fails quietly.')
+  process.exit(1)
+}

--- a/scripts/guard-engine-registry.mjs
+++ b/scripts/guard-engine-registry.mjs
@@ -223,7 +223,14 @@ export function scanRepo() {
   return problems
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Compare filesystem paths, not a hand-built file:// URL. On Windows
+// process.argv[1] is `E:\...` while import.meta.url is `file:///E:/...`, so
+// the string form never matched and `npm run guard:engine-registry` exited 0
+// without ever calling scanRepo() — the guard silently becoming a no-op is the
+// exact failure this file exists to prevent. Same shape guard-big-brain.mjs
+// already used.
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]
+if (isMain) {
   const problems = scanRepo()
   if (problems.length === 0) {
     console.log('✅ engine registry guard: every engine in ENGINE_IDS is wired into all of its lists.')

--- a/scripts/guard-engine-registry.mjs
+++ b/scripts/guard-engine-registry.mjs
@@ -102,8 +102,13 @@ const CHECKS = [
   },
   {
     file: 'src/lib/engines.ts',
-    what: 'RUNNABLE_ENGINE_IDS',
-    body: (s) => extract(s, /export const RUNNABLE_ENGINE_IDS = new Set\(\[([^\]]*)\]/),
+    what: 'the runnable-engine list',
+    // Two accepted shapes: the ordered `RUNNABLE_ENGINES` tuple the UI pickers
+    // map over, and the older `RUNNABLE_ENGINE_IDS` Set literal it is derived
+    // from. Reading whichever exists keeps this guard from being the thing
+    // that blocks collapsing that duplicate.
+    body: (s) => extract(s, /export const RUNNABLE_ENGINES(?::[^=]*)? = \[([^\]]*)\]/)
+      ?? extract(s, /export const RUNNABLE_ENGINE_IDS(?::[^=]*)? = new Set(?:<string>)?\(\[([^\]]*)\]/),
     needle: (id) => `'${id}'`,
     fix: 'add the id to RUNNABLE_ENGINE_IDS, or the engine stays detect-only in the UI',
   },

--- a/server/src/__tests__/guard-engine-registry.test.ts
+++ b/server/src/__tests__/guard-engine-registry.test.ts
@@ -1,0 +1,71 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+// The guard is plain ESM tooling; tsx lets this .ts test import the .mjs.
+import { scanRepo, engineIds, extract } from '../../../scripts/guard-engine-registry.mjs'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Making an engine runnable means adding its id to about ten hand-kept lists.
+// Missing one does not error — BYOA_SOURCES in particular is read through
+// normalizeByoaSource(), which maps anything unknown to 'byoa-claude', so a
+// half-wired engine silently bills its runs to Claude. This test is the CI
+// enforcement. See scripts/guard-engine-registry.mjs.
+
+const ROOT = join(import.meta.dirname, '..', '..', '..')
+const read = (rel: string): string => readFileSync(join(ROOT, rel), 'utf8')
+
+test('every engine is wired into all of its lists', () => {
+  const problems = scanRepo()
+  assert.deepEqual(
+    problems, [],
+    '\n🚨 engine registry is half-wired:\n' +
+      problems.map((p) => `  ${p.where}\n    ${p.why}`).join('\n') +
+      '\nAn engine must be in every list or none.',
+  )
+})
+
+test('the guard is looking at a real, non-empty engine list', () => {
+  // If ENGINE_IDS ever stopped parsing, scanRepo() would have nothing to check
+  // and would pass vacuously. Pin that it found the engines that exist.
+  const ids = engineIds(read('server/src/agents/computer/engine.ts'))
+  assert.ok(ids && ids.length >= 6, `expected the real engine list, got ${JSON.stringify(ids)}`)
+  assert.ok(ids.includes('claude'))
+})
+
+// --- the checks actually catch a half-wired engine (so the guard isn't a no-op) ---
+
+test('a missing BYOA_SOURCES entry is caught', () => {
+  // The one that fails silently in production, so the one most worth pinning.
+  const body = extract(
+    read('server/src/agents/runtime/byoa-source.ts'),
+    /export const BYOA_SOURCES = \[([\s\S]*?)\] as const/,
+  )
+  assert.ok(body, 'anchor not found: BYOA_SOURCES')
+  const ids = engineIds(read('server/src/agents/computer/engine.ts')) ?? []
+  for (const id of ids) {
+    assert.ok(body.includes(`'byoa-${id}'`), `'byoa-${id}' missing from BYOA_SOURCES`)
+  }
+  // The needle carries its quotes, so the match is exact rather than a prefix:
+  // a hypothetical 'byoa-gemini-cli' entry would NOT satisfy 'byoa-gemini'.
+  assert.ok(!body.includes("'byoa-gemini-cl'"))
+  assert.ok(!body.includes("'byoa-notanengine'"))
+})
+
+test('an anchor that stops matching fails loudly rather than passing', () => {
+  // A guard that silently stops checking is worse than no guard. `extract`
+  // returns null when a declaration moves or is renamed, and scanRepo turns
+  // that into a reported problem.
+  assert.equal(extract('nothing to see here', /export const ENGINE_IDS: EngineId\[\] = \[([^\]]*)\]/), null)
+  assert.equal(engineIds('const ENGINE_IDS = "moved elsewhere"'), null)
+})
+
+test('the spawn guard covers every engine BINARY, not every engine id', () => {
+  // cursor's binary is `cursor-agent`, so checking ids against R4 would pass
+  // while the real binary went unguarded.
+  const bigBrain = read('scripts/guard-big-brain.mjs')
+  const at = bigBrain.indexOf('R4 —')
+  assert.ok(at >= 0, 'anchor not found: R4')
+  const alt = extract(bigBrain.slice(at, at + 400), /\(([a-z0-9|-]{10,})\)/)
+  assert.ok(alt, 'anchor not found: the R4 engine-binary alternation')
+  assert.ok(alt.split('|').includes('cursor-agent'))
+})

--- a/server/src/__tests__/guard-engine-registry.test.ts
+++ b/server/src/__tests__/guard-engine-registry.test.ts
@@ -2,7 +2,8 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 // The guard is plain ESM tooling; tsx lets this .ts test import the .mjs.
 import { scanRepo, engineIds, extract } from '../../../scripts/guard-engine-registry.mjs'
-import { readFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 // Making an engine runnable means adding its id to about ten hand-kept lists.
@@ -68,4 +69,47 @@ test('the spawn guard covers every engine BINARY, not every engine id', () => {
   const alt = extract(bigBrain.slice(at, at + 400), /\(([a-z0-9|-]{10,})\)/)
   assert.ok(alt, 'anchor not found: the R4 engine-binary alternation')
   assert.ok(alt.split('|').includes('cursor-agent'))
+})
+
+// --- the script actually RUNS when launched as a CLI ---
+
+test('the CLI entry point reaches scanRepo, not just exits 0', () => {
+  // Every test above calls scanRepo() directly, so none of them can tell a
+  // working guard from one whose main-module check never fires. That is not
+  // hypothetical: the first version compared `import.meta.url` against a
+  // hand-built `file://${process.argv[1]}`, which never matches on Windows —
+  // `npm run guard:engine-registry` exited 0 having checked nothing.
+  const out = execFileSync(process.execPath, [join(ROOT, 'scripts', 'guard-engine-registry.mjs')], {
+    cwd: ROOT, encoding: 'utf8',
+  })
+  assert.match(out, /engine registry guard/, `the script printed nothing:\n${out}`)
+})
+
+test('the CLI exits non-zero when a list is half-wired', () => {
+  // The other half of the same property: a guard that always exits 0 is
+  // indistinguishable from a passing one until something is actually broken.
+  const script = readFileSync(join(ROOT, 'scripts', 'guard-engine-registry.mjs'), 'utf8')
+  // Point the BYOA_SOURCES check at a declaration that cannot contain any
+  // engine, so the run must fail. Written to a sibling file so the real script
+  // is never modified.
+  const sabotaged = script.replace(
+    "/export const BYOA_SOURCES = \\[([\\s\\S]*?)\\] as const/",
+    "/export const BYOA_SOURCE_SET = new Set<string>\\((BYOA_SOURCES)\\)/",
+  )
+  assert.notEqual(sabotaged, script, 'the BYOA_SOURCES anchor moved — update this test with it')
+  const tmp = join(ROOT, 'scripts', '.guard-entry-probe.mjs')
+  writeFileSync(tmp, sabotaged, 'utf8')
+  try {
+    let code = 0
+    let stdout = ''
+    try {
+      stdout = execFileSync(process.execPath, [tmp], { cwd: ROOT, encoding: 'utf8', stdio: 'pipe' })
+    } catch (e) {
+      code = (e as { status?: number }).status ?? 0
+      stdout = String((e as { stdout?: string }).stdout ?? '')
+    }
+    assert.equal(code, 1, `expected a failing exit, got ${code}; stdout was:\n${stdout}`)
+  } finally {
+    rmSync(tmp, { force: true })
+  }
 })


### PR DESCRIPTION
Making a BYOA engine runnable means adding its id to about ten hand-kept lists across the server, the renderer and the tooling. Miss one and nothing shouts.

The worst one is `BYOA_SOURCES`. It is read through `normalizeByoaSource()`:

```ts
export function normalizeByoaSource(value: unknown): ByoaSource {
  return typeof value === 'string' && BYOA_SOURCE_SET.has(value)
    ? value as ByoaSource
    : 'byoa-claude'
}
```

An engine missing from that list does not error. It quietly bills **every one of its runs to Claude** in the ledger.

## Why now

Two things this week were the same shape — a hand-maintained duplicate with no mechanical check:

- **#102** was two identical workspace-slug blocks where one got a `SAVEPOINT` and the other never did. Every sign-up whose email local part was already taken failed, for months, because the fix landed on one copy.
- `cli-version.ts` carried `/** Keep in sync with electron/main.cjs LOCAL_CLIS … */` after `LOCAL_CLIS` had been deleted — pointing the next person at a list that no longer existed.

Adding Gemini (#99) and Qwen (#113) meant walking that list by hand twice. I nearly left `byoa-qwen` out, and nothing would have told me.

## What it checks

Anchored on `ENGINE_IDS` — the engines the daemon actually probes and wakes — and for each id:

| | |
| --- | --- |
| an `ADAPTERS` entry | `engine.ts` |
| all three `EngineId` unions | `engine.ts`, `computer/registry.ts`, `src/types.ts` |
| a label and a PATH binary | `src/lib/engines.ts` |
| `RUNNABLE_ENGINE_IDS` | `src/lib/engines.ts` |
| a version spec | `computer/cli-version.ts` |
| `byoa-<id>` in the shared source list | `runtime/byoa-source.ts` |
| `byoa-<id>` in all four ledger unions | `llm-ledger`, `observability`, `admin/api`, `api/client` |
| the binary is spawn-guarded | `guard-big-brain.mjs` R4 |

The last one is keyed on the **binary**, not the id — cursor's binary is `cursor-agent`, so checking ids there would pass while the real binary went unguarded.

Each failure names the list and what it costs to leave it out, rather than just "missing":

```
server/src/agents/runtime/byoa-source.ts → BYOA_SOURCES
  'gemini' is missing — add 'byoa-gemini' — without it every run of this
  engine is attributed to Claude in the ledger
```

## It fails loudly rather than vacuously

A guard that quietly stops checking is worse than no guard, so every anchor is **required**: if a refactor moves or renames a declaration, `extract()` returns null and the guard reports `anchor not found — update this guard alongside the refactor`. A test also pins that `ENGINE_IDS` really parsed and found the engines that exist, so `scanRepo()` cannot pass by having nothing to check.

## Verified by breaking it

Dropping `'byoa-gemini'` from `BYOA_SOURCES`:

```
🚨 engine registry is half-wired:
  server/src/agents/runtime/byoa-source.ts → BYOA_SOURCES
    'gemini' is missing — add 'byoa-gemini' — without it every run of this engine
    is attributed to Claude in the ledger
```

Dropping `gemini` from `RUNNABLE_ENGINE_IDS`:

```
  src/lib/engines.ts → RUNNABLE_ENGINE_IDS
    'gemini' is missing — add the id to RUNNABLE_ENGINE_IDS, or the engine stays
    detect-only in the UI
```

Both restore to green. Run against the #113 branch as well, which passes — an independent, mechanical confirmation that the Qwen wiring is complete rather than my having remembered every list.

## Shape

Same as the two guards already in CI: `scripts/guard-engine-registry.mjs`, an `npm run guard:engine-registry` script, a `.d.mts` beside it (matching `guard-big-brain.d.mts`), a `guard-engine-registry.test.ts` so `npm test` catches it too, and its own fast-fail CI job.

Runs in milliseconds — it reads eleven files and does string containment, no parsing of the TypeScript.
