### PR TITLE
release: v0.10.0

### DIFF
--- a/agent-cli/package.json
+++ b/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cumora",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Run Cumora agents on your own machine with Claude Code, Codex, Grok Build, Cursor Agent, OpenCode, or pi (BYOA).",
   "license": "MIT",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cumora",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cumora",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1045.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cumora",
   "private": true,
-  "version": "0.9.1",
+  "version": "0.10.0",
   "type": "module",
   "main": "electron/main.cjs",
   "bin": {


### PR DESCRIPTION
Fourteen commits have landed since v0.9.1 and none of them have shipped. This bump releases them.

## Security

- **#110 — agent CLI email no longer accepts filesystem paths as attachments.** `--attach` was resolved with `fs.readFile` inside `runCli`, which runs **server-side for every agent** — BYOA daemons POST argv to `/runtime/cli` rather than executing locally. A prompt-injected agent could therefore read an arbitrary server file and mail it out. The flag is now rejected before any storage, provider, or persistence side effect, with integration coverage asserting that traversal, symlink, `/proc/self/environ`, and k8s service-account-token candidates create no storage objects and no rows. UI-side email attachments (`resolveHttpAttachments`) and chat attachments are untouched.

## Fixes

- **#117 — Windows engine version detection.** The probe added in 0.9.1 spawned the path `where` returns first, which for npm-installed CLIs is an extensionless POSIX shim that `CreateProcess` cannot execute; Windows users saw "official x.y.z · version unknown". Now resolved to the runnable `.cmd`/`.bat` sibling and invoked through ComSpec.
- **#118 — reconnect no longer changes a computer's default engine.** `available_engines[0]` is the default, and the rescan path already protected it via `mergeDetectedEngines`; the pair/reconnect path bypassed that and wrote raw scan order.
- Signup no longer aborts its transaction on a taken workspace slug; a failed sign-in only reports text we wrote.
- Concurrent conversation membership changes no longer lose each other.
- An unknown agent-run status no longer takes down the whole observability view.

## Features and infrastructure

- Observability: a panel for how often a wake produced nothing.
- A CI guard that fails when an engine is wired into some of its lists but not all — the half-wired case previously billed runs to Claude silently.
- One source of truth for the runnable-engine list.
- **#122** — `useButtonType` is now an error, with `type="button"` on all 192 previously untyped buttons. No submit button was converted; `ShippingWorkspace.tsx` is the only file mixing buttons with forms and its three sit outside them.
- **#121** — the i18n coverage doc no longer describes views as untranslated that have been translated for a while.

## Verification on merged main

- 945 unit tests, 0 failures
- `typecheck`, `server:typecheck`, `lint`, `guard:big-brain`, `guard:llm-tracked`, `vite build` all clean