### PR TITLE
fix(byoa): refresh engine versions on demand

### DIFF
--- a/server/src/__tests__/agents-computer-engine-detect.test.ts
+++ b/server/src/__tests__/agents-computer-engine-detect.test.ts
@@ -116,14 +116,24 @@ test('setComputerDefaultEngine reorders engines and only moves inheriting agents
   }
 })
 
-test('heartbeatComputer is quiet when the computer is already online', async () => {
+test('heartbeatComputer returns a pending engine detection request', async () => {
   installPoolMock(({ sql }) => {
     if (/AND status = 'online'/.test(sql)) {
-      return { rows: [{}], rowCount: 1 }
+      return { rows: [{ detect_requested_at: '2026-08-31T00:00:00.000Z' }], rowCount: 1 }
     }
     return { rows: [] }
   })
-  await registry.heartbeatComputer('comp-1', '0.5.0', true)
+  assert.equal(await registry.heartbeatComputer('comp-1', '0.5.0', true), true)
+})
+
+test('heartbeatComputer stays quiet without an engine detection request', async () => {
+  installPoolMock(({ sql }) => {
+    if (/AND status = 'online'/.test(sql)) {
+      return { rows: [{ detect_requested_at: null }], rowCount: 1 }
+    }
+    return { rows: [] }
+  })
+  assert.equal(await registry.heartbeatComputer('comp-1', '0.5.0', true), false)
 })
 
 test('assignAgentToComputer pins when an engine is named and inherits when it is not', async () => {

--- a/server/src/__tests__/agents-computer-engine-inventory.test.ts
+++ b/server/src/__tests__/agents-computer-engine-inventory.test.ts
@@ -7,6 +7,7 @@ import assert from 'node:assert/strict'
 import {
   replaceEngineInventory,
   resolveAvailableEngine,
+  shouldReportEngineSnapshot,
   type EngineInventory,
 } from '../agents/computer/daemon.js'
 
@@ -31,4 +32,11 @@ test('an unchanged scan does not replace the shared inventory', () => {
 
   assert.equal(replaceEngineInventory(inventory, current), false)
   assert.equal(inventory.current, before)
+})
+
+test('a requested refresh reports an unchanged engine snapshot', () => {
+  const snapshot = JSON.stringify([{ id: 'codex', version: '1.2.3' }])
+
+  assert.equal(shouldReportEngineSnapshot(snapshot, snapshot), false)
+  assert.equal(shouldReportEngineSnapshot(snapshot, snapshot, true), true)
 })

--- a/server/src/agents/computer/daemon.ts
+++ b/server/src/agents/computer/daemon.ts
@@ -773,6 +773,12 @@ export function replaceEngineInventory(inventory: EngineInventory, next: readonl
   return changed
 }
 
+/** A user-requested refresh must report even an unchanged snapshot so the
+ * server can clear the pending request and the UI can observe completion. */
+export function shouldReportEngineSnapshot(fingerprint: string, previous: string, force = false): boolean {
+  return force || fingerprint !== previous
+}
+
 // ─── config ─────────────────────────────────────────────────────────────
 
 async function loadConfig(): Promise<DaemonConfig | null> {
@@ -3068,7 +3074,7 @@ async function doRun(serverOverride?: string): Promise<void> {
   // on every heartbeat so installing another supported CLI takes effect without
   // re-pairing — the daemon is already online and can see PATH itself, so there
   // is no reason to make the user mint a new pairing token for it.
-  const rescanEngines = async (): Promise<void> => {
+  const scanEnginesOnce = async (forceReport: boolean): Promise<void> => {
     try {
       const detected = await detectEnginesWithStatus()
       if (!detected.reliable) return  // broken `which` / `where` — keep the last good list
@@ -3095,7 +3101,7 @@ async function doRun(serverOverride?: string): Promise<void> {
       // engine in place leaves the engine *list* identical, and that is exactly
       // when the card's version line goes stale.
       const fingerprint = JSON.stringify(snapshot)
-      if (fingerprint !== lastEngineSnapshot) {
+      if (shouldReportEngineSnapshot(fingerprint, lastEngineSnapshot, forceReport)) {
         lastEngineSnapshot = fingerprint
         await api(cfg.serverUrl, '/api/computers/me/engines', {
           method: 'POST',
@@ -3111,9 +3117,32 @@ async function doRun(serverOverride?: string): Promise<void> {
     } catch { /* transient — the next tick retries */ }
   }
 
+  // Timer/startup/requested scans can land together. Share an in-flight scan;
+  // if a forced request arrives during it, run once more so its acknowledgement
+  // cannot be swallowed by the older scan finishing afterward.
+  let rescanInFlight: Promise<void> | null = null
+  let forcedRescanPending = false
+  const rescanEngines = (forceReport = false): Promise<void> => {
+    forcedRescanPending ||= forceReport
+    if (rescanInFlight) return rescanInFlight
+    const running = (async () => {
+      let first = true
+      while (first || forcedRescanPending) {
+        first = false
+        const force = forcedRescanPending
+        forcedRescanPending = false
+        await scanEnginesOnce(force)
+      }
+    })().finally(() => {
+      if (rescanInFlight === running) rescanInFlight = null
+    })
+    rescanInFlight = running
+    return running
+  }
+
   const heartbeat = async (): Promise<void> => {
     try {
-      await fetch(`${cfg.serverUrl}/api/computers/heartbeat`, {
+      const response = await fetch(`${cfg.serverUrl}/api/computers/heartbeat`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${cfg.deviceToken}` },
         // A heartbeat that never answers must not outlive its own interval, or
@@ -3124,6 +3153,9 @@ async function doRun(serverOverride?: string): Promise<void> {
         // update instructions for this machine.
         body: JSON.stringify({ version: CURRENT_VERSION, supervised: SUPERVISED, engines: engineInventory.current }),
       })
+      if (!response.ok) return
+      const heartbeatResult = await response.json().catch(() => null) as { detectRequested?: boolean } | null
+      if (heartbeatResult?.detectRequested) void rescanEngines(true)
     } catch { /* transient — next tick retries */ }
   }
 

--- a/server/src/agents/computer/registry.ts
+++ b/server/src/agents/computer/registry.ts
@@ -413,26 +413,28 @@ export async function heartbeatComputer(
   version?: string,
   supervised?: boolean,
   detectedEngines?: string[],
-): Promise<void> {
+): Promise<boolean> {
   const v = typeof version === 'string' && version ? version.slice(0, 32) : null
   const sup = typeof supervised === 'boolean' ? supervised : null
   // Liveness is the primary heartbeat contract. Refreshing the optional PATH
   // inventory must not run first: one transient read failure used to reject the
   // whole request, so a healthy daemon could be swept offline even though its
   // heartbeat reached the server.
-  const bumped = await pool.query(
+  const bumped = await pool.query<{ detect_requested_at: string | null }>(
     `UPDATE computers SET last_seen_at = NOW(), daemon_version = COALESCE($2, daemon_version),
             daemon_supervised = COALESCE($3, daemon_supervised)
-      WHERE id = $1 AND revoked_at IS NULL AND status = 'online' RETURNING 1`,
+      WHERE id = $1 AND revoked_at IS NULL AND status = 'online' RETURNING detect_requested_at`,
     [computerId, v, sup],
   )
+  let detectRequested = Boolean(bumped.rows[0]?.detect_requested_at)
   if (!bumped.rowCount) {
-    const { rows } = await pool.query<{ company_id: string }>(
+    const { rows } = await pool.query<{ company_id: string; detect_requested_at: string | null }>(
       `UPDATE computers SET status = 'online', last_seen_at = NOW(), daemon_version = COALESCE($2, daemon_version),
               daemon_supervised = COALESCE($3, daemon_supervised)
-        WHERE id = $1 AND revoked_at IS NULL RETURNING company_id`,
+        WHERE id = $1 AND revoked_at IS NULL RETURNING company_id, detect_requested_at`,
       [computerId, v, sup],
     )
+    detectRequested = Boolean(rows[0]?.detect_requested_at)
     if (rows[0]) await broadcastComputerStatus(computerId, rows[0].company_id, 'online')
   }
 
@@ -460,6 +462,7 @@ export async function heartbeatComputer(
       console.warn('[computers] heartbeat engine refresh failed:', err instanceof Error ? err.message : err)
     }
   }
+  return detectRequested
 }
 
 /** Mark paired computers offline once their heartbeat goes stale, and

--- a/server/src/api/router.ts
+++ b/server/src/api/router.ts
@@ -1280,8 +1280,8 @@ api.post('/computers/heartbeat', safe(async (req, res) => {
   const engines = Array.isArray(req.body?.engines)
     ? (req.body.engines as unknown[]).filter((e): e is string => typeof e === 'string')
     : undefined
-  await heartbeatComputer(computerId, version, supervised, engines)
-  res.json({ ok: true })
+  const detectRequested = await heartbeatComputer(computerId, version, supervised, engines)
+  res.json({ ok: true, detectRequested })
 }))
 
 // Mint a per-agent runtime JWT for the calling computer (daemon refresh loop).

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -939,6 +939,10 @@ export const api = {
   repairComputer: (id: string) =>
     http<{ code: string; expiresInSeconds: number | null }>(
       `/computers/${encodeURIComponent(id)}/repair`, { method: 'POST', body: '{}' }),
+  /** Ask a paired computer to re-probe its local engine inventory + versions. */
+  requestComputerEngineDetect: (id: string) =>
+    http<{ ok: boolean }>(
+      `/computers/${encodeURIComponent(id)}/detect`, { method: 'POST', body: '{}' }),
   /** Move an agent to a computer, choosing its engine (Cumora Cloud = managed). */
   assignAgentComputer: (agentId: string, computerId: string, engine?: EngineId, inherit?: boolean) =>
     http<{ ok: boolean; kind: ComputerKind; engine: EngineId; inherit?: boolean }>(

--- a/src/desktop/MeView.tsx
+++ b/src/desktop/MeView.tsx
@@ -920,7 +920,20 @@ function ComputersTab() {
     setErr(null)
     setBusyId(id)
     try {
-      await useComputers.getState().refresh()
+      const before = useComputers.getState().byId[id]?.enginesDetectedAt ?? null
+      await api.requestComputerEngineDetect(id)
+
+      // A paired daemon receives the request on its next heartbeat and then
+      // reports a fresh snapshot. Keep the button busy until that report lands,
+      // instead of presenting a cached GET as a completed engine refresh.
+      const deadline = Date.now() + 50_000
+      while (Date.now() < deadline) {
+        await new Promise((resolve) => window.setTimeout(resolve, 750))
+        await useComputers.getState().refresh()
+        const after = useComputers.getState().byId[id]?.enginesDetectedAt ?? null
+        if (after && after !== before) return
+      }
+      throw new Error(t('me.agentsRefreshTimedOut'))
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e))
     } finally {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1290,6 +1290,7 @@ export const en = {
   'me.agentsCliDetectedOther': '{n} engines detected',
   'me.agentsRefresh': 'Refresh',
   'me.agentsRefreshing': 'Refreshing…',
+  'me.agentsRefreshTimedOut': 'Engine refresh timed out. Make sure the computer daemon is online and try again.',
   'me.agentsIsDefault': 'Default',
   'me.agentsOffline': 'This computer is offline. The list is still the last pairing report.',
   'me.agentsNoEngines': 'The daemon reported no engines at pairing. Re-run the pairing command on that computer to scan PATH again.',

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -1292,6 +1292,7 @@ export const zhCN: Partial<Record<keyof typeof en, string>> = {
   'me.agentsCliDetectedOther': '{n} 个引擎已被检测',
   'me.agentsRefresh': '刷新',
   'me.agentsRefreshing': '刷新中…',
+  'me.agentsRefreshTimedOut': '引擎刷新超时，请确认该计算机的守护进程在线后重试。',
   'me.agentsIsDefault': '默认',
   'me.agentsOffline': '这台计算机离线。列表仍是上次配对时的检测结果。',
   'me.agentsNoEngines': '配对时 daemon 没有报任何引擎。要重新扫 PATH，请在那台机器上再跑一次配对命令。',


### PR DESCRIPTION
## Summary

- Wire the Computers “Refresh” action to the existing engine detection endpoint instead of only reloading the cached server snapshot.
- Return pending detection requests through daemon heartbeats and trigger a forced engine/version rescan.
- Coalesce overlapping scans while ensuring requested refreshes always report completion.
- Keep the UI loading until `engines_detected_at` changes, with localized timeout feedback.
- Add regression coverage for heartbeat detection requests and forced unchanged-snapshot reports.

## Root cause

The refresh button only fetched the existing computer record. Although the backend stored `detect_requested_at`, the daemon never consumed it, so locally upgraded CLI versions remained stale until the periodic scan or daemon restart.

## Testing

- `npm run typecheck`
- `npm run server:typecheck`
- Relevant engine detection suites: 33 passed
- Biome lint on changed files
- `npm run build`