### PR TITLE
fix(byoa): preserve default engine on reconnect

### DIFF
--- a/server/src/__tests__/agent-computer-pairing-token.test.ts
+++ b/server/src/__tests__/agent-computer-pairing-token.test.ts
@@ -52,7 +52,7 @@ test('company add token is persistent and reattaches an existing host by name', 
       return { rows: [{ pair_token: 'company-token' }] }
     }
     if (/UPDATE companies SET pair_token/.test(sql)) return { rowCount: 1 }
-    if (/SELECT id, company_id FROM computers/.test(sql)) return { rows: [] }
+    if (/SELECT id, company_id/.test(sql)) return { rows: [] }
     if (/SELECT id AS company_id, owner_user_id FROM companies/.test(sql)) {
       return { rows: [{ company_id: 'co-1', owner_user_id: 'u-1' }] }
     }
@@ -79,7 +79,7 @@ test('company add token is persistent and reattaches an existing host by name', 
   assert.equal(calls.some((c) => /INSERT INTO computers/.test(c.sql)), false)
 })
 
-test('computer reconnect token is persistent and updates the exact computer row', async () => {
+test('computer reconnect token is persistent, updates the exact row, and preserves its default engine', async () => {
   let computerTokenSelected = false
   const calls = installPoolMock(({ sql }) => {
     if (/SELECT pair_token FROM computers/.test(sql)) {
@@ -90,8 +90,8 @@ test('computer reconnect token is persistent and updates the exact computer row'
       return { rows: [{ pair_token: 'repair-token' }] }
     }
     if (/UPDATE computers SET pair_token/.test(sql)) return { rowCount: 1 }
-    if (/SELECT id, company_id FROM computers/.test(sql)) {
-      return { rows: [{ id: 'comp-old', company_id: 'co-1' }] }
+    if (/SELECT id, company_id/.test(sql)) {
+      return { rows: [{ id: 'comp-old', company_id: 'co-1', available_engines: ['codex', 'claude'] }] }
     }
     if (/UPDATE computers\s+SET credential_hash/.test(sql)) return { rowCount: 1 }
     throw new Error(`unexpected query: ${sql}`)
@@ -103,7 +103,7 @@ test('computer reconnect token is persistent and updates the exact computer row'
   const paired = await registry.pairComputer({
     code: 'repair-token',
     hostName: 'MacBook Air',
-    engines: ['codex'],
+    engines: ['claude', 'codex'],
     deferBroadcast: true,
   })
   assert.equal(paired?.computerId, 'comp-old')
@@ -111,14 +111,14 @@ test('computer reconnect token is persistent and updates the exact computer row'
 
   const update = calls.find((c) => /UPDATE computers\s+SET credential_hash/.test(c.sql))
   assert.ok(update, 'computer-specific token should update the bound row')
-  assert.equal(update.params[1], JSON.stringify(['codex']))
+  assert.equal(update.params[1], JSON.stringify(['codex', 'claude']))
   assert.equal(update.params[2], 'MacBook Air')
   assert.equal(update.params[3], 'comp-old')
 })
 
 test('daemon run mode (supervised) is persisted on pair and heartbeat', async () => {
   const calls = installPoolMock(({ sql }) => {
-    if (/SELECT id, company_id FROM computers/.test(sql)) {
+    if (/SELECT id, company_id/.test(sql)) {
       return { rows: [{ id: 'comp-old', company_id: 'co-1' }] }
     }
     if (/UPDATE computers\s+SET credential_hash/.test(sql)) return { rowCount: 1 }

--- a/server/src/agents/computer/registry.ts
+++ b/server/src/agents/computer/registry.ts
@@ -319,14 +319,19 @@ export async function pairComputer(args: {
   const reportedName = (args.hostName ?? '').slice(0, 80)
   const name = reportedName || 'My computer'
 
-  const exact = await pool.query<{ id: string; company_id: string }>(
-    `SELECT id, company_id FROM computers
+  const exact = await pool.query<{ id: string; company_id: string; available_engines: string[] }>(
+    `SELECT id, company_id, available_engines FROM computers
       WHERE pair_token = $1 AND kind <> 'cloud' AND revoked_at IS NULL
       LIMIT 1`,
     [args.code],
   )
   if (exact.rows[0]) {
-    const { id, company_id: companyId } = exact.rows[0]
+    const { id, company_id: companyId, available_engines: currentEngines } = exact.rows[0]
+    // A reconnect is an inventory refresh, not a default-engine change. Keep
+    // the existing default first while it is still installed; if it vanished,
+    // mergeDetectedEngines naturally falls back to the daemon's scan order.
+    const orderedEngines = mergeDetectedEngines(currentEngines ?? [], engines) ?? (currentEngines ?? [])
+    const reconnectDetectedJson = JSON.stringify(sanitizeDetectedEngines(args.detected, orderedEngines))
     await pool.query(
       `UPDATE computers
           SET credential_hash = $1, available_engines = $2::jsonb,
@@ -336,7 +341,7 @@ export async function pairComputer(args: {
               detected_engines = $7::jsonb, engines_detected_at = NOW(), detect_requested_at = NULL,
               status = 'online', last_seen_at = NOW(), paired_at = NOW()
         WHERE id = $4`,
-      [hashToken(deviceToken), JSON.stringify(engines), reportedName, id, version, supervised, detectedJson],
+      [hashToken(deviceToken), JSON.stringify(orderedEngines), reportedName, id, version, supervised, reconnectDetectedJson],
     )
     if (!args.deferBroadcast) await broadcastComputerStatus(id, companyId, 'online')
     return { computerId: id, companyId, deviceToken }


### PR DESCRIPTION
## Summary

- preserve a paired computer's current default engine when redeeming its reconnect token
- fall back to the daemon's detected engine order only when the previous default is no longer installed
- leave each agent's saved or pinned engine selection untouched

## Root Cause
Previously, the computer's reconnection command did not carry any additional parameters. The original code would rescan for engines and reuse the detected default engine, overwriting all previous settings. This could lead to the loss of user-defined engines after reconnection, which was unreasonable. This PR resolves the issue.
<img width="1370" height="290" alt="image" src="https://github.com/user-attachments/assets/d2b63ab8-2608-4c4c-a762-8bffb467b33f" />


## Testing

- `node --import tsx --test server/src/__tests__/agent-computer-pairing-token.test.ts`
- `npm run server:typecheck`
- `npx biome lint server/src/agents/computer/registry.ts server/src/__tests__/agent-computer-pairing-token.test.ts`