### PR TITLE
fix(conversations): concurrent membership changes must not lose each other

### DIFF
--- a/server/src/__integration__/membership-concurrency.test.ts
+++ b/server/src/__integration__/membership-concurrency.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Concurrent membership changes must not lose each other.
+ *
+ * `conversations.members` is a jsonb array, and every mutation of it read the
+ * array, edited it in JavaScript, and wrote the whole thing back. Two of those
+ * overlapping means the second write is computed from a snapshot taken before
+ * the first, so the first change is silently erased.
+ *
+ * This is a hot path here rather than a theoretical one: the scheduler wakes
+ * several agents for the same message, and `cumora invite` / `leave` / `kick`
+ * are things those agents do in response. Concurrency is the normal case.
+ *
+ * The dropped invite is worse than it first looks. The `joined` system row is
+ * posted regardless, so the transcript records a join that did not happen —
+ * and because the mailbox query filters on `members @> [agentId]`, the agent
+ * who "joined" is never woken for that conversation again. Nothing errors.
+ *
+ * Only a real Postgres can show this: it is about what two overlapping
+ * statements do to one row.
+ */
+import { test, before, beforeEach, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { randomUUID } from 'node:crypto'
+import { pool } from '../db/pool.js'
+import { runCli } from '../agents/cli.js'
+import { ensureSchemaOnce, resetAllTables, seedCompanyWithAgent, teardownAll } from './_helpers.js'
+
+before(async () => { await ensureSchemaOnce() })
+beforeEach(async () => { await resetAllTables() })
+after(async () => { await teardownAll() })
+
+async function seedAgent(companyId: string, id: string): Promise<string> {
+  await seedCompanyWithAgent({ companyId, agentId: id })
+  return id
+}
+
+async function seedGroup(companyId: string, members: string[]): Promise<string> {
+  const convoId = `conv-${randomUUID().slice(0, 8)}`
+  await pool.query(
+    `INSERT INTO conversations (id, company_id, kind, title, members)
+     VALUES ($1, $2, 'group', 'race', $3::jsonb)`,
+    [convoId, companyId, JSON.stringify(members)],
+  )
+  return convoId
+}
+
+async function membersOf(convoId: string): Promise<string[]> {
+  const { rows } = await pool.query<{ members: string[] }>(
+    `SELECT members FROM conversations WHERE id = $1`, [convoId],
+  )
+  return rows[0]?.members ?? []
+}
+
+test('[integration] simultaneous invites do not lose an invitee', async () => {
+  // Eight at once rather than two: a single overlapping pair only sometimes
+  // interleaves inside the read→write window on a local socket, and a test
+  // that passes on the broken code proves nothing. With eight, a
+  // last-write-wins array loses several every run.
+  const companyId = `c-${randomUUID().slice(0, 8)}`
+  const host = await seedAgent(companyId, 'agent-host')
+  const invitees = await Promise.all(
+    Array.from({ length: 8 }, (_, i) => seedAgent(companyId, `agent-i${i}`)),
+  )
+  const convo = await seedGroup(companyId, [host])
+
+  const results = await Promise.all(
+    invitees.map((who) => runCli(['--as', host, 'invite', convo, who])),
+  )
+  for (const [i, r] of results.entries()) {
+    assert.equal(r.ok, true, `invite ${invitees[i]} failed: ${r.text}`)
+  }
+
+  // Every invite reported success, so every invitee must actually be a member.
+  // Before the fix several were missing while their `joined` rows still stood,
+  // and their mailbox query (members @> [id]) never matched again.
+  const members = await membersOf(convo)
+  const missing = invitees.filter((who) => !members.includes(who))
+  assert.deepEqual(missing, [], `dropped despite reporting success: ${JSON.stringify(missing)}`)
+  assert.equal(new Set(members).size, members.length, `duplicate members: ${JSON.stringify(members)}`)
+})
+
+test('[integration] a leave that overlaps an invite keeps both effects', async () => {
+  // The worst ordering: whoever writes last resurrects or erases the other.
+  // Either the leaver is put back into a conversation they left, or the
+  // invitee never lands — both leave the transcript disagreeing with the row.
+  const companyId = `c-${randomUUID().slice(0, 8)}`
+  const a = await seedAgent(companyId, 'agent-a')
+  const b = await seedAgent(companyId, 'agent-b')
+  const x = await seedAgent(companyId, 'agent-x')
+  const convo = await seedGroup(companyId, [a, b])
+
+  const [leave, invite] = await Promise.all([
+    runCli(['--as', a, 'leave', convo]),
+    runCli(['--as', b, 'invite', convo, x]),
+  ])
+  assert.equal(leave.ok, true, `leave failed: ${leave.text}`)
+  assert.equal(invite.ok, true, `invite failed: ${invite.text}`)
+
+  const members = await membersOf(convo)
+  assert.ok(!members.includes(a), `${a} left but is still a member: ${JSON.stringify(members)}`)
+  assert.ok(members.includes(x), `${x} was invited but is not a member: ${JSON.stringify(members)}`)
+  assert.ok(members.includes(b))
+})
+
+test('[integration] concurrent kicks of different agents both take effect', async () => {
+  const companyId = `c-${randomUUID().slice(0, 8)}`
+  const a = await seedAgent(companyId, 'agent-a')
+  const b = await seedAgent(companyId, 'agent-b')
+  const x = await seedAgent(companyId, 'agent-x')
+  const y = await seedAgent(companyId, 'agent-y')
+  const convo = await seedGroup(companyId, [a, b, x, y])
+
+  const [kx, ky] = await Promise.all([
+    runCli(['--as', a, 'kick', convo, x]),
+    runCli(['--as', b, 'kick', convo, y]),
+  ])
+  assert.equal(kx.ok, true, `kick x failed: ${kx.text}`)
+  assert.equal(ky.ok, true, `kick y failed: ${ky.text}`)
+
+  const members = await membersOf(convo)
+  assert.ok(!members.includes(x), `${x} survived the kick: ${JSON.stringify(members)}`)
+  assert.ok(!members.includes(y), `${y} survived the kick: ${JSON.stringify(members)}`)
+  assert.deepEqual([...members].sort(), [a, b].sort())
+})
+
+test('[integration] inviting the same agent twice at once adds them once', async () => {
+  // The "already a member" guard reads a snapshot, so both callers can pass it.
+  // The write itself has to be what refuses the duplicate.
+  const companyId = `c-${randomUUID().slice(0, 8)}`
+  const a = await seedAgent(companyId, 'agent-a')
+  const b = await seedAgent(companyId, 'agent-b')
+  const x = await seedAgent(companyId, 'agent-x')
+  const convo = await seedGroup(companyId, [a, b])
+
+  await Promise.all([
+    runCli(['--as', a, 'invite', convo, x]),
+    runCli(['--as', b, 'invite', convo, x]),
+  ])
+
+  const members = await membersOf(convo)
+  assert.equal(members.filter((m) => m === x).length, 1, `${x} added twice: ${JSON.stringify(members)}`)
+})
+
+test('[integration] a lone sequential invite still behaves exactly as before', async () => {
+  // The uncontended path is the one every user actually hits; the atomic
+  // rewrite must not change it.
+  const companyId = `c-${randomUUID().slice(0, 8)}`
+  const a = await seedAgent(companyId, 'agent-a')
+  const x = await seedAgent(companyId, 'agent-x')
+  const convo = await seedGroup(companyId, [a])
+
+  const invited = await runCli(['--as', a, 'invite', convo, x])
+  assert.equal(invited.ok, true, invited.text)
+  assert.deepEqual(await membersOf(convo), [a, x])
+
+  const kicked = await runCli(['--as', a, 'kick', convo, x, '--confirm-empty'])
+  assert.equal(kicked.ok, true, kicked.text)
+  assert.deepEqual(await membersOf(convo), [a])
+})

--- a/server/src/agents/cli.ts
+++ b/server/src/agents/cli.ts
@@ -1340,7 +1340,7 @@ async function cmdShip(parsed: ParsedArgs): Promise<CliResult> {
 // `agents/membership.ts` so the HTTP endpoints (POST /members,
 // POST /leave) and the agent CLI share one implementation. Importing
 // here re-exposes the names this file already used.
-import { postMembershipSystemMessage } from './membership.js'
+import { addConversationMember, postMembershipSystemMessage, removeConversationMember } from './membership.js'
 
 async function cmdLeave(parsed: ParsedArgs): Promise<CliResult> {
   const me = resolveAs(parsed)
@@ -1372,11 +1372,7 @@ async function cmdLeave(parsed: ParsedArgs): Promise<CliResult> {
     participantId: me,
   })
 
-  const next = c.members.filter((m) => m !== me)
-  await pool.query(
-    `UPDATE conversations SET members = $2::jsonb, updated_at = NOW() WHERE id = $1`,
-    [convoId, JSON.stringify(next)],
-  )
+  const next = await removeConversationMember({ conversationId: convoId, memberId: me }) ?? []
 
   return ok(`left "${c.title}" (${convoId}); ${next.length} member(s) remain`, [{
     event: 'conversation.membership_changed',
@@ -1423,11 +1419,7 @@ async function cmdInvite(parsed: ParsedArgs): Promise<CliResult> {
     if (!pp[0]) return err(`${target} is not a participant in this workspace`)
   }
 
-  const next = [...c.members, target]
-  await pool.query(
-    `UPDATE conversations SET members = $2::jsonb, updated_at = NOW() WHERE id = $1`,
-    [convoId, JSON.stringify(next)],
-  )
+  const next = await addConversationMember({ conversationId: convoId, memberId: target }) ?? []
 
   const systemMessage = await postMembershipSystemMessage({
     conversationId: convoId,
@@ -1493,12 +1485,12 @@ async function cmdKick(parsed: ParsedArgs): Promise<CliResult> {
     participantId: target,
   })
 
-  await pool.query(
-    `UPDATE conversations SET members = $2::jsonb, updated_at = NOW() WHERE id = $1`,
-    [convoId, JSON.stringify(next)],
-  )
+  // Report what the row actually holds now, not the array we predicted from a
+  // read taken before the guards above — a concurrent join or leave lands in
+  // between, and the count is user-visible.
+  const remaining = await removeConversationMember({ conversationId: convoId, memberId: target }) ?? []
 
-  return ok(`kicked ${target} from "${c.title}" (${convoId}); ${next.length} member(s) remain`, [{
+  return ok(`kicked ${target} from "${c.title}" (${convoId}); ${remaining.length} member(s) remain`, [{
     event: 'conversation.membership_changed',
     command: 'kick',
     action: 'kicked',
@@ -1507,7 +1499,7 @@ async function cmdKick(parsed: ParsedArgs): Promise<CliResult> {
     participantId: target,
     companyId: c.company_id ?? undefined,
     systemMessageId: systemMessage.messageId,
-    memberCount: next.length,
+    memberCount: remaining.length,
     visibleToUser: true,
   }])
 }

--- a/server/src/agents/membership.ts
+++ b/server/src/agents/membership.ts
@@ -21,6 +21,82 @@ import { randomUUID } from 'node:crypto'
 import { pool } from '../db/pool.js'
 import { CH_MESSAGE_NEW, publish } from '../redis.js'
 
+/**
+ * Add `memberId` to a conversation's member list and return the list as it
+ * stands AFTER the write.
+ *
+ * The array is edited by Postgres, not by us. Every caller used to SELECT
+ * `members`, splice it in JavaScript and write the whole array back, which
+ * makes two overlapping membership changes a last-write-wins race: the second
+ * write is computed from a snapshot taken before the first, so the first one
+ * is erased with no error anywhere.
+ *
+ * That is not a rare interleaving here. The scheduler wakes several agents for
+ * the same message, and `invite` / `leave` / `kick` are what those agents do
+ * next. And the damage is silent in the worst way: the `joined` system row is
+ * posted regardless, so the transcript records a join that did not happen,
+ * while the agent's mailbox query (`members @> [agentId]`) never matches, so
+ * they are simply never woken for that conversation again.
+ *
+ * `companyId` is the tenant guard the HTTP paths already applied; omit it on
+ * the agent CLI paths, which resolve the conversation by id.
+ *
+ * Returns null when the conversation does not exist (or is not in that tenant).
+ */
+export async function addConversationMember(args: {
+  conversationId: string
+  memberId: string
+  companyId?: string | null
+}): Promise<string[] | null> {
+  const tenant = args.companyId ? ' AND company_id = $3' : ''
+  const params = args.companyId
+    ? [args.conversationId, args.memberId, args.companyId]
+    : [args.conversationId, args.memberId]
+  const { rows } = await pool.query<{ members: string[] }>(
+    `UPDATE conversations
+        SET members = members || to_jsonb(ARRAY[$2::text]), updated_at = NOW()
+      WHERE id = $1 AND NOT (members @> to_jsonb(ARRAY[$2::text]))${tenant}
+      RETURNING members`,
+    params,
+  )
+  if (rows[0]) return rows[0].members
+  // No row updated: either they were already a member — which is the outcome
+  // the caller wanted, and the reason the guard is in the WHERE rather than
+  // only in JavaScript — or the conversation is gone. Read back to tell those
+  // apart, and to answer with a current list rather than a stale one.
+  const { rows: current } = await pool.query<{ members: string[] }>(
+    `SELECT members FROM conversations WHERE id = $1${args.companyId ? ' AND company_id = $2' : ''}`,
+    args.companyId ? [args.conversationId, args.companyId] : [args.conversationId],
+  )
+  return current[0]?.members ?? null
+}
+
+/**
+ * Remove `memberId` from a conversation's member list, returning the list as
+ * it stands after the write. Same reasoning as addConversationMember.
+ *
+ * `jsonb - text` deletes every matching element, so this is idempotent and
+ * also cleans up a duplicate left behind by the old racy path.
+ */
+export async function removeConversationMember(args: {
+  conversationId: string
+  memberId: string
+  companyId?: string | null
+}): Promise<string[] | null> {
+  const tenant = args.companyId ? ' AND company_id = $3' : ''
+  const params = args.companyId
+    ? [args.conversationId, args.memberId, args.companyId]
+    : [args.conversationId, args.memberId]
+  const { rows } = await pool.query<{ members: string[] }>(
+    `UPDATE conversations
+        SET members = members - $2::text, updated_at = NOW()
+      WHERE id = $1${tenant}
+      RETURNING members`,
+    params,
+  )
+  return rows[0]?.members ?? null
+}
+
 /** Atomically claim the next sequence number for a conversation.
  *  Same UPSERT pattern as the human reply path and `cumora reply`. */
 export async function nextConversationSequence(conversationId: string): Promise<number> {

--- a/server/src/api/router.ts
+++ b/server/src/api/router.ts
@@ -3065,12 +3065,12 @@ api.post('/conversations/:id/members', async (req, res) => {
     `SELECT id FROM participants WHERE id = $1 AND company_id = $2`, [newMember, tenant],
   )
   if (!existing[0]) { res.status(400).json({ error: `unknown participant: ${newMember}` }); return }
-  const next = [...c.members, newMember]
-  await pool.query(
-    `UPDATE conversations SET members = $2::jsonb, updated_at = NOW() WHERE id = $1 AND company_id = $3`,
-    [id, JSON.stringify(next), tenant],
-  )
-  const { postMembershipSystemMessage } = await import('../agents/membership.js')
+  const { addConversationMember, postMembershipSystemMessage } = await import('../agents/membership.js')
+  // Postgres edits the array. Splicing it here and writing the whole thing
+  // back loses a concurrent membership change, and the `joined` row below is
+  // posted either way — so the transcript would record a join that the
+  // members column does not agree with.
+  const next = await addConversationMember({ conversationId: id, memberId: newMember, companyId: tenant }) ?? []
   await postMembershipSystemMessage({
     conversationId: id, companyId: tenant, actorId: me,
     kind: 'joined', participantId: newMember,
@@ -3094,16 +3094,12 @@ api.post('/conversations/:id/leave', async (req, res) => {
     res.status(400).json({ error: 'cannot leave a direct conversation' }); return
   }
   if (!c.members.includes(me)) { res.status(409).json({ error: 'not a member' }); return }
-  const { postMembershipSystemMessage } = await import('../agents/membership.js')
+  const { postMembershipSystemMessage, removeConversationMember } = await import('../agents/membership.js')
   await postMembershipSystemMessage({
     conversationId: id, companyId: tenant, actorId: me,
     kind: 'left', participantId: me,
   })
-  const next = c.members.filter((m) => m !== me)
-  await pool.query(
-    `UPDATE conversations SET members = $2::jsonb, updated_at = NOW() WHERE id = $1 AND company_id = $3`,
-    [id, JSON.stringify(next), tenant],
-  )
+  const next = await removeConversationMember({ conversationId: id, memberId: me, companyId: tenant }) ?? []
   res.json({ ok: true, members: next })
 })
 


### PR DESCRIPTION
`conversations.members` is a jsonb array, and every one of the five places that changed it did the same thing: `SELECT members`, splice it in JavaScript, write the whole array back.

```ts
const next = [...c.members, target]
await pool.query(
  `UPDATE conversations SET members = $2::jsonb, updated_at = NOW() WHERE id = $1`,
  [convoId, JSON.stringify(next)],
)
```

Two of those overlapping is last-write-wins: the second write is computed from a snapshot taken before the first, so the first change is erased. No error, no log line.

## Why this is a hot path, not a theoretical one

Concurrency is the *normal* case here. The scheduler wakes several agents for the same message, and `invite` / `leave` / `kick` are what those agents do in response.

And the dropped invite is worse than it first looks:

- the `joined` system row is posted regardless, so the transcript records a join that the `members` column does not agree with
- the mailbox query filters on `members @> [agentId]`, so the agent who "joined" is **never woken for that conversation again**
- the CLI returned `ok(...)` with a member count computed from the stale array, so the acting agent was told it worked

The leave/invite overlap is the ugliest ordering: whoever writes last either resurrects an agent into a conversation they left, or erases one that was just added.

## Proved before fixing

Straight SQL against Postgres 16, no app code — two "invites" with overlapping read→write windows:

```
read-modify-write → ["a","b","x"]      ← y is gone
atomic            → ["a","b","y","x"]
```

Then through the real code path, `server/src/__integration__/membership-concurrency.test.ts` on unfixed `main`:

```
not ok 1 - simultaneous invites do not lose an invitee
not ok 2 - a leave that overlaps an invite keeps both effects
not ok 3 - concurrent kicks of different agents both take effect
# pass 2  # fail 3
```

Reproduced on three consecutive runs; 5/5 on three consecutive runs after the fix.

A note on that first test: it invites **eight** agents at once rather than two. With a single overlapping pair the read→write window is short enough that a local socket often serialises them, and the test passed on the broken code — which would have made it worthless as a regression test. Eight loses several every run.

## The fix

Postgres edits the array, not us:

```sql
-- add
UPDATE conversations
   SET members = members || to_jsonb(ARRAY[$2::text]), updated_at = NOW()
 WHERE id = $1 AND NOT (members @> to_jsonb(ARRAY[$2::text]))
RETURNING members

-- remove
UPDATE conversations SET members = members - $2::text, updated_at = NOW()
 WHERE id = $1
RETURNING members
```

The "already a member" guard moves into the `WHERE` rather than living only in JavaScript, because the JS guard reads a snapshot and two callers can both pass it. `jsonb - text` deletes every matching element, so removal is idempotent and also cleans up a duplicate left behind by the old path.

Callers now use the `RETURNING` value instead of the array they predicted, so the user-visible member count reflects the row rather than a read taken before the guards ran.

## One implementation, not five

All five call sites — `cumora leave` / `invite` / `kick`, and `POST /conversations/:id/members` / `:id/leave` — now go through two helpers in `agents/membership.ts`. That file already exists for exactly this reason, and says so:

> Putting both in one file keeps the CLI and HTTP paths from drifting.

Pasting the atomic SQL into five places would have left the same trap set. This is the same lesson as #102, where one of two identical blocks got a fix and the other did not.

## Scope

`computers.available_engines` has the same read-modify-write shape, but it is written by one daemon per computer on a periodic heartbeat, so a lost merge self-heals on the next beat. Left alone deliberately rather than swept in.

Membership guards that read a snapshot (`kick` refusing to empty a group, `invite` rejecting a non-participant) can still race on their *conditions* — this fixes the data, not every TOCTOU on a policy check. Those failures are visible and recoverable; a silently dropped member was neither.

## Checks

5/5 in the new integration test (×3 runs), the full integration suite green locally against Postgres 16, 79/79 across the related unit test files, typecheck / `biome lint .` / both guards clean.
