### PR TITLE
refactor(byoa): one source of truth for the engines a user can pick

### DIFF
--- a/server/src/agents/computer/registry.ts
+++ b/server/src/agents/computer/registry.ts
@@ -44,8 +44,17 @@ export async function announceComputerOnline(computerId: string, companyId: stri
   await broadcastComputerStatus(computerId, companyId, 'online')
 }
 
-/** Engines a paired (non-cloud) computer is allowed to advertise. */
-const PAIRABLE_ENGINES: ReadonlySet<string> = new Set(['claude', 'codex', 'grok', 'cursor', 'opencode', 'pi', 'gemini'])
+/** Engines a paired (non-cloud) computer is allowed to advertise.
+ *
+ *  Spelled as a Record over the engine union rather than a Set literal so the
+ *  COMPILER is what notices a new engine, not a reviewer: adding an id to
+ *  EngineId makes this fail to compile until the id is classified here. A
+ *  plain `new Set([...])` accepted an incomplete list silently, and the engine
+ *  left out of it could be detected and shown but never actually paired. */
+const PAIRABLE: Record<Exclude<EngineId, 'managed'>, true> = {
+  claude: true, codex: true, grok: true, cursor: true, opencode: true, pi: true, gemini: true,
+}
+const PAIRABLE_ENGINES: ReadonlySet<string> = new Set<string>(Object.keys(PAIRABLE))
 
 /** Merge a fresh PATH detection into a computer's advertised engine list.
  *

--- a/src/desktop/MeView.tsx
+++ b/src/desktop/MeView.tsx
@@ -12,7 +12,7 @@ import { LanguagePicker } from '@/components/LanguagePicker'
 import { useT, type MessageKey } from '@/lib/i18n'
 import { cn } from '@/lib/utils'
 import { api, getPairingServerOrigin, getServerOrigin, type ApiProject, type ApiQuotaSnapshot, type ApiQuotaWindow } from '@/api/client'
-import { ENGINE_BIN, ENGINE_LABEL, RUNNABLE_ENGINE_IDS, engineLabel } from '@/lib/engines'
+import { ENGINE_BIN, ENGINE_LABEL, RUNNABLE_ENGINES, RUNNABLE_ENGINE_IDS, engineLabel, type RunnableEngineId } from '@/lib/engines'
 import type { Computer, EngineId } from '@/types'
 
 // The tab's identity is its `key`; the label is a message key resolved at
@@ -830,7 +830,7 @@ function ComputersTab() {
   // Engine for a NEWLY added computer's starter/assigned agents. Claude is the
   // default (no flag → daemon auto-detects); every other pick is named
   // explicitly, or the daemon auto-detects and engines[0] silently wins.
-  const [engine, setEngine] = useState<'claude' | 'codex' | 'grok' | 'cursor' | 'opencode' | 'pi' | 'gemini'>('claude')
+  const [engine, setEngine] = useState<RunnableEngineId>('claude')
   // Default on: install the always-on service (auto-start/restart/update).
   const [asService, setAsService] = useState(true)
   // Per-computer re-pair (reconnect) command, keyed by computer id.
@@ -1134,13 +1134,13 @@ function ComputersTab() {
             <div className="flex items-center gap-2.5 mb-2.5">
               <span className="text-[12px] text-ink-500">{t('me.engineLabel')}</span>
               <div className="inline-flex rounded-[9px] p-0.5" style={{ background: 'var(--ink-100)' }}>
-                {([['claude', 'Claude Code'], ['codex', 'Codex'], ['grok', 'Grok Build'], ['cursor', 'Cursor'], ['opencode', 'OpenCode'], ['pi', 'pi'], ['gemini', 'Gemini']] as const).map(([id, label]) => (
+                {RUNNABLE_ENGINES.map((id) => (
                   <button key={id} type="button" onClick={() => setEngine(id)}
                     className="px-3 py-1 rounded-[7px] text-[12px] font-semibold transition-colors duration-150"
                     style={engine === id
                       ? { background: 'var(--paper)', color: 'var(--ink-900)', boxShadow: '0 1px 2px rgba(0,0,0,0.08)' }
                       : { color: 'var(--ink-500)' }}>
-                    {label}
+                    {engineLabel(id)}
                   </button>
                 ))}
               </div>

--- a/src/desktop/Onboarding.tsx
+++ b/src/desktop/Onboarding.tsx
@@ -3,6 +3,7 @@ import { api, getPairingServerOrigin } from '@/api/client'
 import { useComputers } from '@/stores/computers'
 import { TitleBar } from '@/desktop/TitleBar'
 import { useT } from '@/lib/i18n'
+import { RUNNABLE_ENGINES, engineLabel, type RunnableEngineId } from '@/lib/engines'
 
 /**
  * First-run gate for free-tier users: their agents run on their own machine
@@ -21,7 +22,7 @@ export function Onboarding() {
   // Claude is the default; ANY other pick must be named explicitly. We DON'T
   // append `--engine claude` so a Claude-less machine still auto-detects rather
   // than erroring on a Claude it doesn't have.
-  const [engine, setEngine] = useState<'claude' | 'codex' | 'grok' | 'cursor' | 'opencode' | 'pi' | 'gemini'>('claude')
+  const [engine, setEngine] = useState<RunnableEngineId>('claude')
   // Default to installing the always-on service: it auto-starts at sign-in,
   // auto-restarts on crash, and auto-updates — so the user isn't tied to a
   // terminal that must stay open. Appends `--install-service` to the command.
@@ -87,13 +88,13 @@ export function Onboarding() {
                 <div className="flex items-center gap-2.5 mb-2.5">
                   <span className="text-[12px] text-ink-500">{t('onboard.engine')}</span>
                   <div className="inline-flex rounded-[9px] p-0.5" style={{ background: 'var(--ink-100)' }}>
-                    {([['claude', 'Claude Code'], ['codex', 'Codex'], ['grok', 'Grok Build'], ['cursor', 'Cursor'], ['opencode', 'OpenCode'], ['pi', 'pi'], ['gemini', 'Gemini']] as const).map(([id, label]) => (
+                    {RUNNABLE_ENGINES.map((id) => (
                       <button key={id} type="button" onClick={() => setEngine(id)}
                         className="px-3 py-1 rounded-[7px] text-[12px] font-semibold transition-colors duration-150"
                         style={engine === id
                           ? { background: 'var(--paper)', color: 'var(--ink-900)', boxShadow: '0 1px 2px rgba(0,0,0,0.08)' }
                           : { color: 'var(--ink-500)' }}>
-                        {label}
+                        {engineLabel(id)}
                       </button>
                     ))}
                   </div>

--- a/src/lib/engines.ts
+++ b/src/lib/engines.ts
@@ -25,8 +25,19 @@ export const ENGINE_BIN: Record<string, string> = {
   hermes: 'hermes',
 }
 
-/** Engines Cumora can actually wake. Everything else is detect-only. */
-export const RUNNABLE_ENGINE_IDS = new Set(['claude', 'codex', 'grok', 'cursor', 'opencode', 'pi', 'gemini'])
+/** Engines Cumora can actually wake, in the order pickers should offer them.
+ *  Everything else in ENGINE_LABEL is detect-only: the Me page can tell you it
+ *  is installed, but no adapter can drive it.
+ *
+ *  One declaration, three shapes — the ordered list for UI, the type for the
+ *  state that holds a choice, and the set for membership tests. Engine pickers
+ *  used to inline their own copy of this list *and* their own copy of the
+ *  labels, which is how adding an engine could leave it unselectable. */
+export const RUNNABLE_ENGINES = ['claude', 'codex', 'grok', 'cursor', 'opencode', 'pi', 'gemini'] as const
+
+export type RunnableEngineId = typeof RUNNABLE_ENGINES[number]
+
+export const RUNNABLE_ENGINE_IDS: ReadonlySet<string> = new Set<string>(RUNNABLE_ENGINES)
 
 export function engineLabel(id: string): string {
   return ENGINE_LABEL[id] ?? id


### PR DESCRIPTION
#101 had to follow #99 with four one-line additions, and they are all the same mistake:

```diff
-const PAIRABLE_ENGINES: ReadonlySet<string> = new Set(['claude', …, 'pi'])
+const PAIRABLE_ENGINES: ReadonlySet<string> = new Set(['claude', …, 'pi', 'gemini'])

-const [engine, setEngine] = useState<'claude' | … | 'pi'>('claude')
+const [engine, setEngine] = useState<'claude' | … | 'pi' | 'gemini'>('claude')

-{([['claude', 'Claude Code'], …, ['pi', 'pi']] as const).map(([id, label]) => (
+{([['claude', 'Claude Code'], …, ['pi', 'pi'], ['gemini', 'Gemini']] as const).map(([id, label]) => (
```

(the last two twice — once in `MeView`, once in `Onboarding`)

Gemini had an adapter, was detected, was labelled, and still could not be paired or selected, because four lists that are invisible from the adapter had not been told about it. Nothing errored.

The sharpest version of it: **`MeView` already imports `RUNNABLE_ENGINE_IDS` and `engineLabel`** — and then inlines its own copy of both, ten lines away.

## Removing the copies rather than guarding them

`src/lib/engines.ts` declares the runnable engines once and derives the three shapes callers actually need:

```ts
export const RUNNABLE_ENGINES = ['claude', 'codex', 'grok', 'cursor', 'opencode', 'pi', 'gemini'] as const
export type RunnableEngineId = typeof RUNNABLE_ENGINES[number]
export const RUNNABLE_ENGINE_IDS: ReadonlySet<string> = new Set<string>(RUNNABLE_ENGINES)
```

Both pickers become:

```tsx
{RUNNABLE_ENGINES.map((id) => (
  <button key={id} onClick={() => setEngine(id)} …>{engineLabel(id)}</button>
))}
```

and both `useState` unions become `useState<RunnableEngineId>('claude')`. There is no longer a list to forget.

## The one that can't be derived, handed to the compiler

`PAIRABLE_ENGINES` is a server-side policy set ("engines a paired, non-cloud computer may advertise"), so it isn't simply the UI list. It becomes a Record over the engine union instead of a Set literal:

```ts
const PAIRABLE: Record<Exclude<EngineId, 'managed'>, true> = {
  claude: true, codex: true, grok: true, cursor: true, opencode: true, pi: true, gemini: true,
}
const PAIRABLE_ENGINES: ReadonlySet<string> = new Set<string>(Object.keys(PAIRABLE))
```

Adding an id to `EngineId` now fails to compile until it is classified. Verified by adding `'qwen'` to the union:

```
server/src/agents/computer/registry.ts(54,7): error TS2741: Property 'qwen' is missing in type
'{ claude: true; codex: true; grok: true; cursor: true; opencode: true; pi: true; gemini: true; }'
but required in type 'Record<"claude" | … | "qwen", true>'.
```

That is better than a CI check for this one: it fails in the editor, before the commit exists. A `new Set([...])` accepted the incomplete list in silence, and the engine left out could be detected and displayed but never paired.

## One visible change

The picker rendered `pi` as **"pi"** while every other surface — including the engine list eight lines below it in the same file — renders `engineLabel('pi')` = **"Pi"**. They now agree.

## Checks

`tsc` (app + server), `biome lint .`, `npm run build`, both guards, and 39/39 across the engine test files. No behaviour change beyond the label, and the engine sets are byte-identical to what #101 left.

Complements #114, which guards the lists that *can't* be collapsed. This one deletes the ones that can.
