### PR TITLE
fix(byoa): restore Windows engine version detection

### DIFF
--- a/server/src/__tests__/agents-computer-engine-version.test.ts
+++ b/server/src/__tests__/agents-computer-engine-version.test.ts
@@ -10,13 +10,16 @@
  */
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 process.env.CUMORA_RUNTIME_CLIENT = 'http'
 process.env.OPENAI_API_KEY ??= 'test-key'
 
 const {
   parseCliVersion, isCliOutdated, inferUpdateCommand,
-  parseCursorAbout, parseGrokCheck, ENGINE_VERSION_SPECS,
+  parseCursorAbout, parseGrokCheck, ENGINE_VERSION_SPECS, versionCommandInvocation,
 } = await import('../agents/computer/cli-version.js')
 const { sanitizeDetectedEngines } = await import('../agents/computer/registry.js')
 
@@ -30,6 +33,23 @@ test('parseCliVersion reads the shapes real CLIs print', () => {
   assert.equal(parseCliVersion('no version here'), null)
   assert.equal(parseCliVersion(''), null)
   assert.equal(parseCliVersion(null), null)
+})
+
+test('Windows version probe replaces an extensionless npm shim with its runnable .cmd sibling', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'cumora-engine-version-'))
+  try {
+    const shim = join(root, 'codex')
+    await writeFile(shim, '#!/bin/sh\n')
+    await writeFile(`${shim}.cmd`, '@echo off\r\necho codex-cli 0.15.1\r\n')
+    const comspec = String.raw`C:\Windows\System32\cmd.exe`
+    assert.deepEqual(versionCommandInvocation(shim, ['--version'], 'win32', comspec), {
+      command: comspec,
+      args: ['/d', '/s', '/c', `""${shim}.cmd" --version"`],
+      windowsVerbatimArguments: true,
+    })
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
 })
 
 test('isCliOutdated only fires when upstream is strictly newer', () => {

--- a/server/src/agents/computer/cli-version.ts
+++ b/server/src/agents/computer/cli-version.ts
@@ -14,6 +14,46 @@
 import { spawn } from 'node:child_process'
 import fs from 'node:fs'
 
+interface CommandInvocation {
+  command: string
+  args: string[]
+  windowsVerbatimArguments?: boolean
+}
+
+/** npm on Windows installs an extensionless POSIX shim before the runnable
+ * `.cmd` shim in `where` output. CreateProcess cannot execute either file
+ * directly, so select the sibling batch shim and invoke it through ComSpec. */
+export function versionCommandInvocation(
+  command: string,
+  args: string[],
+  platform = process.platform,
+  comspec = process.env.ComSpec || 'cmd.exe',
+): CommandInvocation {
+  if (platform !== 'win32') return { command, args }
+
+  let runnable = command
+  if (!/\.(?:cmd|bat|com|exe)$/i.test(runnable)) {
+    for (const ext of ['.cmd', '.bat', '.exe', '.com']) {
+      if (fs.existsSync(`${command}${ext}`)) {
+        runnable = `${command}${ext}`
+        break
+      }
+    }
+  }
+  if (!/\.(?:cmd|bat)$/i.test(runnable)) return { command: runnable, args }
+
+  const commandArgs = args.map((arg) => {
+    const value = String(arg)
+    return /^[\w./:=+-]+$/u.test(value) ? value : `"${value.replace(/"/g, '""')}"`
+  })
+  const commandLine = `""${runnable}"${commandArgs.length ? ` ${commandArgs.join(' ')}` : ''}"`
+  return {
+    command: comspec,
+    args: ['/d', '/s', '/c', commandLine],
+    windowsVerbatimArguments: true,
+  }
+}
+
 /** How to ask an engine its version, and how to find out what the newest one is. */
 export interface EngineVersionSpec {
   /** Args that make the binary print its version (`--version` for all but hermes). */
@@ -176,7 +216,12 @@ function spawnText(cmd: string, args: string[], timeoutMs: number): Promise<stri
     let settled = false
     let child: ReturnType<typeof spawn>
     try {
-      child = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] })
+      const invocation = versionCommandInvocation(cmd, args)
+      child = spawn(invocation.command, invocation.args, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        windowsHide: true,
+        windowsVerbatimArguments: invocation.windowsVerbatimArguments === true,
+      })
     } catch {
       resolve('')
       return


### PR DESCRIPTION
## Summary

- restore installed engine version detection on Windows
- resolve extensionless npm shims to their runnable `.cmd` / `.bat` siblings
- invoke batch shims through ComSpec without opening a terminal window
- add regression coverage for the Windows npm shim layout

## Root cause

The daemon-side version probe introduced in 072d45d spawned the path returned first by `where`. For npm-installed CLIs on Windows, that path is commonly an extensionless POSIX shim, which CreateProcess cannot execute. Upstream npm lookups still worked, so the UI showed an official version alongside “version unknown”.

## Testing

- `node --import tsx --test server/src/__tests__/agents-computer-engine-version.test.ts`
- `npm run server:typecheck`
- `git diff --check`
