### PR TITLE
fix(observability): an unknown run status must not take down the whole view

### DIFF
--- a/src/desktop/ObservabilityView.tsx
+++ b/src/desktop/ObservabilityView.tsx
@@ -283,9 +283,31 @@ function bytes(size: number): string {
   return `${Math.round(size / 1024 / 102.4) / 10} MB`
 }
 
+/** Neutral styling for a status this build has no entry for. `agent_runs.status`
+ *  is plain TEXT with no CHECK constraint, so a value outside the five known
+ *  ones is reachable — a newer server writing a status an older desktop build
+ *  does not know yet is the realistic case. Without a fallback,
+ *  `STATUS_STYLE[status].cls` threw and took the ENTIRE Observability view to
+ *  the error boundary: one unrecognised row, and the operator loses the traces,
+ *  the workspace browser and both economics panels. */
+const UNKNOWN_STATUS_STYLE = {
+  cls: 'bg-ink-100 text-ink-600 border-ink-100',
+  dot: 'var(--ink-400)',
+} as const
+
 function StatusPill({ status }: { status: ApiAgentRunStatus }) {
   const t = useT()
   const tone = STATUS_STYLE[status]
+  // Show the raw value rather than guessing at a label for it — mislabelling a
+  // status the build does not understand is worse than admitting it.
+  if (!tone) {
+    return (
+      <span className={cn('inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10.5px] font-bold', UNKNOWN_STATUS_STYLE.cls)}>
+        <span className="h-1.5 w-1.5 rounded-full" style={{ background: UNKNOWN_STATUS_STYLE.dot }} />
+        {String(status)}
+      </span>
+    )
+  }
   return (
     <span className={cn('inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10.5px] font-bold', tone.cls)}>
       <span className="h-1.5 w-1.5 rounded-full" style={{ background: tone.dot }} />


### PR DESCRIPTION
`StatusPill` reads the style map with no fallback:

```tsx
const tone = STATUS_STYLE[status]
return <span className={cn(…, tone.cls)}>…
```

`agent_runs.status` is plain `TEXT` with no CHECK constraint, so a value outside the five the desktop build knows is reachable — a newer server writing a status an older build has not learned yet is the realistic route.

When it happens, reading `.cls` throws. And because the pill renders inside **every trace row**, the ErrorBoundary swallows the entire Observability view — traces, the workspace browser and both economics panels — over one unrecognised row.

## Reproduced against a real database

Set three of thirty-five runs to an unknown status:

```sql
UPDATE agent_runs SET status='done' WHERE id IN (SELECT id FROM agent_runs LIMIT 3);
```

**Before:** the whole view is replaced by *"Something went wrong / Cannot read properties of undefined (reading 'cls')"*.

**After:** it renders, and the DOM confirms both paths are live —

```json
{"renderedPills":["Completed","Completed","done","done","done",…],"errorBoundaryVisible":false}
```

Known statuses keep their green `Completed` pill; unknown ones get neutral grey with the raw value.

## Why the raw string

Showing the value rather than picking a nearby label is deliberate: mislabelling a status this build does not understand would be worse than admitting it does not know one. Neutral grey also keeps it from reading as a success or a failure.

Found by accident while verifying #119 — a bad seed value, not a live bug today, which is why it is here on its own rather than folded into that PR.