### PR TITLE
fix(skills): support CRLF frontmatter parsing and enforce atomic install validation

### DIFF
--- a/server/src/__tests__/agents-skills-install-ssrf.test.ts
+++ b/server/src/__tests__/agents-skills-install-ssrf.test.ts
@@ -58,3 +58,79 @@ test('protocol-relative install targets are rejected before any network request'
   )
   assert.equal(fetchCalls, 0)
 })
+
+test('parseSkillMd parses Windows CRLF newlines correctly', async () => {
+  const { parseSkillMd } = await import('../agents/skills.js')
+  const crlfContent = '---\r\nname: test-skill\r\ndescription: "A skill with CRLF"\r\nlicense: MIT\r\nmetadata:\r\n  author: alice\r\n---\r\n# Body\r\nSome instructions here.'
+  const parsed = parseSkillMd(crlfContent)
+
+  assert.ok(parsed.frontmatter)
+  assert.equal(parsed.frontmatter?.name, 'test-skill')
+  assert.equal(parsed.frontmatter?.description, 'A skill with CRLF')
+  assert.equal(parsed.frontmatter?.license, 'MIT')
+  assert.equal(parsed.frontmatter?.metadata?.author, 'alice')
+  assert.ok(parsed.body.includes('# Body'))
+})
+
+test('installSkillFromManifest rejects manifest without SKILL.md or with mismatched name', async () => {
+  const { installSkillFromManifest } = await import('../agents/skills.js')
+
+  // Missing SKILL.md
+  await assert.rejects(
+    installSkillFromManifest({
+      agentId: 'agent-1',
+      manifest: {
+        name: 'pdf-tools',
+        description: 'PDF tools',
+        files: [{ path: 'scripts/run.py', body: 'print(1)' }],
+      },
+    }),
+    /manifest must include SKILL.md at the skill root/i,
+  )
+
+  // Mismatched name in SKILL.md frontmatter vs manifest
+  await assert.rejects(
+    installSkillFromManifest({
+      agentId: 'agent-1',
+      manifest: {
+        name: 'pdf-tools',
+        description: 'PDF tools',
+        files: [{ path: 'SKILL.md', body: '---\nname: other-name\ndescription: Some desc\n---\n' }],
+      },
+    }),
+    /manifest name "pdf-tools" does not match SKILL.md frontmatter name "other-name"/i,
+  )
+
+  // Duplicate path in manifest
+  await assert.rejects(
+    installSkillFromManifest({
+      agentId: 'agent-1',
+      manifest: {
+        name: 'pdf-tools',
+        description: 'PDF tools',
+        files: [
+          { path: 'SKILL.md', body: '---\nname: pdf-tools\ndescription: PDF tools\n---\n' },
+          { path: 'scripts/run.py', body: 'print(1)' },
+          { path: 'scripts/run.py', body: 'print(2)' },
+        ],
+      },
+    }),
+    /duplicate file path in manifest: scripts\/run.py/i,
+  )
+
+  // Unsafe path with ./ or //
+  await assert.rejects(
+    installSkillFromManifest({
+      agentId: 'agent-1',
+      manifest: {
+        name: 'pdf-tools',
+        description: 'PDF tools',
+        files: [
+          { path: 'SKILL.md', body: '---\nname: pdf-tools\ndescription: PDF tools\n---\n' },
+          { path: './scripts/run.py', body: 'print(1)' },
+        ],
+      },
+    }),
+    /unsafe path/i,
+  )
+})

