### PR TITLE
a11y: turn useButtonType on, and give every bare button a type

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -38,7 +38,8 @@
     "rules": {
       "preset": "recommended",
       "a11y": {
-        "preset": "none"
+        "preset": "none",
+        "useButtonType": "error"
       },
       "style": {
         "noNonNullAssertion": "off",

--- a/docs/I18N.md
+++ b/docs/I18N.md
@@ -76,15 +76,16 @@ The picker itself needs no change; it renders from `LOCALES`.
 
 ## Current coverage
 
-Translated: navigation (desktop rail, mobile tab bar), the sign-in
-screen, and both settings surfaces (desktop **You**, mobile **You**),
-including every preference toggle.
+The catalogue is fully mirrored: `zh-CN` carries every key `en` does, and
+every surface reads through `useT()` / `t()` — the conversation, board,
+calendar, document, agent and shipping views, the mobile screens, and the
+admin console included. Components that don't render text of their own
+(`Select`, `ContextMenu`, the peek panes) receive already-translated
+strings as props, so there is no hidden English inside them.
 
-Not yet translated: the conversation, board, calendar, document, agent
-and shipping views, and the admin console. Those still render their
-English strings, which is what the English fallback is for — they can be
-converted a file at a time without touching the machinery. The admin
-console is operator-facing and lowest priority.
+That doesn't retire the English fallback: a key added to `en` renders in
+English until its `zh-CN` value lands, which is why new keys should ship
+with their `zh-CN` translation in the same PR to keep the mirror complete.
 
 Server-generated text (agent replies, digests, emails) is a separate
 problem: it comes from model prompts, not from this catalogue.

--- a/src/admin/AdminApp.tsx
+++ b/src/admin/AdminApp.tsx
@@ -97,7 +97,7 @@ export function AdminApp() {
         <div style={{ fontSize: 14, opacity: 0.7, marginBottom: 16 }}>
           {t('admin.signedInAs', { email: user?.email ?? '(unknown)' })}
         </div>
-        <button className="btn" onClick={() => { clear() }}>
+        <button type="button" className="btn" onClick={() => { clear() }}>
           {t('admin.signOutSwitch')}
         </button>
       </FullScreenNote>
@@ -107,7 +107,7 @@ export function AdminApp() {
   return (
     <div className={`admin-shell${navOpen ? ' nav-open' : ''}`}>
       <header className="admin-topbar">
-        <button className="admin-topbar-burger" onClick={() => setNavOpen((v) => !v)} aria-label={t('admin.toggleNav')}>
+        <button type="button" className="admin-topbar-burger" onClick={() => setNavOpen((v) => !v)} aria-label={t('admin.toggleNav')}>
           <span /><span /><span />
         </button>
         <div className="admin-topbar-brand">
@@ -132,7 +132,7 @@ export function AdminApp() {
           <NavLink current={route} target="settings"      label={t('admin.settings')} />
         </nav>
         <div className="admin-sidebar-foot">
-          <button className="btn-ghost" onClick={() => { clear() }}>{t('admin.signOut')}</button>
+          <button type="button" className="btn-ghost" onClick={() => { clear() }}>{t('admin.signOut')}</button>
         </div>
       </aside>
       <main className="admin-main">

--- a/src/admin/ObservabilityPage.tsx
+++ b/src/admin/ObservabilityPage.tsx
@@ -356,6 +356,7 @@ export function ObservabilityPage() {
           <div className="obs-pills" role="tablist" aria-label={t('adminobs.rangeAria')}>
             {RANGES.map((r) => (
               <button
+                type="button"
                 key={r.days}
                 role="tab"
                 aria-selected={sinceDays === r.days}
@@ -367,6 +368,7 @@ export function ObservabilityPage() {
           <div className="obs-pills" role="tablist" aria-label={t('adminobs.sourceAria')}>
             {SOURCE_FILTERS.map((s) => (
               <button
+                type="button"
                 key={s.key}
                 role="tab"
                 aria-selected={sourceFilter === s.key}
@@ -380,6 +382,7 @@ export function ObservabilityPage() {
           <div className="obs-pills" role="tablist" aria-label={t('adminobs.unitAria')}>
             {UNITS.map((u) => (
               <button
+                type="button"
                 key={u.key}
                 role="tab"
                 aria-selected={unit === u.key}

--- a/src/admin/Pager.tsx
+++ b/src/admin/Pager.tsx
@@ -41,11 +41,12 @@ export function Pager({ total, pageSize, offset, loading, onPage }: {
     <div className="admin-pager">
       <span>{t('adminPager.range', { from: offset + 1, to: Math.min(offset + pageSize, total), total })}</span>
       <div className="admin-pager-btns">
-        <button className="btn-ghost" disabled={current === 0 || loading} onClick={() => go(current - 1)}>{t('adminPager.prev')}</button>
+        <button type="button" className="btn-ghost" disabled={current === 0 || loading} onClick={() => go(current - 1)}>{t('adminPager.prev')}</button>
         {cells.map((c, i) => c === 'gap'
           ? <span key={`gap-${i}`} className="admin-pager-ellipsis">…</span>
           : (
             <button
+              type="button"
               key={c}
               className={`admin-pager-num${c === current ? ' is-active' : ''}`}
               disabled={loading}
@@ -55,7 +56,7 @@ export function Pager({ total, pageSize, offset, loading, onPage }: {
               {c + 1}
             </button>
           ))}
-        <button className="btn-ghost" disabled={current >= pages - 1 || loading} onClick={() => go(current + 1)}>{t('adminPager.next')}</button>
+        <button type="button" className="btn-ghost" disabled={current >= pages - 1 || loading} onClick={() => go(current + 1)}>{t('adminPager.next')}</button>
       </div>
     </div>
   )

--- a/src/admin/SettingsPage.tsx
+++ b/src/admin/SettingsPage.tsx
@@ -73,6 +73,7 @@ function SettingRow({ title, desc, on, busy, disabled, onToggle }: {
         <div className="admin-setting-desc">{desc}</div>
       </div>
       <button
+        type="button"
         className={`admin-switch${on ? ' is-on' : ''}`}
         onClick={onToggle}
         disabled={disabled || busy}

--- a/src/admin/SuspendedScreen.tsx
+++ b/src/admin/SuspendedScreen.tsx
@@ -70,7 +70,7 @@ export function SuspendedScreen({ email, reason }: { email: string | null; reaso
         <div className="cumora-waitlist-sub" style={{ marginTop: 16, marginBottom: 24 }}>
           {t('waitlist.suspendedFooter')}
         </div>
-        <button className="btn-ghost" onClick={() => setDismissed(true)}>
+        <button type="button" className="btn-ghost" onClick={() => setDismissed(true)}>
           {t('waitlist.suspendedDone')}
         </button>
       </div>

--- a/src/admin/UsersPage.tsx
+++ b/src/admin/UsersPage.tsx
@@ -211,6 +211,7 @@ function UserRow({ u, expanded, onToggleExpand, onTierChange, onAdminToggle, onS
         </div>
         <div onClick={(e) => e.stopPropagation()} data-label={t('users.colAdmin')}>
           <button
+            type="button"
             className={`admin-toggle ${u.isAdmin ? 'is-on' : ''}`}
             onClick={onAdminToggle}
             disabled={isMe && u.isAdmin}
@@ -249,6 +250,7 @@ function UserRow({ u, expanded, onToggleExpand, onTierChange, onAdminToggle, onS
               )}
               <div className="admin-detail-actions">
                 <button
+                  type="button"
                   className={`btn-ghost ${detail.suspended ? '' : 'admin-btn-danger'}`}
                   onClick={handleSuspendClick}
                   disabled={isMe && !detail.suspended}

--- a/src/admin/WaitlistConfirmedScreen.tsx
+++ b/src/admin/WaitlistConfirmedScreen.tsx
@@ -65,7 +65,7 @@ export function WaitlistConfirmedScreen({ email }: { email: string | null }) {
         <div style={{ marginBottom: 24, fontSize: 12.5, color: 'var(--ink-400)', fontStyle: 'italic' }}>
           {footerParts[0]}<GetDesktopAppLink variant="text" />{footerParts.slice(1).join('\u0000')}
         </div>
-        <button className="btn-ghost" onClick={() => setDismissed(true)}>
+        <button type="button" className="btn-ghost" onClick={() => setDismissed(true)}>
           {t('waitlist.confirmedDone')}
         </button>
       </div>

--- a/src/admin/WaitlistPage.tsx
+++ b/src/admin/WaitlistPage.tsx
@@ -87,7 +87,7 @@ export function WaitlistPage({ onChanged }: { onChanged: () => void }) {
 
       <div className="admin-tabs">
         {(['pending', 'approved', 'rejected'] as Tab[]).map((tabKey) => (
-          <button key={tabKey}
+          <button type="button" key={tabKey}
             className={`admin-tab${tab === tabKey ? ' is-active' : ''}`}
             onClick={() => setTab(tabKey)}
           >
@@ -134,13 +134,13 @@ export function WaitlistPage({ onChanged }: { onChanged: () => void }) {
             <div className="admin-row-actions">
               {tab === 'pending' ? (
                 <>
-                  <button className="btn-primary"
+                  <button type="button" className="btn-primary"
                     disabled={busyId === entry.id}
                     onClick={() => approve(entry)}
                   >
                     {busyId === entry.id ? t('waitlist.approveBusy') : t('waitlist.approve')}
                   </button>
-                  <button className="btn-ghost"
+                  <button type="button" className="btn-ghost"
                     disabled={busyId === entry.id}
                     onClick={() => reject(entry)}
                   >

--- a/src/components/AgentEditor.tsx
+++ b/src/components/AgentEditor.tsx
@@ -237,6 +237,7 @@ export function AgentEditor({ agent, onClose, onSaved }: Props) {
             </div>
           </div>
           <button
+            type="button"
             onClick={onClose}
             className="w-8 h-8 rounded-full grid place-items-center text-ink-500 hover:bg-sky2-50 hover:text-ink-900 transition"
             aria-label={t('common.close')}
@@ -542,12 +543,14 @@ export function AgentEditor({ agent, onClose, onSaved }: Props) {
 
         <div className="px-6 py-4 border-t border-ink-100 flex items-center gap-2 bg-paper shrink-0">
           <button
+            type="button"
             onClick={onClose}
             className="px-4 py-2 rounded-[9px] text-[12.5px] font-semibold text-ink-700 bg-cloud hover:bg-sky2-50 transition"
             style={{ border: '1px solid var(--ink-100)' }}
           >{t('agent.cancelBtn')}</button>
           <div className="flex-1" />
           <button
+            type="button"
             onClick={submit}
             disabled={busy || !name.trim() || !systemPrompt.trim()}
             className="px-5 py-2 rounded-[9px] text-[12.5px] font-semibold text-white transition disabled:opacity-50"

--- a/src/components/CompanySwitcher.tsx
+++ b/src/components/CompanySwitcher.tsx
@@ -70,6 +70,7 @@ export function CompanySwitcher() {
   return (
     <div className="relative" style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}>
       <button
+        type="button"
         onClick={() => setOpen((v) => !v)}
         className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[12px] font-medium text-ink-700 hover:bg-cloud transition"
         style={{ border: '1px solid var(--ink-100)', background: 'var(--paper)' }}
@@ -99,6 +100,7 @@ export function CompanySwitcher() {
           </div>
           {companies.map((c) => (
             <button
+              type="button"
               key={c.id}
               onClick={() => switchCompany(c.id)}
               className="w-full px-3 py-1.5 flex items-center gap-2 text-left hover:bg-cloud transition"
@@ -121,6 +123,7 @@ export function CompanySwitcher() {
 
           {active && (active.role === 'owner' || active.role === 'admin') && (
             <button
+              type="button"
               onClick={() => { setInviteOpen(true); setOpen(false) }}
               className="w-full px-3 py-1.5 flex items-center gap-2 text-left hover:bg-cloud transition text-[12px] text-ink-700"
             >
@@ -146,12 +149,14 @@ export function CompanySwitcher() {
               {err && <div className="text-[11px] text-coral-deep">{err}</div>}
               <div className="flex gap-1.5">
                 <button
+                  type="button"
                   onClick={() => void submitNew()}
                   disabled={!newName.trim() || busy}
                   className="flex-1 py-1.5 rounded text-[12px] font-semibold text-white disabled:opacity-50"
                   style={{ background: 'var(--skype)' }}
                 >{busy ? '…' : t('company.createBtn')}</button>
                 <button
+                  type="button"
                   onClick={() => { setCreating(false); setNewName(''); setErr(null) }}
                   className="px-3 py-1.5 rounded text-[12px] text-ink-500 hover:bg-cloud"
                 >{t('common.cancel')}</button>
@@ -159,6 +164,7 @@ export function CompanySwitcher() {
             </div>
           ) : (
             <button
+              type="button"
               onClick={() => setCreating(true)}
               className="w-full px-3 py-1.5 flex items-center gap-2 text-left hover:bg-cloud transition text-[12px] text-ink-700"
             >

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -101,6 +101,7 @@ export function ContextMenu({ x, y, items, onClose, _isChild }: Props) {
           const hasSubmenu = !!it.submenu && it.submenu.length > 0
           return (
             <button
+              type="button"
               key={i}
               role="menuitem"
               disabled={it.disabled}

--- a/src/components/EmailComposer.tsx
+++ b/src/components/EmailComposer.tsx
@@ -383,6 +383,7 @@ export function EmailComposer() {
     <div className="fixed inset-0 z-[55] grid place-items-end pointer-events-none" aria-modal="true">
       {/* Click-outside backdrop. Click anywhere outside the panel to close. */}
       <button
+        type="button"
         aria-label={t('email.closeComposerBackdropAria')}
         onClick={close}
         className="absolute inset-0 pointer-events-auto animate-fade-in"

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -39,6 +39,7 @@ export class ErrorBoundary extends Component<Props, State> {
             </pre>
             <div className="flex gap-2 justify-center">
               <button
+                type="button"
                 onClick={() => this.setState({ error: null, resetKey: this.state.resetKey + 1 })}
                 className="py-2 px-4 rounded-[10px] text-[13px] font-semibold text-white"
                 style={{
@@ -47,6 +48,7 @@ export class ErrorBoundary extends Component<Props, State> {
                 }}
               >{t('errorBoundary.resetView')}</button>
               <button
+                type="button"
                 onClick={() => window.location.reload()}
                 className="py-2 px-4 rounded-[10px] text-[13px] font-semibold text-ink-700 bg-cloud"
                 style={{ border: '1px solid var(--ink-100)' }}

--- a/src/components/EventEditor.tsx
+++ b/src/components/EventEditor.tsx
@@ -549,6 +549,7 @@ export function EventEditor({ event, prefill, onClose }: Props) {
         <div className="px-6 py-4 border-t border-ink-100 flex items-center gap-2 bg-paper shrink-0">
           {canDelete && (
             <button
+              type="button"
               onClick={onDelete}
               disabled={busy}
               className="px-3 py-2 rounded-[9px] text-[12.5px] font-semibold text-coral-deep bg-cloud hover:bg-coral-soft transition"
@@ -557,6 +558,7 @@ export function EventEditor({ event, prefill, onClose }: Props) {
           )}
           {isEdit && event!.kind === 'agent_task' && event!.status === 'active' && (
             <button
+              type="button"
               onClick={onRunNow}
               disabled={busy}
               className="px-3 py-2 rounded-[9px] text-[12.5px] font-semibold text-skype-deep bg-cloud hover:bg-sky2-100 transition"
@@ -566,12 +568,14 @@ export function EventEditor({ event, prefill, onClose }: Props) {
           )}
           <div className="flex-1" />
           <button
+            type="button"
             onClick={onClose}
             disabled={busy}
             className="px-4 py-2 rounded-[9px] text-[12.5px] font-semibold text-ink-700 bg-cloud hover:bg-sky2-50 transition"
             style={{ border: '1px solid var(--ink-100)' }}
           >{tLabel('common.cancel', "Cancel")}</button>
           <button
+            type="button"
             onClick={submit}
             disabled={busy}
             className="px-5 py-2 rounded-[9px] text-[12.5px] font-semibold text-white transition disabled:opacity-50"

--- a/src/components/GroupCreator.tsx
+++ b/src/components/GroupCreator.tsx
@@ -227,6 +227,7 @@ export function GroupCreator({ onClose, initialPicked }: Props) {
 
         <div className="px-6 py-4 border-t border-ink-100 flex items-center gap-2 bg-paper shrink-0">
           <button
+            type="button"
             onClick={onClose}
             disabled={busy}
             className="px-4 py-2 rounded-[9px] text-[12.5px] font-semibold text-ink-700 bg-cloud hover:bg-sky2-50 transition"
@@ -234,6 +235,7 @@ export function GroupCreator({ onClose, initialPicked }: Props) {
           >{t('group.cancelBtn')}</button>
           <div className="flex-1" />
           <button
+            type="button"
             onClick={submit}
             disabled={!canSubmit}
             className="px-5 py-2 rounded-[9px] text-[12.5px] font-semibold text-white transition disabled:opacity-50"

--- a/src/components/InviteAcceptScreen.tsx
+++ b/src/components/InviteAcceptScreen.tsx
@@ -271,6 +271,7 @@ export function InviteAcceptScreen({ token, onDone }: Props) {
               })}
             </p>
             <button
+              type="button"
               onClick={() => { useAuth.getState().clear() }}
               className="px-4 py-2 rounded-[10px] text-[13px] font-semibold transition"
               style={{ background: 'var(--ink-700)', color: 'white' }}
@@ -311,6 +312,7 @@ export function InviteAcceptScreen({ token, onDone }: Props) {
             ) : (
               <>
                 <button
+                  type="button"
                   onClick={() => void accept()}
                   disabled={busy}
                   className="w-full py-3 rounded-[12px] text-[14px] font-semibold text-white transition disabled:opacity-60"
@@ -320,6 +322,7 @@ export function InviteAcceptScreen({ token, onDone }: Props) {
                   }}
                 >{busy ? t('inviteAccept.joinBusy') : t('inviteAccept.joinAs', { company: companyName, role: inv.role })}</button>
                 <button
+                  type="button"
                   onClick={() => { clearPendingInvite(); onDone() }}
                   className="text-[12px] text-ink-400 hover:text-ink-700 transition font-display italic"
                 >{t('inviteAccept.notNow')}</button>
@@ -375,6 +378,7 @@ function JoinedSuccessBlock({ companyName, onContinueInBrowser }: {
       </div>
       <div className="w-full flex flex-col gap-2.5">
         <button
+          type="button"
           onClick={tryOpenDesktopApp}
           className="w-full py-3 rounded-[12px] text-[14px] font-semibold text-white transition"
           style={{
@@ -385,6 +389,7 @@ function JoinedSuccessBlock({ companyName, onContinueInBrowser }: {
         <GetDesktopAppLink variant="button-secondary" />
         {!isWebAppHost && (
           <button
+            type="button"
             onClick={onContinueInBrowser}
             className="text-[12px] text-ink-400 hover:text-ink-700 transition font-display italic mt-1"
           >{t('inviteAccept.continueInBrowser')}</button>
@@ -413,6 +418,7 @@ function AlreadyMemberBlock({ companyName, onSwitchInBrowser }: {
       </p>
       <div className="w-full flex flex-col gap-2.5">
         <button
+          type="button"
           onClick={tryOpenDesktopApp}
           className="w-full py-3 rounded-[12px] text-[14px] font-semibold text-white transition"
           style={{
@@ -423,6 +429,7 @@ function AlreadyMemberBlock({ companyName, onSwitchInBrowser }: {
         <GetDesktopAppLink variant="button-secondary" />
         {!isWebAppHost && (
           <button
+            type="button"
             onClick={onSwitchInBrowser}
             className="text-[12px] text-ink-400 hover:text-ink-700 transition font-display italic mt-1"
           >{t('inviteAccept.continueInBrowser')}</button>
@@ -441,6 +448,7 @@ function ErrorBlock({ title, body, onDismiss }: { title: string; body: string; o
       <p className="text-[13px] text-ink-500 font-display italic leading-relaxed">{body}</p>
       {tokenStr && onDismiss && (
         <button
+          type="button"
           onClick={onDismiss}
           className="px-4 py-2 rounded-[10px] text-[12.5px] font-semibold text-ink-700 transition"
           style={{ background: 'var(--cloud)', border: '1px solid var(--ink-100)' }}

--- a/src/components/InvitePeopleModal.tsx
+++ b/src/components/InvitePeopleModal.tsx
@@ -249,6 +249,7 @@ export function InvitePeopleModal({ companyId, companyName, onClose }: Props) {
 
           <div>
             <button
+              type="button"
               onClick={submit}
               disabled={busy}
               className="w-full py-2.5 rounded-[10px] text-[13px] font-semibold text-white transition disabled:opacity-50"
@@ -306,6 +307,7 @@ export function InvitePeopleModal({ companyId, companyName, onClose }: Props) {
           </div>
           <div className="flex-1" />
           <button
+            type="button"
             onClick={onClose}
             className="px-4 py-2 rounded-[9px] text-[12.5px] font-semibold text-ink-700 bg-cloud hover:bg-sky2-50 transition"
             style={{ border: '1px solid var(--ink-100)' }}
@@ -389,6 +391,7 @@ function CreatedInviteCard({ invite, onDone }: { invite: ApiInvitationWithToken;
           onFocus={(e) => e.currentTarget.select()}
         />
         <button
+          type="button"
           onClick={copy}
           className="px-3 py-2 rounded-[8px] text-[12px] font-semibold text-white transition"
           style={{ background: copied ? 'var(--leaf-700, #2d8c72)' : 'var(--ink-700)' }}
@@ -396,6 +399,7 @@ function CreatedInviteCard({ invite, onDone }: { invite: ApiInvitationWithToken;
       </div>
       <div className="flex justify-end">
         <button
+          type="button"
           onClick={onDone}
           className="text-[11.5px] text-ink-400 hover:text-ink-700 transition"
         >{t('invite.dismissBtn')}</button>
@@ -453,6 +457,7 @@ function InvitationRow({
         <div className="flex items-center gap-1.5">
           <CopyLinkButton inviteId={inv.id} />
           <button
+            type="button"
             onClick={onRevoke}
             className="px-2 py-1.5 text-[11.5px] font-semibold rounded-[8px] transition"
             style={{ color: 'var(--coral-deep)', border: '1px solid var(--ink-100)' }}
@@ -480,6 +485,7 @@ function CopyLinkButton({ inviteId }: { inviteId: string }) {
   }
   return (
     <button
+      type="button"
       onClick={onClick}
       title={t('invite.copyRefTitle')}
       className="px-2 py-1.5 text-[11.5px] font-semibold rounded-[8px] transition"

--- a/src/components/MembersPopover.tsx
+++ b/src/components/MembersPopover.tsx
@@ -92,6 +92,7 @@ export function MembersPopover({ members, anchor, triggerRef, onClose }: Props) 
           const isYou = p.id === meId
           return (
             <button
+              type="button"
               key={p.id}
               onClick={() => {
                 if (!isYou) openInfo(p.id)

--- a/src/components/Message.tsx
+++ b/src/components/Message.tsx
@@ -1397,6 +1397,7 @@ function ReactionPill({ msgId, r }: { msgId: string; r: import('@/types').Reacti
   return (
     <>
       <button
+        type="button"
         ref={btnRef}
         onMouseEnter={onEnter}
         onMouseLeave={onLeave}
@@ -1443,6 +1444,7 @@ function QuickReactionButton({ msgId, emoji }: { msgId: string; emoji: string })
   const [burst, setBurst] = useState(0)
   return (
     <button
+      type="button"
       onClick={() => {
         setBurst((n) => n + 1)
         void toggleReaction(msgId, emoji)
@@ -1620,6 +1622,7 @@ export function SystemRow({ msg, delay = 0, animate = true }: { msg: { body: str
 function SystemActor({ p, onClick }: { p: Participant; onClick: () => void }) {
   return (
     <button
+      type="button"
       onClick={onClick}
       disabled={p.kind !== 'agent'}
       className="inline-flex items-center gap-1.5 not-italic font-semibold text-ink-500 hover:text-skype-deep transition disabled:cursor-default disabled:hover:text-ink-500"
@@ -1648,6 +1651,7 @@ function QuoteCard({ msg }: { msg: Message }) {
   if (!summary) {
     return (
       <button
+        type="button"
         onClick={jump}
         className="mb-1 max-w-[min(100%,580px)] flex items-stretch gap-2 text-left rounded-md bg-cloud/60 border border-ink-100 hover:border-ink-200 px-2 py-1.5 transition-colors"
       >
@@ -1662,6 +1666,7 @@ function QuoteCard({ msg }: { msg: Message }) {
     : summary.body.slice(0, 140).replace(/\n/g, ' ')
   return (
     <button
+      type="button"
       onClick={jump}
       className="mb-1 max-w-[min(100%,580px)] flex items-stretch gap-2 text-left rounded-md bg-cloud/60 border border-ink-100 hover:border-ink-200 hover:bg-cloud px-2 py-1.5 transition-colors"
       title={t('msgview.jumpToOriginal')}
@@ -1683,6 +1688,7 @@ function ReplyIconButton({ msg }: { msg: Message }) {
   const setReplyingTo = useApp((s) => s.setReplyingTo)
   return (
     <button
+      type="button"
       onClick={() => setReplyingTo(msg.conversationId, msg.id)}
       className="w-6 h-6 rounded-full hover:bg-sky2-50 grid place-items-center text-ink-400 hover:text-skype-deep"
       title={t('chat.reply')}
@@ -1796,6 +1802,7 @@ function MessageRowImpl({ msg, author, delay = 0, animate = true }: MessageRowPr
       style={animate ? { animationDelay: `${delay}ms` } : undefined}
     >
       <button
+        type="button"
         onClick={onAvatarClick}
         disabled={isMine}
         className={cn('rounded-full transition shrink-0', !isMine && 'hover:opacity-80 active:scale-95 cursor-pointer')}
@@ -1843,6 +1850,7 @@ function MessageRowImpl({ msg, author, delay = 0, animate = true }: MessageRowPr
 
         {(msg.replyCount ?? 0) > 0 && (
           <button
+            type="button"
             onClick={() => openThreadView(msg.conversationId, msg.id)}
             className="mt-1 text-[11.5px] text-skype-deep hover:underline flex items-center gap-1"
           >

--- a/src/components/NotificationToasts.tsx
+++ b/src/components/NotificationToasts.tsx
@@ -364,6 +364,7 @@ function ToastCard({ toast, onClick, onDismiss }: { toast: Toast; onClick: () =>
 
   return (
     <button
+      type="button"
       onClick={onClick}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}

--- a/src/components/ShippingWorkspace.tsx
+++ b/src/components/ShippingWorkspace.tsx
@@ -95,7 +95,7 @@ export function ShippingWorkspace({ compact = false }: { compact?: boolean }) {
                 <h1 className="text-[18px] font-semibold text-ink-900">{t('nav.ship')}</h1>
                 <p className="mt-0.5 text-[11px] text-ink-400">{t('ship.subtitle')}</p>
               </div>
-              <button onClick={() => setCreating(true)} className="grid h-9 w-9 place-items-center rounded-xl bg-skype text-white shadow-soft" aria-label={t('ship.newFeature')} title={t('ship.newFeatureTitle')}><IPlus className="h-4 w-4" /></button>
+              <button type="button" onClick={() => setCreating(true)} className="grid h-9 w-9 place-items-center rounded-xl bg-skype text-white shadow-soft" aria-label={t('ship.newFeature')} title={t('ship.newFeatureTitle')}><IPlus className="h-4 w-4" /></button>
             </div>
           </div>
           {creating && <CreateFeature onClose={() => setCreating(false)} />}
@@ -109,7 +109,7 @@ export function ShippingWorkspace({ compact = false }: { compact?: boolean }) {
             {overview.features.map((feature) => {
               const progress = featureProgress(feature)
               return (
-                <button key={feature.id} onClick={() => void select(feature.id)} className={cn('mb-1 w-full rounded-xl px-3 py-3 text-left transition', selectedId === feature.id ? 'bg-sky2-50 ring-1 ring-sky2-200' : 'hover:bg-ink-50')}>
+                <button type="button" key={feature.id} onClick={() => void select(feature.id)} className={cn('mb-1 w-full rounded-xl px-3 py-3 text-left transition', selectedId === feature.id ? 'bg-sky2-50 ring-1 ring-sky2-200' : 'hover:bg-ink-50')}>
                   <div className="flex items-start justify-between gap-2">
                     <span className="min-w-0 truncate text-[13px] font-semibold text-ink-900">{feature.title}</span>
                     <Pill tone={feature.failedSquares ? 'bad' : feature.status === 'learned' ? 'good' : 'blue'}>{t(STATUS_LABEL_KEY[feature.status])}</Pill>
@@ -127,7 +127,7 @@ export function ShippingWorkspace({ compact = false }: { compact?: boolean }) {
       )}
       {showDetail && (
         <main className={cn('h-full min-w-0 overflow-y-auto bg-[var(--ship-canvas)]', compact && 'absolute inset-0')}>
-          {compact && <button onClick={() => void select(null)} className="sticky top-0 z-20 flex h-11 w-full items-center gap-1 border-b border-ink-100 bg-cloud/95 px-3 text-[12px] font-semibold text-skype-deep backdrop-blur"><IBack className="h-4 w-4" /> {t('ship.allFeatures')}</button>}
+          {compact && <button type="button" onClick={() => void select(null)} className="sticky top-0 z-20 flex h-11 w-full items-center gap-1 border-b border-ink-100 bg-cloud/95 px-3 text-[12px] font-semibold text-skype-deep backdrop-blur"><IBack className="h-4 w-4" /> {t('ship.allFeatures')}</button>}
           {loadingFeatureId === selectedId && !detail ? <Centered title={t('ship.openingContract')} /> : detail ? <FeatureDetail feature={detail} /> : <Centered title={t('ship.pickOne')} />}
         </main>
       )}

--- a/src/components/UpdaterDialog.tsx
+++ b/src/components/UpdaterDialog.tsx
@@ -172,6 +172,7 @@ export function UpdateBanner({ forceOpen, onOpen }: BannerProps) {
         )}
       </div>
       <button
+        type="button"
         onClick={onOpen}
         className="px-3 py-1.5 rounded-[8px] text-[12px] font-semibold text-white transition shrink-0"
         style={{ background: 'var(--skype)' }}
@@ -180,6 +181,7 @@ export function UpdateBanner({ forceOpen, onOpen }: BannerProps) {
       </button>
       {!isDownloading && (
         <button
+          type="button"
           onClick={() => setDismissed(true)}
           className="w-6 h-6 rounded-[6px] grid place-items-center text-ink-400 hover:text-ink-700 hover:bg-cloud transition text-[14px] shrink-0"
           aria-label={t('updater.bannerDismiss')}
@@ -325,6 +327,7 @@ export function UpdaterDialog({ open, onClose }: DialogProps) {
 
         <div className="px-6 py-4 flex items-center gap-2 border-t border-ink-100 bg-cloud">
           <button
+            type="button"
             onClick={onClose}
             className="px-4 py-2 rounded-[9px] text-[12.5px] font-semibold text-ink-700 hover:bg-paper transition"
             style={{ border: '1px solid var(--ink-100)' }}
@@ -335,6 +338,7 @@ export function UpdaterDialog({ open, onClose }: DialogProps) {
 
           {(kind === 'idle' || kind === 'update-not-available' || kind === 'error') && !isUnsupported && (
             <button
+              type="button"
               onClick={() => void check()}
               className="px-4 py-2 rounded-[9px] text-[12.5px] font-semibold text-white transition"
               style={{ background: 'var(--skype)' }}
@@ -342,6 +346,7 @@ export function UpdaterDialog({ open, onClose }: DialogProps) {
           )}
           {kind === 'checking' && (
             <button
+              type="button"
               disabled
               className="px-4 py-2 rounded-[9px] text-[12.5px] font-semibold text-white opacity-60"
               style={{ background: 'var(--skype)' }}
@@ -349,6 +354,7 @@ export function UpdaterDialog({ open, onClose }: DialogProps) {
           )}
           {kind === 'update-available' && (
             <button
+              type="button"
               onClick={() => void download()}
               className="px-5 py-2 rounded-[9px] text-[12.5px] font-semibold text-white transition"
               style={{
@@ -359,6 +365,7 @@ export function UpdaterDialog({ open, onClose }: DialogProps) {
           )}
           {kind === 'downloading' && (
             <button
+              type="button"
               disabled
               className="px-5 py-2 rounded-[9px] text-[12.5px] font-semibold text-white opacity-60"
               style={{ background: 'var(--skype)' }}
@@ -366,6 +373,7 @@ export function UpdaterDialog({ open, onClose }: DialogProps) {
           )}
           {kind === 'update-downloaded' && (
             <button
+              type="button"
               onClick={() => void install()}
               className="px-5 py-2 rounded-[9px] text-[12.5px] font-semibold text-white transition"
               style={{

--- a/src/desktop/AgentsView.tsx
+++ b/src/desktop/AgentsView.tsx
@@ -77,6 +77,7 @@ function AgentCard({ p, onEdit, onDelete }: {
       {/* Hover actions: edit / delete */}
       <div className="absolute top-3 right-3 flex gap-1 opacity-0 group-hover/card:opacity-100 transition-opacity">
         <button
+          type="button"
           onClick={() => onEdit(p)}
           className="w-7 h-7 rounded-full grid place-items-center bg-cloud hover:bg-sky2-50 text-ink-500 hover:text-skype-deep transition"
           style={{ border: '1px solid var(--ink-100)' }}
@@ -86,6 +87,7 @@ function AgentCard({ p, onEdit, onDelete }: {
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
         </button>
         <button
+          type="button"
           onClick={() => onDelete(p)}
           className="w-7 h-7 rounded-full grid place-items-center bg-cloud hover:bg-coral-soft text-ink-500 hover:text-coral-deep transition"
           style={{ border: '1px solid var(--ink-100)' }}
@@ -146,13 +148,14 @@ function AgentCard({ p, onEdit, onDelete }: {
 
       <div className="flex gap-2 mt-auto">
         <button
+          type="button"
           onClick={openChat}
           disabled={openingChat}
           className="flex-1 py-2 px-3 bg-skype text-white rounded-[9px] text-[12px] font-semibold transition disabled:opacity-60"
           style={{ boxShadow: '0 4px 12px -3px rgba(0, 168, 240, 0.4)' }}>
           {openingChat ? t('agents.openingChat') : t('agents.cardChat')}
         </button>
-        <button className="flex-1 py-2 px-3 bg-cloud text-ink-700 rounded-[9px] text-[12px] font-semibold hover:border-whisper-200 hover:text-whisper-deep transition"
+        <button type="button" className="flex-1 py-2 px-3 bg-cloud text-ink-700 rounded-[9px] text-[12px] font-semibold hover:border-whisper-200 hover:text-whisper-deep transition"
           style={{ border: '1px solid var(--ink-100)' }}>
           {t('agents.cardWhisper')}
         </button>
@@ -190,6 +193,7 @@ function HireCard({ onClick }: { onClick: () => void }) {
   const t = useT()
   return (
     <button
+      type="button"
       onClick={onClick}
       className="rounded-[16px] p-5 grid place-items-center text-center min-h-[280px] cursor-pointer transition hover:bg-sky2-50 active:scale-[0.99]"
       style={{
@@ -252,12 +256,14 @@ function ConfirmOffboard({ p, onCancel, onConfirmed }: {
         )}
         <div className="flex gap-2">
           <button
+            type="button"
             onClick={onCancel}
             disabled={busy}
             className="flex-1 py-2 px-3 rounded-[9px] text-[12.5px] font-semibold text-ink-700 bg-cloud hover:bg-sky2-50 transition"
             style={{ border: '1px solid var(--ink-100)' }}
           >{t('common.cancel')}</button>
           <button
+            type="button"
             onClick={submit}
             disabled={busy}
             className="flex-1 py-2 px-3 rounded-[9px] text-[12.5px] font-semibold text-white transition disabled:opacity-50"
@@ -285,6 +291,7 @@ function FormerAgentCard({ p, onRehire }: { p: Participant; onRehire: (p: Partic
         <div className="text-[11px] text-ink-500 italic font-display">{p.role} · {departed}</div>
       </div>
       <button
+        type="button"
         onClick={() => onRehire(p)}
         className="px-3 py-1.5 rounded-[8px] text-[11.5px] font-semibold text-skype-deep bg-cloud hover:bg-sky2-50 transition inline-flex items-center gap-1"
         style={{ border: '1px solid var(--sky2-200)' }}
@@ -348,6 +355,7 @@ export function AgentsView() {
             </div>
           </div>
           <button
+            type="button"
             onClick={openCreate}
             className="inline-flex items-center gap-1.5 px-4 py-2.5 rounded-[10px] text-[12.5px] font-semibold text-white transition"
             style={{

--- a/src/desktop/BoardsView.tsx
+++ b/src/desktop/BoardsView.tsx
@@ -86,6 +86,7 @@ function BoardsSidebar({ onResizeStart }: { onResizeStart: (e: React.MouseEvent)
       <div className="px-4 py-4 flex items-center justify-between">
         <h2 className="text-lg font-semibold text-ink-900">{t('boards.title')}</h2>
         <button
+          type="button"
           onClick={() => setCreating(true)}
           className="w-7 h-7 rounded-md grid place-items-center text-ink-500 hover:bg-ink-50 hover:text-skype-deep"
           title={t('boards.newBoard')}
@@ -116,6 +117,7 @@ function BoardsSidebar({ onResizeStart }: { onResizeStart: (e: React.MouseEvent)
           return (
             <li key={b.id}>
               <button
+                type="button"
                 onClick={() => selectBoard(b.id)}
                 className={cn(
                   'w-full text-left px-4 py-2.5 flex items-center gap-2.5 transition-colors',
@@ -229,6 +231,7 @@ function BoardCanvas({ boardId }: { boardId: string }) {
             />
           ) : (
             <button
+              type="button"
               onClick={() => { setTitleDraft(snap.title); setEditingTitle(true) }}
               className="text-2xl font-semibold text-ink-900 hover:text-skype-deep text-left truncate"
             >
@@ -242,6 +245,7 @@ function BoardCanvas({ boardId }: { boardId: string }) {
           )}
         </div>
         <button
+          type="button"
           onClick={async () => {
             if (!confirm(t('boards.deleteBoardConfirm', { title: snap.title }))) return
             try { await deleteBoard(boardId) } catch (e) { console.warn('[boards] delete failed', e) }
@@ -282,6 +286,7 @@ function BoardCanvas({ boardId }: { boardId: string }) {
             </div>
           ) : (
             <button
+              type="button"
               onClick={() => setAddingCol(true)}
               className="w-72 flex-shrink-0 px-3 py-2.5 rounded-lg text-sm text-ink-500 border border-dashed border-ink-200 hover:bg-cloud/40 hover:text-ink-700 transition-colors text-left"
             >
@@ -371,6 +376,7 @@ function ColumnView({ boardId, column, cards, onOpenCard }: {
           />
         ) : (
           <button
+            type="button"
             onClick={() => { setTitleDraft(column.title); setEditingTitle(true) }}
             className="text-sm font-medium text-ink-700 hover:text-skype-deep flex-1 text-left truncate"
           >
@@ -379,6 +385,7 @@ function ColumnView({ boardId, column, cards, onOpenCard }: {
         )}
         <span className="text-xs text-ink-400">{cards.length}</span>
         <button
+          type="button"
           onClick={async () => {
             if (cards.length > 0 && !confirm(t('boards.deleteColumnConfirm', { title: column.title, count: cards.length }))) return
             try { await deleteColumn(boardId, column.id) } catch (e) { console.warn('[boards] delete col failed', e) }
@@ -410,6 +417,7 @@ function ColumnView({ boardId, column, cards, onOpenCard }: {
           />
         ) : (
           <button
+            type="button"
             onClick={() => setAdding(true)}
             className="w-full text-left text-xs text-ink-400 px-2.5 py-1.5 rounded-md hover:bg-cloud hover:text-ink-600 transition-colors"
           >
@@ -914,6 +922,7 @@ function CardDetailModal({ boardId, card, columns, onClose }: {
             )}
             <div className="mt-1 flex justify-end">
               <button
+                type="button"
                 onClick={() => void saveDescription()}
                 className="text-xs text-ink-500 hover:text-skype-deep px-2 py-1"
               >{t('boards.saveDescription')}</button>
@@ -957,6 +966,7 @@ function CardDetailModal({ boardId, card, columns, onClose }: {
               />
               <div className="mt-1 flex justify-end gap-2">
                 <button
+                  type="button"
                   onClick={() => void postComment()}
                   disabled={!draftComment.trim() || posting}
                   className="px-3 py-1.5 text-sm rounded-md bg-skype text-white hover:bg-skype-deep disabled:opacity-40 disabled:hover:bg-skype"
@@ -971,6 +981,7 @@ function CardDetailModal({ boardId, card, columns, onClose }: {
             {t('boards.createdByAt', { time: formatTime(card.createdAt), author: byId[card.createdBy]?.name ?? card.createdBy })}
           </div>
           <button
+            type="button"
             onClick={async () => {
               if (!confirm(t('boards.deleteCardConfirm'))) return
               try { await deleteCard(boardId, card.id); onClose() } catch (e) { console.warn(e) }

--- a/src/desktop/CalendarView.tsx
+++ b/src/desktop/CalendarView.tsx
@@ -203,6 +203,7 @@ function ContextMenu({ x, y, items, onClose }: {
     >
       {items.map((it, i) => (
         <button
+          type="button"
           key={i}
           onClick={() => { it.onClick(); onClose() }}
           className={cn(
@@ -334,6 +335,7 @@ function MonthGrid({ cursor, events, onEdit, onNew }: GridProps) {
                 <div className="flex flex-col gap-0.5 overflow-hidden">
                   {items.slice(0, 3).map((it, i) => (
                     <button
+                      type="button"
                       key={`${it.event.id}-${i}`}
                       onMouseDown={(e) => e.stopPropagation()}
                       onClick={(e) => { e.stopPropagation(); onEdit(it.event) }}
@@ -574,6 +576,7 @@ function TimeGrid({ cursor, events, onEdit, onNew, dayCount }: GridProps & { day
                 const height = (durMin / 60) * HOUR_HEIGHT
                 return (
                   <button
+                    type="button"
                     key={`${occ.event.id}-${i}`}
                     onMouseDown={(e) => e.stopPropagation()}
                     onClick={() => onEdit(occ.event)}
@@ -701,12 +704,12 @@ export function CalendarView() {
           <h1 className="text-lg font-semibold text-ink-900">{t('cal.title')}</h1>
 
           <div className="flex items-center gap-1 ml-3">
-            <button onClick={goPrev}
+            <button type="button" onClick={goPrev}
               className="w-7 h-7 rounded-md grid place-items-center text-ink-500 hover:bg-ink-100"
               aria-label={t('cal.previous')}>‹</button>
-            <button onClick={goToday}
+            <button type="button" onClick={goToday}
               className="px-2 h-7 rounded-md text-xs font-medium text-ink-700 hover:bg-ink-100">{t('cal.today')}</button>
-            <button onClick={goNext}
+            <button type="button" onClick={goNext}
               className="w-7 h-7 rounded-md grid place-items-center text-ink-500 hover:bg-ink-100"
               aria-label={t('cal.next')}>›</button>
             <span className="ml-2 text-sm text-ink-700 font-medium">{headerLabel}</span>
@@ -720,6 +723,7 @@ export function CalendarView() {
           >
             {(['day', 'week', 'month'] as const).map((m) => (
               <button
+                type="button"
                 key={m}
                 onClick={() => setMode(m)}
                 className={cn(
@@ -733,6 +737,7 @@ export function CalendarView() {
           </div>
 
           <button
+            type="button"
             onClick={() => openNew()}
             className="inline-flex items-center gap-1.5 px-3.5 h-8 rounded-full text-[12.5px] font-semibold text-white transition active:scale-[0.985]"
             style={{
@@ -766,6 +771,7 @@ export function CalendarView() {
             <div className="px-1 py-6 text-center">
               <div className="text-sm text-ink-500 mb-2">{t('cal.empty30')}</div>
               <button
+                type="button"
                 onClick={() => openNew()}
                 className="text-xs text-skype font-medium hover:underline"
               >{t('cal.scheduleCta')}</button>
@@ -804,6 +810,7 @@ export function CalendarView() {
                       )}
                     </div>
                     <button
+                      type="button"
                       onClick={() => openEdit(it.event)}
                       className="text-left text-sm font-medium text-ink-900 hover:text-skype-deep block w-full truncate"
                     >{it.event.title}</button>
@@ -822,6 +829,7 @@ export function CalendarView() {
                   <div className="flex flex-col gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
                     {it.event.kind === 'agent_task' && (
                       <button
+                        type="button"
                         title={t('cal.runNow')}
                         onClick={async () => {
                           try { await runNow(it.event.id) } catch (err) { console.warn('[calendar] run-now failed', err) }
@@ -831,6 +839,7 @@ export function CalendarView() {
                     )}
                     {(it.event.createdBy === meId) && (
                       <button
+                        type="button"
                         title={t('cal.deleteEvent')}
                         onClick={async () => {
                           if (!confirm(t('cal.deleteEventConfirm', { title: it.event.title }))) return

--- a/src/desktop/ChatPane.tsx
+++ b/src/desktop/ChatPane.tsx
@@ -236,6 +236,7 @@ function ChatHeader({
             <>
               <span className="w-1 h-1 rounded-full bg-ink-300 shrink-0" />
               <button
+                type="button"
                 onClick={startEditTopic}
                 className="text-ink-300 italic font-display hover:text-skype-deep transition shrink-0"
                 title={t('chat.setTopic')}
@@ -263,6 +264,7 @@ function ChatHeader({
           />
         ) : c.topic ? (
           <button
+            type="button"
             onClick={startEditTopic}
             // Italic glyphs lean past their box — without right padding,
             // `truncate`'s overflow:hidden chops the slanted edge of the
@@ -279,6 +281,7 @@ function ChatHeader({
           already lists the names below it, so this is a redundant visual
           worth dropping when space is tight. */}
       <button
+        type="button"
         ref={memberStackRef}
         onClick={onClickStack}
         aria-haspopup="dialog"
@@ -304,6 +307,7 @@ function ChatHeader({
           action in this header. */}
       <div className="flex gap-1 text-ink-500 shrink-0">
         <button
+          type="button"
           onClick={onToggleSearch}
           title={t('chat.search')}
           aria-label={t('chat.search')}
@@ -315,6 +319,7 @@ function ChatHeader({
           <ISearch className="w-[19px] h-[19px]" />
         </button>
         <button
+          type="button"
           onClick={async () => {
             // Optimistic flip so the icon updates instantly; reload to sync
             // pinned-order in the sidebar. Mirrors the conversations-pane flow.
@@ -341,6 +346,7 @@ function ChatHeader({
         </button>
         <div className="relative">
           <button
+            type="button"
             onClick={() => setShowConveneSoon((v) => !v)}
             title={t('chat.convene')}
             className="px-3.5 inline-flex items-center gap-1.5 font-semibold text-[12.5px] rounded-full text-white"
@@ -414,6 +420,7 @@ function EmojiPopover({ onPick, onClose }: { onPick: (e: string) => void; onClos
       <div className="flex gap-1 mb-2 px-0.5">
         {(['std', 'skype'] as const).map((k) => (
           <button
+            type="button"
             key={k}
             onClick={() => setTab(k)}
             className={cn(
@@ -427,6 +434,7 @@ function EmojiPopover({ onPick, onClose }: { onPick: (e: string) => void; onClos
         <div className="grid grid-cols-6 gap-1">
           {COMPOSER_EMOJIS.map((e) => (
             <button
+              type="button"
               key={e}
               onClick={() => onPick(e)}
               className="h-8 w-8 rounded grid place-items-center hover:bg-sky2-50 transition"
@@ -440,6 +448,7 @@ function EmojiPopover({ onPick, onClose }: { onPick: (e: string) => void; onClos
         >
           {SKYPE_EMOJIS.map((e) => (
             <button
+              type="button"
               key={e.key}
               onClick={() => {
                 onPick(e.shortcodes[0])
@@ -1036,6 +1045,7 @@ export function Composer({
               <div className="text-[10.5px] text-ink-500 truncate">{attachment.mime ?? attachment.kind}{attachment.size ? ` · ${Math.round(attachment.size / 1024)}KB` : ''}</div>
             </div>
             <button
+              type="button"
               onClick={() => setAttachment(null)}
               className="ml-1 w-6 h-6 rounded-md grid place-items-center text-ink-500 hover:bg-cloud hover:text-ink-900 transition shrink-0"
               aria-label={t('chat.removeAttachment')}
@@ -1073,6 +1083,7 @@ export function Composer({
               </div>
             </div>
             <button
+              type="button"
               onClick={() => setReplyingTo(convoId, null)}
               className="w-6 h-6 rounded-md grid place-items-center text-ink-500 hover:bg-cloud hover:text-ink-900 transition shrink-0 self-center"
               aria-label={t('chat.cancelReply')}
@@ -1221,11 +1232,13 @@ export function Composer({
             onChange={onPickFile}
           />
           <button
+            type="button"
             onClick={() => fileRef.current?.click()}
             className="w-7 h-7 rounded-[7px] grid place-items-center hover:bg-sky2-50 hover:text-skype-deep transition"
             title={t('chat.attachFile')}
           ><IClip className="w-[17px] h-[17px]" /></button>
           <button
+            type="button"
             onMouseDown={(e) => e.preventDefault()}
             onClick={() => insertAtCursor('@')}
             className="w-7 h-7 rounded-[7px] grid place-items-center hover:bg-sky2-50 hover:text-skype-deep transition"
@@ -1233,6 +1246,7 @@ export function Composer({
           ><IAt className="w-[17px] h-[17px]" /></button>
           <div className="relative">
             <button
+              type="button"
               onClick={() => setEmojiOpen((v) => !v)}
               className={cn(
                 'w-7 h-7 rounded-[7px] grid place-items-center hover:bg-sky2-50 hover:text-skype-deep transition',
@@ -1248,6 +1262,7 @@ export function Composer({
             )}
           </div>
           <button
+            type="button"
             onClick={send}
             disabled={!canSend}
             className="ml-auto h-[30px] px-3.5 rounded-full font-semibold text-[12px] text-white inline-flex items-center gap-1.5 transition disabled:cursor-not-allowed"
@@ -1348,6 +1363,7 @@ function ThreadError({ message, onRetry }: { message: string; onRetry: () => voi
           {message}
         </div>
         <button
+          type="button"
           onClick={handleRetry}
           disabled={retrying}
           className="mt-1 h-[30px] px-3.5 rounded-full font-semibold text-[12px] text-white inline-flex items-center gap-1.5 transition disabled:cursor-not-allowed"

--- a/src/desktop/ConveneView.tsx
+++ b/src/desktop/ConveneView.tsx
@@ -90,6 +90,7 @@ export function ConveneView() {
             {t('convene.ctaSub', { title: c.title })}
           </div>
           <button
+            type="button"
             onClick={startConvene}
             className="py-3 px-5 rounded-full text-white text-[13.5px] font-semibold inline-flex items-center gap-2"
             style={{ background: 'linear-gradient(135deg, var(--skype), var(--skype-deep))', boxShadow: '0 6px 16px -4px rgba(0, 168, 240, 0.5)' }}>

--- a/src/desktop/ConversationsPane.tsx
+++ b/src/desktop/ConversationsPane.tsx
@@ -464,6 +464,7 @@ function SearchResultsPane({
           const sel = idx === selectedIdx
           return (
             <button
+              type="button"
               key={`p-${p.id}`}
               data-search-idx={idx}
               onMouseEnter={() => onHover(idx)}
@@ -548,6 +549,7 @@ function SearchResultsPane({
           })
           return (
             <button
+              type="button"
               key={`m-${m.id}`}
               data-search-idx={idx}
               onMouseEnter={() => onHover(idx)}
@@ -598,6 +600,7 @@ function SearchConvoButton({ id, kind, title, members, byId, query, index, isSel
   })()
   return (
     <button
+      type="button"
       key={id}
       data-search-idx={index}
       onMouseEnter={() => onHover(index)}
@@ -950,6 +953,7 @@ export function ConversationsPane({ onResizeStart }: { onResizeStart?: (e: React
           const isActive = filter === f
           return (
             <button
+              type="button"
               key={f}
               onClick={() => setFilter(f)}
               className={cn(
@@ -984,6 +988,7 @@ export function ConversationsPane({ onResizeStart }: { onResizeStart?: (e: React
           const isActive = filter === filterKey
           return (
             <button
+              type="button"
               key={p.id}
               onClick={() => setFilter(filterKey)}
               className={cn(
@@ -1164,6 +1169,7 @@ function AddToGroupPicker({ participantId, participantName, groups, onClose }: {
             <div className="flex flex-col gap-1.5">
               {groups.map((g) => (
                 <button
+                  type="button"
                   key={g.id}
                   onClick={() => pick(g)}
                   disabled={busy}
@@ -1187,6 +1193,7 @@ function AddToGroupPicker({ participantId, participantName, groups, onClose }: {
         </div>
         <div className="px-6 py-4 border-t border-ink-100 flex items-center justify-end shrink-0 bg-paper">
           <button
+            type="button"
             onClick={onClose}
             className="px-4 py-2 rounded-[9px] text-[12.5px] font-semibold text-ink-700 bg-cloud hover:bg-sky2-50 transition"
             style={{ border: '1px solid var(--ink-100)' }}
@@ -1221,12 +1228,14 @@ function ConfirmLeave({ c, onCancel, onLeft }: {
         </p>
         <div className="flex gap-2">
           <button
+            type="button"
             onClick={onCancel}
             disabled={busy}
             className="flex-1 py-2 px-3 rounded-[9px] text-[12.5px] font-semibold text-ink-700 bg-cloud hover:bg-sky2-50 transition"
             style={{ border: '1px solid var(--ink-100)' }}
           >{t('common.cancel')}</button>
           <button
+            type="button"
             onClick={async () => { setBusy(true); await onLeft() }}
             disabled={busy}
             className="flex-1 py-2 px-3 rounded-[9px] text-[12.5px] font-semibold text-white transition disabled:opacity-50"
@@ -1315,6 +1324,7 @@ function AddMembersPicker({ group, candidates, onClose }: {
             const busy = busyId === p.id
             return (
               <button
+                type="button"
                 key={p.id}
                 disabled={busy}
                 onClick={() => void pick(p)}
@@ -1353,6 +1363,7 @@ function AddMembersPicker({ group, candidates, onClose }: {
         )}
         <div className="px-5 py-3 border-t border-ink-100 flex shrink-0">
           <button
+            type="button"
             onClick={onClose}
             className="ml-auto py-2 px-4 rounded-[9px] text-[12.5px] font-semibold text-ink-700 bg-cloud hover:bg-sky2-50 transition"
             style={{ border: '1px solid var(--ink-100)' }}

--- a/src/desktop/InfoPane.tsx
+++ b/src/desktop/InfoPane.tsx
@@ -68,6 +68,7 @@ export function InfoPane() {
       style={{ background: 'var(--chrome-pane)' }}
     >
       <button
+        type="button"
         onClick={close}
         aria-label={t('info.close')}
         className="absolute top-3 right-3 z-10 w-7 h-7 rounded-full grid place-items-center text-ink-500 hover:bg-cloud hover:text-ink-900 transition border border-ink-100 bg-cloud/70 backdrop-blur-sm"
@@ -91,6 +92,7 @@ export function InfoPane() {
 
       <div className="flex gap-2 py-3.5 px-[22px] border-b border-ink-100">
         <button
+          type="button"
           onClick={startDM}
           disabled={opening}
           className="flex-1 py-2.5 px-3 text-white rounded-[9px] text-[12px] font-semibold inline-flex items-center justify-center gap-1.5 transition disabled:opacity-50"
@@ -105,10 +107,10 @@ export function InfoPane() {
         {/* Whisper / Convene are agent-team rituals; humans use plain DM. */}
         {isAgent && (
           <>
-            <button className="flex-1 py-2.5 px-3 bg-skype-ink text-white rounded-[9px] text-[12px] font-semibold inline-flex items-center justify-center gap-1.5">
+            <button type="button" className="flex-1 py-2.5 px-3 bg-skype-ink text-white rounded-[9px] text-[12px] font-semibold inline-flex items-center justify-center gap-1.5">
               {t('info.whisper')}
             </button>
-            <button className="flex-1 py-2.5 px-3 bg-cloud border border-ink-100 rounded-[9px] text-[12px] font-semibold inline-flex items-center justify-center gap-1.5 hover:border-sky2-200 hover:text-skype-deep">
+            <button type="button" className="flex-1 py-2.5 px-3 bg-cloud border border-ink-100 rounded-[9px] text-[12px] font-semibold inline-flex items-center justify-center gap-1.5 hover:border-sky2-200 hover:text-skype-deep">
               {t('info.convene')}
             </button>
           </>

--- a/src/desktop/MeView.tsx
+++ b/src/desktop/MeView.tsx
@@ -343,7 +343,7 @@ function UsageTab() {
             style={{ border: '1px solid var(--ink-100)' }}>
             <div className="font-display text-[14px] text-ink-700 mb-1">{t('me.quotaFetchFailed')}</div>
             <div className="font-display italic text-[12px] text-coral-deep mb-3">{state.message}</div>
-            <button onClick={load}
+            <button type="button" onClick={load}
               className="px-4 py-1.5 rounded-[8px] text-[12px] font-semibold text-white"
               style={{ background: 'var(--skype)' }}>
               {t('common.tryAgain')}
@@ -384,7 +384,7 @@ function UsageTab() {
             <div className="font-display italic text-[12px] text-ink-500 mt-1 max-w-xl">
               {error ? t('me.quotaGatewayUnreachHint') : t('me.subNotProvisioned')}
             </div>
-            <button onClick={load}
+            <button type="button" onClick={load}
               className="mt-3 px-4 py-1.5 rounded-[8px] text-[12px] font-semibold text-skype-deep bg-cloud hover:bg-sky2-50 transition"
               style={{ border: '1px dashed var(--sky2-300)' }}>
               {t('me.refresh')}
@@ -414,7 +414,7 @@ function UsageTab() {
           ))}
         </div>
         <div className="mt-4 flex items-center gap-3">
-          <button onClick={load}
+          <button type="button" onClick={load}
             className="px-4 py-1.5 rounded-[8px] text-[12px] font-semibold text-skype-deep bg-cloud hover:bg-sky2-50 transition"
             style={{ border: '1px solid var(--ink-100)' }}>
             {t('me.refresh')}
@@ -569,6 +569,7 @@ function ProjectsTab() {
                   </div>
                 </div>
                 <button
+                  type="button"
                   onClick={() => archive(p.id, p.status !== 'archived')}
                   className="px-3 py-1.5 rounded-[8px] text-[11.5px] font-semibold text-ink-700 bg-paper hover:bg-sky2-50 transition"
                   style={{ border: '1px solid var(--ink-100)' }}
@@ -601,12 +602,14 @@ function ProjectsTab() {
             {err && <div className="text-[11.5px] text-coral-deep">{err}</div>}
             <div className="flex gap-2">
               <button
+                type="button"
                 onClick={create}
                 disabled={!name.trim() || busy}
                 className="px-4 py-1.5 rounded-[8px] text-[12px] font-semibold text-white disabled:opacity-50"
                 style={{ background: 'var(--skype)' }}
               >{busy ? t('me.createProjectBusy') : t('me.createProject')}</button>
               <button
+                type="button"
                 onClick={() => { setCreating(false); setName(''); setDescription(''); setErr(null) }}
                 className="px-3 py-1.5 rounded-[8px] text-[12px] text-ink-500 hover:bg-cloud"
               >{t('common.cancel')}</button>
@@ -615,12 +618,14 @@ function ProjectsTab() {
         ) : (
           <div className="mt-4 flex items-center gap-3">
             <button
+              type="button"
               onClick={() => setCreating(true)}
               className="px-4 py-2 rounded-[10px] text-[12.5px] font-semibold text-skype-deep bg-cloud hover:bg-sky2-50 transition"
               style={{ border: '1px dashed var(--sky2-300)' }}
             >{t('me.newProject')}</button>
             {archivedCount > 0 && (
               <button
+                type="button"
                 onClick={() => setShowArchived((v) => !v)}
                 className="text-[11.5px] text-ink-500 hover:text-skype-deep transition italic font-display"
               >
@@ -1003,7 +1008,7 @@ function ComputersTab() {
                         className="text-[12px] font-semibold text-skype-deep px-2 py-1">
                         {expanded ? t('me.hideAction') : t('me.reconnect')}
                       </button>
-                      <button onClick={(e) => { e.stopPropagation(); void remove(c.id, c.name) }}
+                      <button type="button" onClick={(e) => { e.stopPropagation(); void remove(c.id, c.name) }}
                         className="text-[12px] font-semibold text-coral-deep hover:underline px-2 py-1">
                         {t('me.remove')}
                       </button>
@@ -1110,7 +1115,7 @@ function ComputersTab() {
                     ) : (
                       <>
                         <pre className="bg-ink-900 text-cloud rounded-[10px] p-3 text-[12px] overflow-x-auto whitespace-pre-wrap break-all font-mono select-all">{repairCmd}</pre>
-                        <button onClick={(e) => { e.stopPropagation(); void navigator.clipboard?.writeText(repairCmd); setRepairCopied(true) }}
+                        <button type="button" onClick={(e) => { e.stopPropagation(); void navigator.clipboard?.writeText(repairCmd); setRepairCopied(true) }}
                           className="mt-2 inline-flex items-center justify-center min-w-[120px] text-[12px] font-semibold px-3 py-1.5 rounded-[9px] text-white transition-colors duration-200"
                           style={{ background: repairCopied ? '#3BB273' : 'var(--skype)' }}>
                           {repairCopied ? t('me.copied') : t('me.copyCommand')}
@@ -1154,7 +1159,7 @@ function ComputersTab() {
             </label>
             <pre className="bg-ink-900 text-cloud rounded-[10px] p-3 text-[12px] overflow-x-auto whitespace-pre-wrap break-all font-mono select-all">{pairCommand}</pre>
             <div className="flex gap-2 mt-3">
-              <button onClick={copyCommand} aria-live="polite"
+              <button type="button" onClick={copyCommand} aria-live="polite"
                 className="inline-flex items-center justify-center gap-1.5 min-w-[128px] text-[12px] font-semibold px-3 py-1.5 rounded-[9px] text-white transition-colors duration-200"
                 style={{ background: copied ? '#3BB273' : 'var(--skype)' }}>
                 {copied ? (
@@ -1168,7 +1173,7 @@ function ComputersTab() {
                   </>
                 ) : t('me.copyCommand')}
               </button>
-              <button onClick={() => setCode(null)}
+              <button type="button" onClick={() => setCode(null)}
                 className="text-[12px] font-semibold px-3 py-1.5 rounded-[9px] border border-ink-100 text-ink-600">{t('me.done')}</button>
             </div>
             <style>{`
@@ -1177,7 +1182,7 @@ function ComputersTab() {
             `}</style>
           </div>
         ) : (
-          <button onClick={addComputer} disabled={busy}
+          <button type="button" onClick={addComputer} disabled={busy}
             className="mt-4 px-4 py-2 rounded-[10px] bg-skype text-white text-[13px] font-semibold disabled:opacity-50">
             {busy ? t('me.computersGenerating') : t('me.addComputer')}
           </button>
@@ -1257,13 +1262,13 @@ function DaemonUpgradeBanner({ onJump }: { onJump: () => void }) {
           </div>
           <div className="mt-2.5 flex items-stretch gap-2 max-w-[580px]">
             <code className="flex-1 bg-ink-900 text-cloud rounded-[10px] px-3 py-2 text-[12px] font-mono overflow-x-auto whitespace-nowrap select-all flex items-center">{cmd}</code>
-            <button onClick={copy}
+            <button type="button" onClick={copy}
               className="shrink-0 inline-flex items-center justify-center min-w-[82px] text-[12px] font-semibold px-3 rounded-[10px] text-white transition-colors duration-200"
               style={{ background: copied ? 'var(--avail)' : 'var(--gold-deep)' }}>
               {copied ? t('me.copiedShort') : t('me.copy')}
             </button>
           </div>
-          <button onClick={onJump} className="mt-2 text-[11.5px] font-semibold text-gold-deep hover:underline" style={{ color: 'var(--gold-deep)' }}>
+          <button type="button" onClick={onJump} className="mt-2 text-[11.5px] font-semibold text-gold-deep hover:underline" style={{ color: 'var(--gold-deep)' }}>
             {t('me.manageComputers')}
           </button>
         </div>
@@ -1296,6 +1301,7 @@ export function MeView() {
         <div className="flex gap-1 mb-7 border-b border-ink-100">
           {tabs.map((tabDef, i) => (
             <button
+              type="button"
               key={tabDef.key}
               onClick={() => setTab(tabDef.key)}
               className={cn(

--- a/src/desktop/ObservabilityView.tsx
+++ b/src/desktop/ObservabilityView.tsx
@@ -366,6 +366,7 @@ function RunRow({ run, active, onClick }: { run: ApiAgentRun; active: boolean; o
   const t = useT()
   return (
     <button
+      type="button"
       onClick={onClick}
       className={cn(
         'w-full rounded-[12px] border p-3 text-left transition',
@@ -503,6 +504,7 @@ function FolderRow({ node, depth, expanded, onToggle }: {
 }) {
   return (
     <button
+      type="button"
       onClick={onToggle}
       className="flex w-full items-center gap-1.5 rounded-[7px] px-1.5 py-1 text-left transition hover:bg-cloud/80"
       style={{ paddingLeft: 6 + depth * 14 }}
@@ -552,6 +554,7 @@ function FileRow({ node, depth, active, onClick }: {
   const tint = FILE_TYPE_TINT[ext] ?? { bg: 'var(--ink-100)', fg: 'var(--ink-500)' }
   return (
     <button
+      type="button"
       onClick={onClick}
       className={cn(
         'flex w-full items-center gap-2 rounded-[7px] py-1 pr-1.5 text-left transition',
@@ -761,6 +764,7 @@ function WakeEconomicsPanel(props: {
           <div className="grid grid-cols-4 gap-1 rounded-[11px] border border-ink-100 bg-cloud p-1">
             {DEV_PANELS.map((item) => (
               <button
+                type="button"
                 key={item}
                 onClick={() => props.setPanel(item)}
                 className={cn(
@@ -912,6 +916,7 @@ function TriageEconomicsPanel(props: {
           <div className="grid grid-cols-4 gap-1 rounded-[11px] border border-ink-100 bg-cloud p-1">
             {DEV_PANELS.map((item) => (
               <button
+                type="button"
                 key={item}
                 onClick={() => props.setPanel(item)}
                 className={cn(
@@ -1341,6 +1346,7 @@ export function ObservabilityView() {
           <div className="mt-4 grid grid-cols-4 gap-1 rounded-[11px] border border-ink-100 bg-cloud p-1">
             {DEV_PANELS.map((item) => (
               <button
+                type="button"
                 key={item}
                 onClick={() => setPanel(item)}
                 className={cn(

--- a/src/desktop/Onboarding.tsx
+++ b/src/desktop/Onboarding.tsx
@@ -74,7 +74,7 @@ export function Onboarding() {
                 {/* biome-ignore lint/security/noDangerouslySetInnerHtml: static copy from the locale bundle, not user input */}
                 <div className="text-[13px] text-ink-600 mb-4" dangerouslySetInnerHTML={{ __html: t('onboard.cmdIntro') }} />
                 {err && <div className="text-[12px] text-coral-deep bg-coral-soft rounded-[8px] p-2 mb-3">{err}</div>}
-                <button onClick={getCode} disabled={busy}
+                <button type="button" onClick={getCode} disabled={busy}
                   className="px-5 py-2.5 rounded-[11px] bg-skype text-white text-[14px] font-semibold disabled:opacity-50">
                   {busy ? t('onboard.generating') : t('onboard.addComputer')}
                 </button>
@@ -108,7 +108,7 @@ export function Onboarding() {
                 </label>
                 <pre className="bg-ink-900 text-cloud rounded-[10px] p-3 text-[12px] overflow-x-auto whitespace-pre-wrap break-all font-mono select-all">{cmd}</pre>
                 <div className="flex items-center gap-3 mt-3">
-                  <button onClick={() => { void navigator.clipboard?.writeText(cmd); setCopied(true) }}
+                  <button type="button" onClick={() => { void navigator.clipboard?.writeText(cmd); setCopied(true) }}
                     className="inline-flex items-center justify-center min-w-[120px] text-[12px] font-semibold px-3 py-1.5 rounded-[9px] text-white transition-colors duration-200"
                     style={{ background: copied ? '#3BB273' : 'var(--skype)' }}>
                     {copied ? t('onboard.copied') : t('onboard.copy')}

--- a/src/desktop/Rail.tsx
+++ b/src/desktop/Rail.tsx
@@ -80,6 +80,7 @@ export function Rail() {
       style={{ background: 'var(--chrome-rail)' }}
     >
       <button
+        type="button"
         className="mb-3.5 relative"
         onClick={() => setView('me')}
         title={daemonOutdated ? t('common.daemonOutdatedTip') : (authUser?.name ?? t('common.you'))}
@@ -98,6 +99,7 @@ export function Rail() {
         const badge = key === 'conversations' && totalUnread > 0 ? totalUnread : undefined
         return (
           <button
+            type="button"
             key={key}
             onClick={() => setView(key)}
             title={t(label)}
@@ -123,6 +125,7 @@ export function Rail() {
 
       <div className="flex-1" />
       <button
+        type="button"
         onClick={async () => {
           // Revoke session server-side before clearing local state, so a
           // leaked token isn't valid anywhere after sign out. Best-effort —

--- a/src/desktop/ThreadDrawer.tsx
+++ b/src/desktop/ThreadDrawer.tsx
@@ -128,6 +128,7 @@ export function ThreadDrawer() {
           </div>
         </div>
         <button
+          type="button"
           onClick={close}
           aria-label={t('thread.close')}
           className="w-7 h-7 rounded-md grid place-items-center text-ink-500 hover:bg-cloud hover:text-ink-900 transition"

--- a/src/desktop/WhispersView.tsx
+++ b/src/desktop/WhispersView.tsx
@@ -78,6 +78,7 @@ export function WhispersView() {
                 : t('whispers.andNMore', { a: ms[0].name, b: ms[1].name, n: ms.length - 2 })
             return (
               <button
+                type="button"
                 key={w.id}
                 onClick={() => setSelectedId(w.id)}
                 className={cn(

--- a/src/mobile/MobileCalendar.tsx
+++ b/src/mobile/MobileCalendar.tsx
@@ -216,6 +216,7 @@ export function MobileCalendar() {
         className="sticky top-0 z-10 bg-paper/95 backdrop-blur-md px-3 pt-2 pb-1 flex items-center gap-2"
       >
         <button
+          type="button"
           onClick={() => goMonth(-1)}
           className="w-9 h-9 grid place-items-center rounded-full text-ink-700 active:bg-sky2-50 transition text-[20px] leading-none"
           aria-label={t('mcal.prevMonth')}
@@ -224,11 +225,13 @@ export function MobileCalendar() {
           {monthLabel}
         </div>
         <button
+          type="button"
           onClick={() => goMonth(1)}
           className="w-9 h-9 grid place-items-center rounded-full text-ink-700 active:bg-sky2-50 transition text-[20px] leading-none"
           aria-label={t('mcal.nextMonth')}
         >›</button>
         <button
+          type="button"
           onClick={goToday}
           className="py-1.5 px-3 text-[11.5px] font-semibold rounded-full bg-sky2-50 border border-sky2-100 active:bg-sky2-100 transition"
           style={{ color: 'var(--skype)' }}
@@ -255,6 +258,7 @@ export function MobileCalendar() {
             const isSelected = selectedDay !== null && sameDay(d, selectedDay)
             return (
               <button
+                type="button"
                 key={k}
                 onClick={() => {
                   setSelectedDay(new Date(d))
@@ -346,6 +350,7 @@ function DayDetail({ day, items, onEdit, onNew, byId }: {
         </div>
         <span className="text-[11px] text-ink-400">· {items.length === 1 ? t('mcal.eventCount', { n: items.length, s: '' }) : t('mcal.eventCount', { n: items.length, s: 's' })}</span>
         <button
+          type="button"
           onClick={onNew}
           className="ml-auto py-1 px-2 text-[11px] font-semibold rounded-full text-skype-deep bg-sky2-50 border border-sky2-100 active:bg-sky2-100 transition"
         >{t('mcal.newEvent')}</button>
@@ -360,6 +365,7 @@ function DayDetail({ day, items, onEdit, onNew, byId }: {
           </div>
           <div className="text-[12.5px] text-ink-500 font-display italic leading-relaxed">{t('mcal.emptyDay')}</div>
           <button
+            type="button"
             onClick={onNew}
             className="mt-3 py-1.5 px-3 text-[12px] font-semibold rounded-full bg-cloud border border-ink-100 text-ink-700 active:bg-sky2-50 transition"
           >{t('mcal.addEvent')}</button>
@@ -374,6 +380,7 @@ function DayDetail({ day, items, onEdit, onNew, byId }: {
             const assignee = ev.assigneeId ? byId[ev.assigneeId] : null
             return (
               <button
+                type="button"
                 key={`${ev.id}-${it.occurrence.getTime()}`}
                 onClick={() => onEdit(ev)}
                 className="w-full text-left rounded-[12px] p-3 border active:scale-[0.99] transition"

--- a/src/mobile/MobileChat.tsx
+++ b/src/mobile/MobileChat.tsx
@@ -547,12 +547,14 @@ export function MobileChat() {
                   }}
                 >
                   <button
+                    type="button"
                     onClick={() => { pushStack('info'); setMenuOpen(false) }}
                     className="w-full text-left py-2.5 px-3.5 text-[13px] text-ink-700 active:bg-sky2-50"
                   >
                     {t('mobchat.viewDetails')}
                   </button>
                   <button
+                    type="button"
                     onClick={toggleMute}
                     className="w-full text-left py-2.5 px-3.5 text-[13px] text-ink-700 active:bg-sky2-50"
                   >
@@ -560,6 +562,7 @@ export function MobileChat() {
                   </button>
                   <div className="h-px bg-ink-100 mx-1.5 my-1" />
                   <button
+                    type="button"
                     onClick={leaveConvo}
                     className="w-full text-left py-2.5 px-3.5 text-[13px] text-coral-deep active:bg-coral-soft/60"
                   >
@@ -667,6 +670,7 @@ export function MobileChat() {
               <div className="text-[10.5px] text-ink-500 truncate">{attachment.mime ?? attachment.kind}{attachment.size ? ` · ${Math.round(attachment.size / 1024)}KB` : ''}</div>
             </div>
             <button
+              type="button"
               onClick={() => setAttachment(null)}
               className="ml-1 w-6 h-6 rounded-md grid place-items-center text-ink-500 active:bg-cloud transition shrink-0"
               aria-label={t('mobchat.removeAttachment')}
@@ -693,6 +697,7 @@ export function MobileChat() {
               </div>
             </div>
             <button
+              type="button"
               onClick={() => setReplyingTo(convoId, null)}
               className="w-6 h-6 rounded-md grid place-items-center text-ink-500 active:bg-cloud transition shrink-0 self-center"
               aria-label={t('mobchat.cancelReply')}
@@ -878,6 +883,7 @@ export function MobileChat() {
             <div className="flex gap-1 px-2 pt-2">
               {(['std', 'skype'] as const).map((k) => (
                 <button
+                  type="button"
                   key={k}
                   onClick={() => setEmojiTab(k)}
                   className={cn(
@@ -892,6 +898,7 @@ export function MobileChat() {
                 <div className="grid grid-cols-8 gap-0.5">
                   {COMPOSER_EMOJIS.map((e) => (
                     <button
+                      type="button"
                       key={e}
                       onClick={() => insertAtCursor(e)}
                       className="h-9 grid place-items-center rounded active:bg-sky2-50 transition"
@@ -903,6 +910,7 @@ export function MobileChat() {
                 <div className="grid grid-cols-7 gap-0.5">
                   {SKYPE_EMOJIS.map((e) => (
                     <button
+                      type="button"
                       key={e.key}
                       onClick={() => insertAtCursor(e.shortcodes[0])}
                       className="h-10 grid place-items-center rounded active:bg-sky2-50 transition"
@@ -1184,6 +1192,7 @@ export function MobileChatInfo() {
       >
         <div className="px-2 py-2.5 flex items-center gap-2">
           <button
+            type="button"
             onClick={() => pushStack('chat')}
             className="w-10 h-10 grid place-items-center text-ink-700 active:bg-sky2-50 rounded-full transition"
             aria-label={t('mpinfo.back')}
@@ -1280,6 +1289,7 @@ export function MobileChatInfo() {
 
       <div className="grid grid-cols-2 gap-2 px-4 py-4 border-b border-ink-100">
         <button
+          type="button"
           onClick={startConvene}
           disabled={busy}
           className="py-3 px-4 rounded-xl text-white font-semibold text-[13px] active:opacity-80 transition disabled:opacity-50"
@@ -1288,6 +1298,7 @@ export function MobileChatInfo() {
           {busy ? t('mobchat.starting') : t('mobchat.convene')}
         </button>
         <button
+          type="button"
           onClick={onToggleMute}
           className="py-3 px-4 rounded-xl bg-cloud border border-ink-100 text-ink-700 font-semibold text-[13px] active:bg-sky2-50 transition"
         >
@@ -1392,6 +1403,7 @@ export function MobileChatInfo() {
 
       <div className="py-4 px-5">
         <button
+          type="button"
           onClick={onLeave}
           className="w-full py-3 px-4 rounded-[12px] text-[13px] font-semibold text-coral-deep transition text-left active:opacity-70"
           style={{ border: '1px solid rgba(255, 122, 107, 0.3)' }}

--- a/src/mobile/MobileContextMenu.tsx
+++ b/src/mobile/MobileContextMenu.tsx
@@ -134,6 +134,7 @@ export function MobileContextMenu({ open, anchor, items, caption, onClose }: Mob
             <div role="menu">
               {items.map((it, i) => (
                 <button
+                  type="button"
                   key={i}
                   role="menuitem"
                   disabled={it.disabled}

--- a/src/mobile/MobileLibrary.tsx
+++ b/src/mobile/MobileLibrary.tsx
@@ -82,6 +82,7 @@ export function MobileLibrary() {
             const active = tab === key
             return (
               <button
+                type="button"
                 key={key}
                 onClick={() => setTab(key)}
                 className={cn(
@@ -110,6 +111,7 @@ export function MobileLibrary() {
           or board list. Color/label switch per-tab to keep the affordance
           honest about what + means. */}
       <button
+        type="button"
         onClick={onPlus}
         disabled={creating}
         aria-label={tab === 'documents' ? 'New document' : tab === 'boards' ? 'New board' : 'New event'}
@@ -173,6 +175,7 @@ function DocumentsList() {
           const authorName = author?.name ?? (d.createdBy === me?.id ? 'You' : d.createdBy)
           return (
             <button
+              type="button"
               key={d.id}
               onClick={() => openDocumentPeek(d.id)}
               className="w-full text-left grid grid-cols-[36px_1fr_auto] gap-3 py-3 px-4 active:bg-sky2-50 transition"
@@ -223,6 +226,7 @@ function BoardsList() {
           const authorName = author?.name ?? (b.createdBy === me?.id ? 'You' : b.createdBy)
           return (
             <button
+              type="button"
               key={b.id}
               onClick={() => openBoardPeek(b.id, null)}
               className="w-full text-left grid grid-cols-[36px_1fr_auto] gap-3 py-3 px-4 active:bg-sky2-50 transition"

--- a/src/mobile/MobileMessageTapback.tsx
+++ b/src/mobile/MobileMessageTapback.tsx
@@ -161,6 +161,7 @@ export function MobileMessageTapback({
             <div role="menu">
               {actions.map((a, i) => (
                 <button
+                  type="button"
                   key={i}
                   role="menuitem"
                   onClick={() => {

--- a/src/mobile/SwipeableRow.tsx
+++ b/src/mobile/SwipeableRow.tsx
@@ -92,6 +92,7 @@ export function SwipeableRow({ actions, children, className }: SwipeableRowProps
           }
           return (
             <button
+              type="button"
               key={i}
               tabIndex={revealed ? 0 : -1}
               onClick={() => {

--- a/src/web/WebShell.tsx
+++ b/src/web/WebShell.tsx
@@ -82,6 +82,7 @@ function WebHandoff() {
         </div>
         <div className="w-full flex flex-col gap-2.5">
           <button
+            type="button"
             onClick={openApp}
             className="w-full py-3 rounded-[12px] text-[14px] font-semibold text-white transition"
             style={{
@@ -91,6 +92,7 @@ function WebHandoff() {
           >{t('web.openDesktop')}</button>
           <GetDesktopAppLink variant="button-secondary" />
           <button
+            type="button"
             onClick={() => void signOut()}
             className="text-[12px] text-ink-400 hover:text-ink-700 transition font-display italic mt-1"
           >{t('web.signOut')}</button>


### PR DESCRIPTION
## What

CONTRIBUTING defers the biome a11y group as "separate follow-up work". This is that work, **one rule at a time**, starting with the most mechanical one:

- `biome.json`: `a11y.preset` stays `none`, but `useButtonType` becomes `error` — from now on CI fails on the next untyped `<button>`.
- All **192** currently-flagged DOM buttons get `type="button"` (161 as a standalone attribute line, 31 as an inline attribute on single-line tags), across 42 files. Every one is an action that must never submit — tabs, menu items, row openers, pickers, dismissers.

The buttons that intentionally submit (the shipping inline forms' `<Button type="submit">`) already declare their type and were never flagged. None of the 192 needed a case-by-case judgment beyond the sweep: the only file that mixes buttons with `<form>` elements is `ShippingWorkspace.tsx`, and its three flagged buttons all sit outside the forms.

## How it was done and verified

- Enumerated findings with `biome lint . --max-diagnostics=none` (the default 20-diagnostic cap hides the real count — worth knowing when picking at this group), inserted the attribute at each reported site, then re-linted to zero for this rule.
- Gates: `npm run lint` (back to the pre-existing single info), `npm run typecheck`, `npm run server:typecheck`, and the three `guard:*` scripts all pass.
- The remaining a11y findings (decorative-SVG titles ~105, keyboard access on click-only surfaces ~82, label association ~16, autoFocus ~14, a small tail ~20) are deliberately **not** touched here — they need per-site judgment and are the same follow-up, rule by rule.