### PR TITLE
docs(i18n): the coverage section lags the views it describes

### DIFF
--- a/docs/I18N.md
+++ b/docs/I18N.md
@@ -76,15 +76,16 @@ The picker itself needs no change; it renders from `LOCALES`.
 
 ## Current coverage
 
-Translated: navigation (desktop rail, mobile tab bar), the sign-in
-screen, and both settings surfaces (desktop **You**, mobile **You**),
-including every preference toggle.
+The catalogue is fully mirrored: `zh-CN` carries every key `en` does, and
+every surface reads through `useT()` / `t()` — the conversation, board,
+calendar, document, agent and shipping views, the mobile screens, and the
+admin console included. Components that don't render text of their own
+(`Select`, `ContextMenu`, the peek panes) receive already-translated
+strings as props, so there is no hidden English inside them.
 
-Not yet translated: the conversation, board, calendar, document, agent
-and shipping views, and the admin console. Those still render their
-English strings, which is what the English fallback is for — they can be
-converted a file at a time without touching the machinery. The admin
-console is operator-facing and lowest priority.
+That doesn't retire the English fallback: a key added to `en` renders in
+English until its `zh-CN` value lands, which is why new keys should ship
+with their `zh-CN` translation in the same PR to keep the mirror complete.
 
 Server-generated text (agent replies, digests, emails) is a separate
 problem: it comes from model prompts, not from this catalogue.


### PR DESCRIPTION
## What

`docs/I18N.md`'s **Current coverage** section still described the app as it was when zh-CN first landed: it said the conversation, board, calendar, document, agent and shipping views, and the admin console were *not yet translated*.

They all read through `useT()` / `t()` today, and `zh-CN.ts` mirrors every key `en.ts` has. This PR rewrites the section to say that — including the non-obvious part that components which render no text of their own (`Select`, `ContextMenu`, the peek panes) receive already-translated strings as props, so there is no hidden English inside them.

## Why

A contributor reading the doc today would conclude those views are fair game to convert, file by file, and start touching machinery that no longer needs touching. The doc was accurate when written; the app outgrew it.

## Verification

- `grep -c "t('" ` across the supposedly-untranslated views: `ChatPane.tsx` 51, `BoardsView.tsx` 47, `CalendarView.tsx` 26, `AgentsView.tsx` 36, `DocumentsView.tsx` 13, `ShippingWorkspace.tsx` 46, `AdminApp.tsx` 11, plus every mobile screen.
- Key parity: extracting the catalogue keys from `src/locales/en.ts` and `src/locales/zh-CN.ts` gives 1713 and 1713, with zero en keys missing from zh-CN.
- Docs-only change: no gates affected.