--- a/server/src/agents/skills.ts
+++ b/server/src/agents/skills.ts
@@ -44,11 +44,12 @@ export interface SkillFrontmatter {
  *  defines (scalar fields + a flat metadata mapping). For richer
  *  document trees we'd swap in `js-yaml`, but the spec doesn't need it. */
 export function parseSkillMd(content: string): { frontmatter: SkillFrontmatter | null; body: string } {
-  if (!content.startsWith('---\n')) return { frontmatter: null, body: content }
-  const end = content.indexOf('\n---', 4)
-  if (end < 0) return { frontmatter: null, body: content }
-  const fmRaw = content.slice(4, end)
-  const after = content.slice(end + 4).replace(/^\n/, '')
+  const normalized = content.replace(/\r\n/g, '\n')
+  if (!normalized.startsWith('---\n')) return { frontmatter: null, body: normalized }
+  const end = normalized.indexOf('\n---', 4)
+  if (end < 0) return { frontmatter: null, body: normalized }
+  const fmRaw = normalized.slice(4, end)
+  const after = normalized.slice(end + 4).replace(/^\n/, '')
 
   const scalar = (raw: string): string => {
     let v = raw.trim()
@@ -192,9 +193,19 @@ export async function installSkillFromManifest(args: {
     throw new Error(`too many files: ${manifest.files.length} > ${MAX_FILES_PER_SKILL}`)
   }
   // Must contain a SKILL.md at the root.
-  if (!manifest.files.some((f) => f.path === 'SKILL.md')) {
+  const rootSkillFile = manifest.files.find((f) => f.path === 'SKILL.md')
+  if (!rootSkillFile) {
     throw new Error('manifest must include SKILL.md at the skill root')
   }
+  const rootParsed = parseSkillMd(rootSkillFile.body)
+  if (!rootParsed.frontmatter) {
+    throw new Error('SKILL.md has missing or malformed YAML frontmatter')
+  }
+  if (rootParsed.frontmatter.name !== manifest.name) {
+    throw new Error(`manifest name "${manifest.name}" does not match SKILL.md frontmatter name "${rootParsed.frontmatter.name}"`)
+  }
+
+  const seenPaths = new Set<string>()
   // Path-traversal / size validation per file.
   for (const f of manifest.files) {
     if (typeof f.path !== 'string' || typeof f.body !== 'string') {
@@ -203,44 +214,66 @@ export async function installSkillFromManifest(args: {
     if (f.path.length === 0 || f.path.length > 200) {
       throw new Error(`bad path length: ${f.path}`)
     }
-    if (f.path.startsWith('/') || f.path.includes('..') || /[\\:*?<>"|]/.test(f.path)) {
+    if (
+      f.path.startsWith('/') ||
+      f.path.startsWith('./') ||
+      f.path.endsWith('/') ||
+      f.path.includes('..') ||
+      f.path.includes('/./') ||
+      f.path.includes('//') ||
+      /[\\:*?<>"|]/.test(f.path)
+    ) {
       throw new Error(`unsafe path: ${f.path}`)
     }
+    if (seenPaths.has(f.path)) {
+      throw new Error(`duplicate file path in manifest: ${f.path}`)
+    }
+    seenPaths.add(f.path)
     if (Buffer.byteLength(f.body, 'utf8') > MAX_FILE_BODY_BYTES) {
       throw new Error(`file ${f.path} > ${MAX_FILE_BODY_BYTES} bytes`)
     }
   }
 
-  // Don't clobber an existing skill — the agent decides whether to
-  // delete the old one first.
-  const { rows: existing } = await pool.query<{ path: string }>(
-    `SELECT path FROM agent_workspace WHERE agent_id = $1 AND path = $2 LIMIT 1`,
-    [agentId, `skills/${manifest.name}/SKILL.md`],
-  )
-  if (existing[0]) {
-    throw new Error(`skill "${manifest.name}" already installed — \`cumora skills delete ${manifest.name}\` first if you want to reinstall`)
-  }
-
-  // Same tenant lookup the CLI's workspace writes do — without it
-  // `agent_workspace.company_id` lands NULL and the Observability
-  // panel (which filters by the user's company) can't see the files.
-  const { rows: ag } = await pool.query<{ company_id: string | null }>(
-    `SELECT company_id FROM participants WHERE id = $1 LIMIT 1`, [agentId],
-  )
-  const tenant = ag[0]?.company_id ?? null
-
-  let written = 0
-  for (const f of manifest.files) {
-    const path = `skills/${manifest.name}/${f.path}`
-    await pool.query(
-      `INSERT INTO agent_workspace (agent_id, path, body, company_id, updated_at)
-       VALUES ($1, $2, $3, $4, NOW())
-       ON CONFLICT (agent_id, path) DO UPDATE SET body = EXCLUDED.body, company_id = EXCLUDED.company_id, updated_at = NOW()`,
-      [agentId, path, f.body, tenant],
+  const client = await pool.connect()
+  try {
+    await client.query('BEGIN')
+    // Don't clobber an existing skill — the agent decides whether to
+    // delete the old one first.
+    const { rows: existing } = await client.query<{ path: string }>(
+      `SELECT path FROM agent_workspace WHERE agent_id = $1 AND path = $2 LIMIT 1 FOR UPDATE`,
+      [agentId, `skills/${manifest.name}/SKILL.md`],
     )
-    written++
+    if (existing[0]) {
+      throw new Error(`skill "${manifest.name}" already installed — \`cumora skills delete ${manifest.name}\` first if you want to reinstall`)
+    }
+
+    // Same tenant lookup the CLI's workspace writes do — without it
+    // `agent_workspace.company_id` lands NULL and the Observability
+    // panel (which filters by the user's company) can't see the files.
+    const { rows: ag } = await client.query<{ company_id: string | null }>(
+      `SELECT company_id FROM participants WHERE id = $1 LIMIT 1`, [agentId],
+    )
+    const tenant = ag[0]?.company_id ?? null
+
+    let written = 0
+    for (const f of manifest.files) {
+      const path = `skills/${manifest.name}/${f.path}`
+      await client.query(
+        `INSERT INTO agent_workspace (agent_id, path, body, company_id, updated_at)
+         VALUES ($1, $2, $3, $4, NOW())
+         ON CONFLICT (agent_id, path) DO UPDATE SET body = EXCLUDED.body, company_id = EXCLUDED.company_id, updated_at = NOW()`,
+        [agentId, path, f.body, tenant],
+      )
+      written++
+    }
+    await client.query('COMMIT')
+    return { name: manifest.name, files: written }
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {})
+    throw err
+  } finally {
+    client.release()
   }
-  return { name: manifest.name, files: written }
 }
 
 /** Load only `name` + `description` for each installed skill — the


### PR DESCRIPTION
This PR addresses two reliability and integrity gaps in agent skills management (`server/src/agents/skills.ts`):

## What changed

1. **CRLF Frontmatter Parsing (`parseSkillMd`)**:
   - `content.startsWith('---\\n')` previously failed on Windows or CRLF-formatted `SKILL.md` files (returning `frontmatter: null`), which caused `loadSkillsIndex` to discard valid installed skills as malformed.
   - Normalizes `\\r\\n` newlines prior to delimiter extraction so YAML frontmatter parses identically across platforms and line endings.

2. **Skill Manifest & Frontmatter Integrity Verification (`installSkillFromManifest`)**:
   - Validates that the root `SKILL.md` contains valid YAML frontmatter and that its `name` matches the manifest's declared `name` before touching storage.
   - Rejects duplicate relative file paths within the same manifest.
   - Prevents unsafe path variants including relative prefixes (`./`), empty segments (`//`, `/./`), or trailing slashes (`/`).

3. **Atomic Installation Transaction**:
   - Wraps the pre-existence check and all file writes in an atomic Postgres transaction (`BEGIN` / `COMMIT` / `ROLLBACK`). If any file write fails, all previously inserted files for that skill are rolled back cleanly, avoiding half-installed or orphaned workspace files.

4. **Unit Tests**:
   - Added unit test cases to `server/src/__tests__/agents-skills-install-ssrf.test.ts` covering CRLF frontmatter parsing, mismatched names, missing `SKILL.md`, duplicate paths, and path hygiene.

## Verification
- `npx biome lint .`: 0 errors, 0 warnings
- `npm run typecheck` & `npm run server:typecheck`: PASS
- `guard:big-brain`, `guard:llm-tracked`, `guard:engine-registry`: ALL GREEN
- Full unit test suite (`npm test`): 952 tests executed, 948 passed, 0 failed, 4 skipped