### PR TITLE
feat(byoa): tell the operator why an installed engine is not being used

### DIFF
--- a/server/src/__integration__/blocked-engine-reason.test.ts
+++ b/server/src/__integration__/blocked-engine-reason.test.ts
@@ -33,17 +33,18 @@ interface StoredEngines {
   detected: Array<{ id: string; blockedReason?: string | null; path?: string | null }>
 }
 
-async function seedCompany(): Promise<string> {
+async function seedCompany(): Promise<{ companyId: string; ownerUserId: string }> {
   const companyId = `co-${randomUUID().slice(0, 8)}`
+  const ownerUserId = `u-${companyId}`
   await pool.query(
     `INSERT INTO users (id, email, display_name) VALUES ($1, $2, 'Owner') ON CONFLICT (id) DO NOTHING`,
-    [`u-${companyId}`, `${companyId}@example.com`],
+    [ownerUserId, `${companyId}@example.com`],
   )
   await pool.query(
     `INSERT INTO companies (id, name, slug, owner_user_id) VALUES ($1, $1, $1, $2)`,
-    [companyId, `u-${companyId}`],
+    [companyId, ownerUserId],
   )
-  return companyId
+  return { companyId, ownerUserId }
 }
 
 async function storedEngines(computerId: string): Promise<StoredEngines> {
@@ -62,8 +63,8 @@ const SNAPSHOT = [
 ]
 
 test('[integration] pairing stores the refusal reason without making it runnable', async () => {
-  const companyId = await seedCompany()
-  const { code } = await issuePairingCode({ companyId })
+  const { companyId, ownerUserId } = await seedCompany()
+  const { code } = await issuePairingCode({ companyId, ownerUserId })
 
   const paired = await pairComputer({
     code, hostName: 'Dev Mac', engines: ['codex'], detected: SNAPSHOT, blocked: ['claude'],
@@ -87,14 +88,14 @@ test('[integration] reconnecting the same computer keeps the reason', async () =
   // A reconnect takes the other branch inside pairComputer, with its own
   // sanitize call. Wiring one branch and not the other would make the reason
   // appear at pairing and then vanish the next time the daemon restarted.
-  const companyId = await seedCompany()
+  const { companyId, ownerUserId } = await seedCompany()
   const first = await pairComputer({
-    code: (await issuePairingCode({ companyId })).code,
+    code: (await issuePairingCode({ companyId, ownerUserId })).code,
     hostName: 'Dev Mac', engines: ['codex'], detected: SNAPSHOT, blocked: ['claude'],
   })
   assert.ok(first)
 
-  const { code } = await issueRepairCodeFor(first.computerId, companyId)
+  const { code } = await issueRepairCodeFor(first.computerId, companyId, ownerUserId)
   const again = await pairComputer({
     code, hostName: 'Dev Mac', engines: ['codex'], detected: SNAPSHOT, blocked: ['claude'],
   })
@@ -107,9 +108,9 @@ test('[integration] reconnecting the same computer keeps the reason', async () =
 })
 
 test('[integration] the rescan report keeps the same separation', async () => {
-  const companyId = await seedCompany()
+  const { companyId, ownerUserId } = await seedCompany()
   const paired = await pairComputer({
-    code: (await issuePairingCode({ companyId })).code,
+    code: (await issuePairingCode({ companyId, ownerUserId })).code,
     hostName: 'Dev Mac', engines: ['codex', 'claude'], detected: SNAPSHOT,
   })
   assert.ok(paired)
@@ -128,9 +129,9 @@ test('[integration] the rescan report keeps the same separation', async () => {
 test('[integration] fixing the cause clears the reason on the next report', async () => {
   // The reason is state, not a one-way flag: upgrading the CLI has to make the
   // card go quiet again without any other change.
-  const companyId = await seedCompany()
+  const { companyId, ownerUserId } = await seedCompany()
   const paired = await pairComputer({
-    code: (await issuePairingCode({ companyId })).code,
+    code: (await issuePairingCode({ companyId, ownerUserId })).code,
     hostName: 'Dev Mac', engines: ['codex'], detected: SNAPSHOT, blocked: ['claude'],
   })
   assert.ok(paired)
@@ -155,9 +156,9 @@ test('[integration] a daemon claiming a blocked engine is runnable does not get 
   // Belt and braces on the invariant, from the direction a buggy or hostile
   // daemon would come at it: sending the same id in both lists must not put a
   // refused engine into the list that picks an adapter.
-  const companyId = await seedCompany()
+  const { companyId, ownerUserId } = await seedCompany()
   const paired = await pairComputer({
-    code: (await issuePairingCode({ companyId })).code,
+    code: (await issuePairingCode({ companyId, ownerUserId })).code,
     hostName: 'Dev Mac', engines: ['codex'], detected: SNAPSHOT, blocked: ['claude'],
   })
   assert.ok(paired)
@@ -173,9 +174,11 @@ test('[integration] a daemon claiming a blocked engine is runnable does not get 
 })
 
 /** Mint a reconnect code for an existing computer row. */
-async function issueRepairCodeFor(computerId: string, companyId: string): Promise<{ code: string }> {
+async function issueRepairCodeFor(
+  computerId: string, companyId: string, ownerUserId: string,
+): Promise<{ code: string }> {
   const { issueRepairCode } = await import('../agents/computer/registry.js')
-  const out = await issueRepairCode({ computerId, companyId })
+  const out = await issueRepairCode({ computerId, companyId, ownerUserId })
   assert.ok(out, 'could not mint a repair code')
   return out
 }

--- a/server/src/__integration__/blocked-engine-reason.test.ts
+++ b/server/src/__integration__/blocked-engine-reason.test.ts
@@ -1,0 +1,181 @@
+/**
+ * The refusal reason survives every path that stores an engine snapshot.
+ *
+ * Three of them do: pairing a fresh computer, reconnecting an existing one, and
+ * the periodic PATH rescan. Each sanitizes its own snapshot, so wiring one and
+ * not the others is a silent hole — and the first cut of this feature had
+ * exactly that hole, covering only the rescan. A card that stays blank for
+ * minutes after pairing is blank during the one window in which someone is
+ * actually asking why their engine is missing.
+ *
+ * These run against a real Postgres because the property is about the stored
+ * row: `available_engines` picks an agent's adapter, `detected_engines` is
+ * display. A blocked engine belongs in the second and must never appear in the
+ * first, or the daemon would run precisely what the sandbox gate refused.
+ *
+ * Run: node --import tsx --test --test-concurrency=1 server/src/__integration__/blocked-engine-reason.test.ts
+ */
+import { after, before, beforeEach, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { randomUUID } from 'node:crypto'
+import { pool } from '../db/pool.js'
+import { issuePairingCode, pairComputer, reportDetectedEngines } from '../agents/computer/registry.js'
+import { ensureSchemaOnce, resetAllTables, teardownAll } from './_helpers.js'
+
+before(async () => { await ensureSchemaOnce() })
+beforeEach(async () => { await resetAllTables() })
+after(async () => { await teardownAll() })
+
+const OLD_CLAUDE = 'version 2.0.9 is older than the secure minimum 2.1.248'
+
+interface StoredEngines {
+  available: string[]
+  detected: Array<{ id: string; blockedReason?: string | null; path?: string | null }>
+}
+
+async function seedCompany(): Promise<string> {
+  const companyId = `co-${randomUUID().slice(0, 8)}`
+  await pool.query(
+    `INSERT INTO users (id, email, display_name) VALUES ($1, $2, 'Owner') ON CONFLICT (id) DO NOTHING`,
+    [`u-${companyId}`, `${companyId}@example.com`],
+  )
+  await pool.query(
+    `INSERT INTO companies (id, name, slug, owner_user_id) VALUES ($1, $1, $1, $2)`,
+    [companyId, `u-${companyId}`],
+  )
+  return companyId
+}
+
+async function storedEngines(computerId: string): Promise<StoredEngines> {
+  const { rows } = await pool.query<StoredEngines>(
+    `SELECT available_engines AS available, detected_engines AS detected
+       FROM computers WHERE id = $1`,
+    [computerId],
+  )
+  return rows[0]
+}
+
+/** What a daemon on a machine with a too-old Claude and a good Codex sends. */
+const SNAPSHOT = [
+  { id: 'codex', bin: 'codex', path: '/usr/local/bin/codex', version: '0.140.0' },
+  { id: 'claude', bin: 'claude', path: '/usr/local/bin/claude', version: '2.0.9', blockedReason: OLD_CLAUDE },
+]
+
+test('[integration] pairing stores the refusal reason without making it runnable', async () => {
+  const companyId = await seedCompany()
+  const { code } = await issuePairingCode({ companyId })
+
+  const paired = await pairComputer({
+    code, hostName: 'Dev Mac', engines: ['codex'], detected: SNAPSHOT, blocked: ['claude'],
+  })
+  assert.ok(paired, 'pairing failed')
+
+  const stored = await storedEngines(paired.computerId)
+  // The whole point of the separation: an agent assigned to this computer
+  // resolves its adapter from available_engines, so claude must not be there.
+  assert.deepEqual(stored.available, ['codex'])
+  const claude = stored.detected.find((e) => e.id === 'claude')
+  assert.ok(claude, 'the refused engine should still be listed for display')
+  assert.equal(claude.blockedReason, OLD_CLAUDE)
+  // The path matters too — "installed, and here is where" is half of what makes
+  // the reason actionable.
+  assert.equal(claude.path, '/usr/local/bin/claude')
+  assert.equal(stored.detected.find((e) => e.id === 'codex')?.blockedReason, null)
+})
+
+test('[integration] reconnecting the same computer keeps the reason', async () => {
+  // A reconnect takes the other branch inside pairComputer, with its own
+  // sanitize call. Wiring one branch and not the other would make the reason
+  // appear at pairing and then vanish the next time the daemon restarted.
+  const companyId = await seedCompany()
+  const first = await pairComputer({
+    code: (await issuePairingCode({ companyId })).code,
+    hostName: 'Dev Mac', engines: ['codex'], detected: SNAPSHOT, blocked: ['claude'],
+  })
+  assert.ok(first)
+
+  const { code } = await issueRepairCodeFor(first.computerId, companyId)
+  const again = await pairComputer({
+    code, hostName: 'Dev Mac', engines: ['codex'], detected: SNAPSHOT, blocked: ['claude'],
+  })
+  assert.ok(again)
+  assert.equal(again.computerId, first.computerId, 'reconnect should reuse the row')
+
+  const stored = await storedEngines(first.computerId)
+  assert.deepEqual(stored.available, ['codex'])
+  assert.equal(stored.detected.find((e) => e.id === 'claude')?.blockedReason, OLD_CLAUDE)
+})
+
+test('[integration] the rescan report keeps the same separation', async () => {
+  const companyId = await seedCompany()
+  const paired = await pairComputer({
+    code: (await issuePairingCode({ companyId })).code,
+    hostName: 'Dev Mac', engines: ['codex', 'claude'], detected: SNAPSHOT,
+  })
+  assert.ok(paired)
+  // Claude was runnable at pairing and is refused now — an in-place CLI
+  // downgrade, or a newly enforced minimum. It has to leave available_engines
+  // and arrive in the display list with its reason.
+  await reportDetectedEngines({
+    computerId: paired.computerId, engines: ['codex'], blocked: ['claude'], detected: SNAPSHOT,
+  })
+
+  const stored = await storedEngines(paired.computerId)
+  assert.deepEqual(stored.available, ['codex'])
+  assert.equal(stored.detected.find((e) => e.id === 'claude')?.blockedReason, OLD_CLAUDE)
+})
+
+test('[integration] fixing the cause clears the reason on the next report', async () => {
+  // The reason is state, not a one-way flag: upgrading the CLI has to make the
+  // card go quiet again without any other change.
+  const companyId = await seedCompany()
+  const paired = await pairComputer({
+    code: (await issuePairingCode({ companyId })).code,
+    hostName: 'Dev Mac', engines: ['codex'], detected: SNAPSHOT, blocked: ['claude'],
+  })
+  assert.ok(paired)
+  assert.equal((await storedEngines(paired.computerId)).detected.find((e) => e.id === 'claude')?.blockedReason, OLD_CLAUDE)
+
+  await reportDetectedEngines({
+    computerId: paired.computerId,
+    engines: ['codex', 'claude'],
+    blocked: [],
+    detected: [
+      { id: 'codex', bin: 'codex', path: '/usr/local/bin/codex', version: '0.140.0' },
+      { id: 'claude', bin: 'claude', path: '/usr/local/bin/claude', version: '2.1.250' },
+    ],
+  })
+
+  const stored = await storedEngines(paired.computerId)
+  assert.ok(stored.available.includes('claude'), 'the upgraded engine should be runnable again')
+  assert.equal(stored.detected.find((e) => e.id === 'claude')?.blockedReason, null)
+})
+
+test('[integration] a daemon claiming a blocked engine is runnable does not get it both ways', async () => {
+  // Belt and braces on the invariant, from the direction a buggy or hostile
+  // daemon would come at it: sending the same id in both lists must not put a
+  // refused engine into the list that picks an adapter.
+  const companyId = await seedCompany()
+  const paired = await pairComputer({
+    code: (await issuePairingCode({ companyId })).code,
+    hostName: 'Dev Mac', engines: ['codex'], detected: SNAPSHOT, blocked: ['claude'],
+  })
+  assert.ok(paired)
+  await reportDetectedEngines({
+    computerId: paired.computerId, engines: ['codex'], blocked: ['codex', 'claude'], detected: SNAPSHOT,
+  })
+
+  const stored = await storedEngines(paired.computerId)
+  assert.deepEqual(stored.available, ['codex'], 'codex is runnable and must stay so')
+  // Claimed as both: runnable wins, and it appears once rather than twice.
+  assert.equal(stored.detected.filter((e) => e.id === 'codex').length, 1)
+  assert.equal(stored.detected.find((e) => e.id === 'codex')?.blockedReason, null)
+})
+
+/** Mint a reconnect code for an existing computer row. */
+async function issueRepairCodeFor(computerId: string, companyId: string): Promise<{ code: string }> {
+  const { issueRepairCode } = await import('../agents/computer/registry.js')
+  const out = await issueRepairCode({ computerId, companyId })
+  assert.ok(out, 'could not mint a repair code')
+  return out
+}

--- a/server/src/__tests__/agents-computer-blocked-engines.test.ts
+++ b/server/src/__tests__/agents-computer-blocked-engines.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Surfacing the reason an installed engine is refused.
+ *
+ * `evaluateRunnableEngines()` already computes why it declined an engine — an
+ * old CLI, a missing sandbox dependency — but that reason only ever reached the
+ * daemon's own stdout. Whoever reads the Computers card is usually not sitting
+ * at that machine, which is the same argument the version fields are carried
+ * for, so the engine simply went absent with no explanation anywhere visible.
+ *
+ * The safety property these pin is the separation: a blocked engine is a
+ * DISPLAY row and must never reach `available_engines`, because that list is
+ * what picks an agent's adapter. Letting one through would run exactly what the
+ * sandbox gate refused.
+ *
+ * Run: node --import tsx --test server/src/__tests__/agents-computer-blocked-engines.test.ts
+ */
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+process.env.CUMORA_RUNTIME_CLIENT = 'http'
+process.env.OPENAI_API_KEY ??= 'test-key'
+
+const { sanitizeDetectedEngines } = await import('../agents/computer/registry.js')
+
+const OLD_CLAUDE = 'version 2.0.9 is older than the secure minimum 2.1.248'
+
+test('a blocked engine becomes a display row carrying its reason', () => {
+  const out = sanitizeDetectedEngines(
+    [
+      { id: 'codex', bin: 'codex', path: '/usr/local/bin/codex' },
+      { id: 'claude', bin: 'claude', path: '/usr/local/bin/claude', blockedReason: OLD_CLAUDE },
+    ],
+    ['codex'],
+    ['claude'],
+  )
+  assert.deepEqual(out.map((e) => e.id), ['codex', 'claude'])
+  assert.equal(out.find((e) => e.id === 'codex')?.blockedReason, null)
+  assert.equal(out.find((e) => e.id === 'claude')?.blockedReason, OLD_CLAUDE)
+  // The path still shows: "installed here, and here is where" is half the
+  // point of telling the operator it was refused.
+  assert.equal(out.find((e) => e.id === 'claude')?.path, '/usr/local/bin/claude')
+})
+
+test('a reason on a RUNNABLE engine is discarded', () => {
+  // Otherwise a daemon could mark a perfectly good engine broken in the UI.
+  // Only the ids the caller passed as blocked may carry a reason.
+  const out = sanitizeDetectedEngines(
+    [{ id: 'codex', bin: 'codex', path: '/bin/codex', blockedReason: 'not actually blocked' }],
+    ['codex'],
+    [],
+  )
+  assert.equal(out[0].blockedReason, null)
+})
+
+test('an id claimed as both runnable and blocked stays runnable', () => {
+  // Runnable wins, and it appears exactly once — a duplicate row would render
+  // the same engine twice, once contradicting the other.
+  const out = sanitizeDetectedEngines(
+    [{ id: 'claude', bin: 'claude', path: '/bin/claude', blockedReason: OLD_CLAUDE }],
+    ['claude'],
+    ['claude'],
+  )
+  assert.equal(out.length, 1)
+  assert.equal(out[0].id, 'claude')
+  assert.equal(out[0].blockedReason, null)
+})
+
+test('blocked ids do not disturb the runnable order', () => {
+  // available_engines[0] is the computer's DEFAULT engine. Blocked rows are
+  // appended, never interleaved, so adding this display data cannot silently
+  // repoint which adapter an agent gets.
+  const out = sanitizeDetectedEngines(
+    [
+      { id: 'codex', bin: 'codex', path: '/bin/codex' },
+      { id: 'gemini', bin: 'gemini', path: '/bin/gemini' },
+      { id: 'claude', bin: 'claude', path: '/bin/claude', blockedReason: OLD_CLAUDE },
+    ],
+    ['codex', 'gemini'],
+    ['claude'],
+  )
+  assert.deepEqual(out.map((e) => e.id), ['codex', 'gemini', 'claude'])
+})
+
+test('an unknown blocked id is dropped like any other', () => {
+  // The pairable allowlist governs both lists; a newer daemon naming an engine
+  // this server has no adapter for must not create a phantom row.
+  const out = sanitizeDetectedEngines(
+    [{ id: 'hermes', bin: 'hermes', path: '/bin/hermes', blockedReason: 'nope' }],
+    ['codex'],
+    ['hermes'],
+  )
+  assert.deepEqual(out.map((e) => e.id), ['codex'])
+})
+
+test('a hostile reason is trimmed and length-capped like every other display string', () => {
+  const out = sanitizeDetectedEngines(
+    [{ id: 'claude', bin: 'claude', path: '/bin/claude', blockedReason: `  ${'x'.repeat(500)}  ` }],
+    [],
+    ['claude'],
+  )
+  const reason = out[0].blockedReason ?? ''
+  assert.ok(reason.length <= 200, `reason was ${reason.length} chars`)
+  assert.ok(!reason.startsWith(' ') && !reason.endsWith(' '))
+})
+
+test('a non-string reason is dropped rather than rendered', () => {
+  const out = sanitizeDetectedEngines(
+    [{ id: 'claude', bin: 'claude', path: '/bin/claude', blockedReason: { evil: true } }],
+    [],
+    ['claude'],
+  )
+  assert.equal(out[0].blockedReason, null)
+})
+
+test('omitting the blocked list keeps the previous behaviour exactly', () => {
+  // Every existing caller passes two arguments; the third must be optional and
+  // change nothing when absent.
+  const out = sanitizeDetectedEngines(
+    [{ id: 'codex', bin: 'codex', path: '/bin/codex' }],
+    ['codex'],
+  )
+  assert.deepEqual(out.map((e) => e.id), ['codex'])
+  assert.equal(out[0].blockedReason, null)
+})
+
+test('a blocked engine the daemon reported nothing about still gets a row', () => {
+  // The reason is the point of the row, but even without one the operator
+  // should see that the engine is installed and unused rather than missing.
+  const out = sanitizeDetectedEngines(null, ['codex'], ['claude'])
+  assert.deepEqual(out.map((e) => e.id), ['codex', 'claude'])
+})

--- a/server/src/__tests__/agents-computer-blocked-engines.test.ts
+++ b/server/src/__tests__/agents-computer-blocked-engines.test.ts
@@ -130,3 +130,36 @@ test('a blocked engine the daemon reported nothing about still gets a row', () =
   const out = sanitizeDetectedEngines(null, ['codex'], ['claude'])
   assert.deepEqual(out.map((e) => e.id), ['codex', 'claude'])
 })
+
+// --- every path that stores a snapshot, not just the rescan ---
+
+test('the reason travels on the pairing snapshot, not only the rescan', () => {
+  // The first version of this feature wired only the periodic PATH rescan, so a
+  // freshly paired computer showed nothing for minutes — exactly the window in
+  // which someone asks why their Claude Code is missing. pairComputer() and the
+  // reconnect branch sanitize their own snapshots, so they need the same list.
+  const out = sanitizeDetectedEngines(
+    [
+      { id: 'codex', bin: 'codex', path: '/bin/codex' },
+      { id: 'claude', bin: 'claude', path: '/bin/claude', blockedReason: OLD_CLAUDE },
+    ],
+    ['codex'],
+    ['claude'],
+  )
+  assert.equal(out.find((e) => e.id === 'claude')?.blockedReason, OLD_CLAUDE)
+})
+
+test('a blocked engine never reaches the runnable list it is derived from', () => {
+  // The invariant stated as the caller sees it: whatever this returns for
+  // display, `available_engines` is built from the runnable ids alone, so a
+  // blocked engine cannot become the adapter an agent runs on.
+  const runnable = ['codex']
+  const out = sanitizeDetectedEngines(
+    [{ id: 'claude', bin: 'claude', path: '/bin/claude', blockedReason: OLD_CLAUDE }],
+    runnable,
+    ['claude'],
+  )
+  assert.deepEqual(runnable, ['codex'], 'the runnable list must not be mutated')
+  assert.ok(out.some((e) => e.id === 'claude' && e.blockedReason))
+  assert.ok(!runnable.includes('claude'))
+})

--- a/server/src/__tests__/agents-computer-engine-detect.test.ts
+++ b/server/src/__tests__/agents-computer-engine-detect.test.ts
@@ -48,8 +48,10 @@ test('sanitizeDetectedEngines drops unknown ids and fills missing bins', () => {
     ['claude', 'codex', 'gemini', 'bogus'],
   )
   // Version fields come back on every row — null here, since a daemon this old
-  // reports paths only. See agents-computer-engine-version.test.ts.
-  const noVersion = { version: null, latest: null, outdated: false, updateCommand: null }
+  // reports paths only. See agents-computer-engine-version.test.ts. blockedReason
+  // is null for the same reason every key is present on every row: the app must
+  // never have to tell "field absent" from "nothing to report".
+  const noVersion = { version: null, latest: null, outdated: false, updateCommand: null, blockedReason: null }
   assert.deepEqual(out, [
     { id: 'claude', bin: 'claude', path: '/usr/bin/claude', ...noVersion },
     { id: 'codex', bin: 'codex', path: null, ...noVersion },

--- a/server/src/__tests__/agents-computer-engine-version.test.ts
+++ b/server/src/__tests__/agents-computer-engine-version.test.ts
@@ -118,6 +118,7 @@ test('sanitizeDetectedEngines carries version fields through', () => {
     id: 'codex', bin: 'codex', path: '/usr/local/bin/codex',
     version: '0.5.0', latest: '0.6.0', outdated: true,
     updateCommand: 'npm install -g @openai/codex@latest',
+    blockedReason: null,
   }])
 })
 

--- a/server/src/agents/computer/daemon.ts
+++ b/server/src/agents/computer/daemon.ts
@@ -3096,17 +3096,33 @@ async function doRun(serverOverride?: string): Promise<void> {
       // engine's version *as installed on this machine*: the app renders it
       // verbatim and never probes its own PATH, because whoever is looking at
       // the card is usually not sitting at the machine it describes.
-      const snapshot = await enrichDetectedEngines(await snapshotDetectedEngines(next))
+      // Blocked engines ride along as extra display rows carrying the reason
+      // they were refused. Until now that reason existed only as the
+      // console.warn above — on a machine the operator is usually not sitting
+      // at — so an engine could disappear from the card with no explanation
+      // anywhere they could see. They stay OUT of `next`: that list becomes
+      // available_engines and picks an agent's adapter.
+      const blockedIds = evaluated.blocked.map(({ id }) => id)
+      const blockedRows = (await snapshotDetectedEngines(blockedIds)).map((row) => ({
+        ...row,
+        blockedReason: evaluated.blocked.find(({ id }) => id === row.id)?.reason,
+      }))
+      const snapshot = [
+        ...await enrichDetectedEngines(await snapshotDetectedEngines(next)),
+        ...await enrichDetectedEngines(blockedRows),
+      ]
       // Report on version drift too, not just install/uninstall — upgrading an
       // engine in place leaves the engine *list* identical, and that is exactly
-      // when the card's version line goes stale.
+      // when the card's version line goes stale. The blocked reasons are part
+      // of the fingerprint: fixing the cause (upgrading the CLI, installing
+      // bwrap) has to clear the card, not wait for an unrelated change.
       const fingerprint = JSON.stringify(snapshot)
       if (shouldReportEngineSnapshot(fingerprint, lastEngineSnapshot, forceReport)) {
         lastEngineSnapshot = fingerprint
         await api(cfg.serverUrl, '/api/computers/me/engines', {
           method: 'POST',
           headers: { Authorization: `Bearer ${cfg.deviceToken}` },
-          body: JSON.stringify({ engines: next, detected: snapshot }),
+          body: JSON.stringify({ engines: next, detected: snapshot, blocked: blockedIds }),
         }).catch((err) => {
           console.warn('[computer] engine snapshot report failed', err instanceof Error ? err.message : err)
         })

--- a/server/src/agents/computer/daemon.ts
+++ b/server/src/agents/computer/daemon.ts
@@ -45,7 +45,7 @@ import {
 } from '../runtime/wake-options.js'
 import { SKYPE_EMOTICONS_GUIDE } from '../skype-emoticons.js'
 import { finalizeTriage, isRateLimited, parseTriage } from '../triage-core.js'
-import { allowUnsandboxedByoa, detectEnginesWithStatus, ENGINE_IDS, type EngineHopReport, type EngineId, type EngineRunResult, type EngineSession, type EngineUsage, enrichDetectedEngines, evaluateRunnableEngines, getAdapter, runEngineDoctor, snapshotDetectedEngines } from './engine.js'
+import { allowUnsandboxedByoa, detectEnginesWithStatus, ENGINE_IDS, type DetectedEngineSnapshot, type EngineHopReport, type EngineId, type EngineRunResult, type EngineSession, type EngineUsage, enrichDetectedEngines, evaluateRunnableEngines, getAdapter, runEngineDoctor, type RunnableEngineEvaluation, snapshotDetectedEngines } from './engine.js'
 
 export { conversationHeader }
 
@@ -736,7 +736,27 @@ function helpText(): string {
   ].join('\n')
 }
 
-async function requireLocalEngine(): Promise<EngineId[]> {
+/** Snapshot rows for refused engines, each carrying the reason it was refused.
+ *  Reported alongside the runnable ones so the card can explain an absence;
+ *  they never enter the `engines` list, which is what picks an adapter. */
+async function blockedSnapshotRows(
+  blocked: RunnableEngineEvaluation['blocked'],
+): Promise<DetectedEngineSnapshot[]> {
+  const rows = await snapshotDetectedEngines(blocked.map(({ id }) => id))
+  return rows.map((row) => ({
+    ...row,
+    blockedReason: blocked.find(({ id }) => id === row.id)?.reason,
+  }))
+}
+
+/** The engines this machine can run, plus the ones it cannot and why.
+ *
+ *  The refusals used to stop at the console.warn below. Pairing then reported
+ *  only the runnable list, so a fresh computer's card said nothing about the
+ *  engine that was skipped until the first PATH rescan minutes later — which is
+ *  precisely the window in which someone asks why their Claude Code is not
+ *  listed. */
+async function requireLocalEngine(): Promise<RunnableEngineEvaluation> {
   const detected = await detectEnginesWithStatus()
   if (!detected.reliable) {
     throw new Error('could not scan PATH (`which` / `where` failed). Fix that, then retry pairing.')
@@ -750,7 +770,7 @@ async function requireLocalEngine(): Promise<EngineId[]> {
   if (evaluated.blocked.length > 0) {
     console.warn(`[computer] secure engine(s) disabled: ${evaluated.blocked.map(({ id, reason }) => `${id} (${reason})`).join('; ')}`)
   }
-  return evaluated.runnable
+  return evaluated
 }
 
 /** Resolve the engine a daemon can actually run from its LIVE PATH inventory. */
@@ -1238,7 +1258,8 @@ async function detectHostName(): Promise<string> {
 }
 
 async function doPair(code: string, serverUrl: string, preferredEngine?: string): Promise<void> {
-  const detected = await requireLocalEngine()
+  const evaluated = await requireLocalEngine()
+  const detected = evaluated.runnable
   // The chosen engine becomes this computer's DEFAULT — it's sent first in the
   // engines list, which the server stores as available_engines[0] and uses as
   // the engine for the starter team and any agent assigned here without an
@@ -1253,12 +1274,16 @@ async function doPair(code: string, serverUrl: string, preferredEngine?: string)
     }
     engines = [preferredEngine as EngineId, ...detected.filter((e) => e !== preferredEngine)]
   }
-  const snapshot = await snapshotDetectedEngines(engines)
+  const blockedIds = evaluated.blocked.map(({ id }) => id)
+  const snapshot = [
+    ...await snapshotDetectedEngines(engines),
+    ...await blockedSnapshotRows(evaluated.blocked),
+  ]
   const paired = await api<{ computerId: string; deviceToken: string }>(
     serverUrl, '/api/computers/pair',
     { method: 'POST', body: JSON.stringify({
       code, hostName: await detectHostName(), engines, detected: snapshot,
-      version: CURRENT_VERSION, supervised: SUPERVISED,
+      blocked: blockedIds, version: CURRENT_VERSION, supervised: SUPERVISED,
     }) },
   )
   await saveConfig({ serverUrl, computerId: paired.computerId, deviceToken: paired.deviceToken })
@@ -2982,7 +3007,7 @@ async function doRun(serverOverride?: string): Promise<void> {
   if (serverOverride) cfg.serverUrl = serverOverride
   let initialEngines: EngineId[]
   try {
-    initialEngines = await requireLocalEngine()
+    initialEngines = (await requireLocalEngine()).runnable
   } catch (err) {
     console.error(`[computer] ${err instanceof Error ? err.message : String(err)}`)
     process.exitCode = 70
@@ -3103,14 +3128,12 @@ async function doRun(serverOverride?: string): Promise<void> {
       // anywhere they could see. They stay OUT of `next`: that list becomes
       // available_engines and picks an agent's adapter.
       const blockedIds = evaluated.blocked.map(({ id }) => id)
-      const blockedRows = (await snapshotDetectedEngines(blockedIds)).map((row) => ({
-        ...row,
-        blockedReason: evaluated.blocked.find(({ id }) => id === row.id)?.reason,
-      }))
-      const snapshot = [
-        ...await enrichDetectedEngines(await snapshotDetectedEngines(next)),
-        ...await enrichDetectedEngines(blockedRows),
-      ]
+      // One enrich over the whole list: it maps entry-by-entry, so splitting it
+      // bought nothing and only risked the two halves drifting apart.
+      const snapshot = await enrichDetectedEngines([
+        ...await snapshotDetectedEngines(next),
+        ...await blockedSnapshotRows(evaluated.blocked),
+      ])
       // Report on version drift too, not just install/uninstall — upgrading an
       // engine in place leaves the engine *list* identical, and that is exactly
       // when the card's version line goes stale. The blocked reasons are part

--- a/server/src/agents/computer/engine.ts
+++ b/server/src/agents/computer/engine.ts
@@ -4583,6 +4583,9 @@ export interface DetectedEngineSnapshot {
   latest?: string | null
   outdated?: boolean
   updateCommand?: string | null
+  /** Why this installed engine will NOT be driven — the reason
+   *  evaluateRunnableEngines() produced. Absent on runnable engines. */
+  blockedReason?: string
 }
 
 /** Snapshot the installed engines, optionally in a caller-supplied order

--- a/server/src/agents/computer/registry.ts
+++ b/server/src/agents/computer/registry.ts
@@ -116,6 +116,16 @@ export interface DetectedEngine {
   latest?: string | null
   outdated?: boolean
   updateCommand?: string | null
+  /** Why Cumora will not drive this engine even though it is installed here —
+   *  "version 2.0.9 is older than the secure minimum 2.1.248", "missing sandbox
+   *  dependency: bubblewrap (bwrap)". Absent when the engine is runnable.
+   *
+   *  This travels because the person reading the card is usually not sitting at
+   *  the machine it describes — the same reason the version fields do. The
+   *  daemon knew the reason all along and only wrote it to its own stdout, so
+   *  an engine could vanish from a computer with no explanation anywhere the
+   *  operator was looking. */
+  blockedReason?: string | null
 }
 
 /** Trim a daemon-reported display string, or drop it. Control characters are
@@ -145,12 +155,29 @@ function sanitizeVersionFields(rec: Record<string, unknown>): Partial<DetectedEn
 function unreportedEngine(id: string): DetectedEngine {
   return {
     id, bin: ENGINE_BINS[id] ?? id, path: null,
-    version: null, latest: null, outdated: false, updateCommand: null,
+    version: null, latest: null, outdated: false, updateCommand: null, blockedReason: null,
   }
 }
 
-export function sanitizeDetectedEngines(raw: unknown, engineIds: string[]): DetectedEngine[] {
-  const allowed = engineIds.filter((id) => PAIRABLE_ENGINES.has(id))
+/**
+ * Shape the daemon's PATH report for storage and display.
+ *
+ * `runnableIds` are the engines the daemon will actually wake; `blockedIds` are
+ * installed but refused, and appear ONLY here. That separation is the safety
+ * property of this function: `available_engines` is what picks an agent's
+ * adapter, so a blocked engine reaching it would run the very thing the
+ * sandbox gate declined. Blocked ids are therefore never returned to the
+ * caller as runnable and never influence `ordered` — they ride along as extra
+ * display rows carrying the reason they were refused.
+ */
+export function sanitizeDetectedEngines(
+  raw: unknown,
+  engineIds: string[],
+  blockedIds: string[] = [],
+): DetectedEngine[] {
+  const runnable = engineIds.filter((id) => PAIRABLE_ENGINES.has(id))
+  const blocked = blockedIds.filter((id) => PAIRABLE_ENGINES.has(id) && !runnable.includes(id))
+  const allowed = [...runnable, ...blocked]
   if (!Array.isArray(raw)) return allowed.map(unreportedEngine)
   const byId = new Map<string, DetectedEngine>()
   for (const item of raw) {
@@ -160,7 +187,10 @@ export function sanitizeDetectedEngines(raw: unknown, engineIds: string[]): Dete
     if (!PAIRABLE_ENGINES.has(id) || !allowed.includes(id)) continue
     const bin = typeof rec.bin === 'string' && rec.bin.trim() ? rec.bin.trim() : (ENGINE_BINS[id] ?? id)
     const path = typeof rec.path === 'string' && rec.path.trim() ? rec.path.trim() : null
-    byId.set(id, { id, bin, path, ...sanitizeVersionFields(rec) })
+    // A reason is only meaningful on an engine we actually refused. Accepting
+    // one on a runnable engine would let a daemon mark a working engine broken.
+    const blockedReason = blocked.includes(id) ? displayString(rec.blockedReason, 200) : null
+    byId.set(id, { id, bin, path, ...sanitizeVersionFields(rec), blockedReason })
   }
   // Every row carries the same keys, reported or not, so the app never has to
   // distinguish "field absent" from "nothing installed to report".
@@ -686,6 +716,9 @@ export async function reportDetectedEngines(args: {
   computerId: string
   engines?: string[]
   detected?: unknown
+  /** Installed engines the daemon refused to run. Display-only — they are
+   *  deliberately kept out of `available_engines`, which chooses adapters. */
+  blocked?: string[]
 }): Promise<boolean> {
   const { rows } = await pool.query<{ available_engines: string[]; company_id: string }>(
     `SELECT available_engines, company_id FROM computers
@@ -699,7 +732,7 @@ export async function reportDetectedEngines(args: {
   const ordered = prevDefault && incoming.includes(prevDefault)
     ? [prevDefault, ...incoming.filter((e) => e !== prevDefault)]
     : incoming
-  const detected = sanitizeDetectedEngines(args.detected, ordered)
+  const detected = sanitizeDetectedEngines(args.detected, ordered, args.blocked ?? [])
   await pool.query(
     `UPDATE computers
         SET available_engines = $2::jsonb,

--- a/server/src/agents/computer/registry.ts
+++ b/server/src/agents/computer/registry.ts
@@ -345,6 +345,11 @@ export async function pairComputer(args: {
   engines?: string[]
   /** Optional PATH snapshot from the daemon (bin + resolved path). */
   detected?: unknown
+  /** Installed engines the daemon refused to run, so the card can say why from
+   *  the very first pairing rather than only after the next PATH rescan — which
+   *  is minutes later, and right after pairing is exactly when "why is only
+   *  codex here?" gets asked. Display-only; never joins available_engines. */
+  blocked?: string[]
   /** The daemon's running version, stored so the app can flag outdated daemons. */
   version?: string
   /** Whether the daemon runs supervised (service) vs. as a foreground command. */
@@ -356,7 +361,8 @@ export async function pairComputer(args: {
   deferBroadcast?: boolean
 }): Promise<{ computerId: string; companyId: string; deviceToken: string } | null> {
   const engines = (args.engines ?? []).filter((e) => PAIRABLE_ENGINES.has(e))
-  const detected = sanitizeDetectedEngines(args.detected, engines)
+  const blocked = args.blocked ?? []
+  const detected = sanitizeDetectedEngines(args.detected, engines, blocked)
   const detectedJson = JSON.stringify(detected)
   const version = typeof args.version === 'string' && args.version ? args.version.slice(0, 32) : null
   const supervised = typeof args.supervised === 'boolean' ? args.supervised : null
@@ -376,7 +382,7 @@ export async function pairComputer(args: {
     // the existing default first while it is still installed; if it vanished,
     // mergeDetectedEngines naturally falls back to the daemon's scan order.
     const orderedEngines = mergeDetectedEngines(currentEngines ?? [], engines) ?? (currentEngines ?? [])
-    const reconnectDetectedJson = JSON.stringify(sanitizeDetectedEngines(args.detected, orderedEngines))
+    const reconnectDetectedJson = JSON.stringify(sanitizeDetectedEngines(args.detected, orderedEngines, blocked))
     await pool.query(
       `UPDATE computers
           SET credential_hash = $1, available_engines = $2::jsonb,

--- a/server/src/api/router.ts
+++ b/server/src/api/router.ts
@@ -1186,6 +1186,11 @@ api.post('/computers/pair', safe(async (req, res) => {
     ? (req.body.engines as unknown[]).filter((e): e is string => typeof e === 'string')
     : []
   const detected = req.body?.detected
+  // Same separation as /computers/me/engines: display-only, never merged into
+  // the engines list that picks an adapter.
+  const blockedAtPair = Array.isArray(req.body?.blocked)
+    ? (req.body.blocked as unknown[]).filter((e): e is string => typeof e === 'string')
+    : []
   const hostName = typeof req.body?.hostName === 'string' ? req.body.hostName : undefined
   const version = typeof req.body?.version === 'string' ? req.body.version : undefined
   const supervised = typeof req.body?.supervised === 'boolean' ? req.body.supervised : undefined
@@ -1193,7 +1198,7 @@ api.post('/computers/pair', safe(async (req, res) => {
   // its onboarding gate on that event and immediately reloads its roster, so the
   // starter team + "Everyone" group must already exist when it fires — otherwise
   // the user lands on an empty Conversations list that fills in a beat later.
-  const paired = await pairComputer({ code, hostName, engines, detected, version, supervised, deferBroadcast: true })
+  const paired = await pairComputer({ code, hostName, engines, detected, blocked: blockedAtPair, version, supervised, deferBroadcast: true })
   if (!paired) throw new HttpError(400, 'invalid pairing token')
   // Free-tier BYOA onboarding on pair. The daemon sends the engines list with
   // the user's CHOSEN engine first (`cumora agent computer --pair … --engine X`),

--- a/server/src/api/router.ts
+++ b/server/src/api/router.ts
@@ -1258,7 +1258,13 @@ api.post('/computers/me/engines', safe(async (req, res) => {
   const engines = Array.isArray(req.body?.engines)
     ? (req.body.engines as unknown[]).filter((e): e is string => typeof e === 'string')
     : []
-  const ok = await reportDetectedEngines({ computerId, engines, detected: req.body?.detected })
+  // Installed-but-refused engines. Kept apart from `engines` on purpose: that
+  // list becomes available_engines and picks an agent's adapter, so a blocked
+  // id arriving there would run what the sandbox gate declined.
+  const blocked = Array.isArray(req.body?.blocked)
+    ? (req.body.blocked as unknown[]).filter((e): e is string => typeof e === 'string')
+    : []
+  const ok = await reportDetectedEngines({ computerId, engines, detected: req.body?.detected, blocked })
   if (!ok) throw new HttpError(404, 'computer not found')
   res.json({ ok: true })
 }))

--- a/src/desktop/MeView.tsx
+++ b/src/desktop/MeView.tsx
@@ -784,6 +784,7 @@ type AgentRow = {
   latest?: string | null
   outdated?: boolean
   updateCommand?: string | null
+  blockedReason?: string | null
 }
 
 const CLI_ORDER = [
@@ -1080,10 +1081,25 @@ function ComputersTab() {
                                       {t('me.agentsCliUpdateAvailable')}
                                     </span>
                                   )}
-                                  {!engineId && (
+                                  {/* Two different things, deliberately not one
+                                      label: "not runnable" means Cumora has no
+                                      adapter for this CLI and the operator can
+                                      do nothing about it, while "blocked" means
+                                      it is supported but was refused here for a
+                                      reason they can act on. */}
+                                  {row.blockedReason ? (
+                                    <span className="text-[12px] font-semibold px-2 py-0.5 rounded-full shrink-0 bg-coral-soft text-coral-deep">
+                                      {t('me.agentsCliBlocked')}
+                                    </span>
+                                  ) : !engineId && (
                                     <span className="text-[12px] text-ink-400 truncate">{t('me.agentsNotRunnable')}</span>
                                   )}
                                 </div>
+                                {row.blockedReason && (
+                                  <div className="mt-1 text-[12px] leading-[1.55] text-coral-deep">
+                                    {t('me.agentsCliBlockedReason', { reason: row.blockedReason })}
+                                  </div>
+                                )}
                                 <div className="mt-1 flex items-center min-w-0 font-mono text-[12px] text-ink-400">
                                   <span className="shrink-0">{row.bin}</span>
                                   {row.path && (

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1294,6 +1294,8 @@ export const en = {
   'me.agentsIsDefault': 'Default',
   'me.agentsOffline': 'This computer is offline. The list is still the last pairing report.',
   'me.agentsNoEngines': 'The daemon reported no engines at pairing. Re-run the pairing command on that computer to scan PATH again.',
+  'me.agentsCliBlocked': 'Not used',
+  'me.agentsCliBlockedReason': 'Installed, but Cumora will not run it here: {reason}. Until that is fixed, agents on this computer cannot use it.',
   'me.agentsNotRunnable': 'Detected only — Cumora cannot run this yet',
   'me.agentsNeedPair': 'Re-pair to use',
   'me.agentsCliUnknown': 'version unknown',

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -1296,6 +1296,8 @@ export const zhCN: Partial<Record<keyof typeof en, string>> = {
   'me.agentsIsDefault': '默认',
   'me.agentsOffline': '这台计算机离线。列表仍是上次配对时的检测结果。',
   'me.agentsNoEngines': '配对时 daemon 没有报任何引擎。要重新扫 PATH，请在那台机器上再跑一次配对命令。',
+  'me.agentsCliBlocked': '未启用',
+  'me.agentsCliBlockedReason': '已安装，但 Cumora 不会在这台机器上运行它：{reason}。在此修复前，这台计算机上的智能体无法使用它。',
   'me.agentsNotRunnable': '仅识别，Cumora 还不能当引擎跑',
   'me.agentsNeedPair': '重新配对后使用',
   'me.agentsCliUnknown': '版本未知',

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,10 @@ export interface Computer {
     outdated?: boolean
     /** How to update this engine on that computer (vendor updater, brew, or npm). */
     updateCommand?: string | null
+    /** Set when the engine is installed there but Cumora refuses to drive it —
+     *  an old CLI, or a missing sandbox dependency. The daemon knows this and
+     *  now says so, instead of the engine merely going absent. */
+    blockedReason?: string | null
   }>
   enginesDetectedAt?: string | null
   lastSeenAt?: string | null


### PR DESCRIPTION
`evaluateRunnableEngines()` already knows why it declined an engine — `version 2.0.9 is older than the secure minimum 2.1.248`, `missing sandbox dependency: bubblewrap (bwrap)`. That reason only ever reached the daemon's own stdout:

```ts
if (capabilityWarning) console.warn(`[computer] secure engine(s) disabled: ${capabilityWarning}`)
```

From the app, the engine just stopped existing. Someone whose Claude Code is a release behind, or whose Linux box lacks `bwrap`, sees a computer with fewer engines and agents that will not wake — and nothing anywhere they are looking says why, or what to do about it.

The card already makes this exact argument, three lines below, about version numbers:

> the app renders it verbatim and never probes its own PATH, because whoever is looking at the card is usually not sitting at the machine it describes

The refusal is the same kind of fact and was not travelling.

## What it looks like

> **Claude Code**  `Not used`
> Installed, but Cumora will not run it here: version 2.0.9 is older than the secure minimum 2.1.248. Until that is fixed, agents on this computer cannot use it.
> `claude · /usr/local/bin/claude · installed 2.0.9`

**"Not used" is deliberately not the existing "not runnable" label.** That one means Cumora has no adapter for the CLI and the operator can do nothing about it. This one means the engine is supported and was refused for a reason they can act on — a different message deserves a different word.

## All three snapshot paths, which the first cut got wrong

Three paths store an engine snapshot — **pairing, reconnect, and the periodic rescan** — and each sanitizes its own. My first version wired only the rescan, so a freshly paired computer said nothing about the engine it had just skipped until minutes later. That is precisely the window in which someone asks why their Claude Code is not listed: the one moment the explanation was most wanted was the one moment it was missing.

`requireLocalEngine()` had the refusals and discarded them after the `console.warn`; it now returns them, `doPair` reports them, and `pairComputer` threads them into both its fresh-pair and reconnect branches.

## The safety property, which most of the tests are about

`available_engines` picks an agent's adapter, so a blocked id reaching it would run **precisely what the sandbox gate refused**. The separation is enforced deliberately:

- blocked ids travel in their own `blocked` field, never inside `engines`
- they are appended *after* the runnable ones, so they cannot repoint `available_engines[0]` — the computer's default engine
- an id claimed as both runnable and blocked stays runnable, and appears once
- a `blockedReason` offered for a **runnable** engine is discarded, so a daemon cannot mark a working engine broken in someone else's UI
- the reason goes through the same `displayString` trim/cap as every other daemon-supplied string

## Tests

**11 unit tests** on the sanitizer, and **5 integration tests against a real Postgres** on the stored row, because the property is about what lands in the two columns:

| | |
| --- | --- |
| pairing stores the reason without making it runnable | `available_engines = ["codex"]`, claude in `detected_engines` with its reason and path |
| reconnecting keeps it | the other branch inside `pairComputer`, with its own sanitize call |
| the rescan keeps the separation | an engine that was runnable at pairing and is refused now leaves `available_engines` |
| fixing the cause clears it | upgrading the CLI makes the card go quiet with no other change — the reason is state, not a one-way flag |
| a daemon claiming both does not get it both ways | the same id in both lists stays runnable and appears once |

Removing the pairing/reconnect wiring fails 3 of the 5, so they pin the hole this closes rather than merely describing it.

Also verified in the running app against a seeded computer with one runnable and one refused engine, driven through the real `reportDetectedEngines` path: the card renders in English and 中文, light and dark, and the runnable Codex row is unchanged.

## Two things I did not do

The reason text stays English in the 中文 UI, because `secureEngineCapabilityReason()` returns prose rather than a structured code. The surrounding copy is localized; the diagnostic is not. Localizing it properly means turning those reasons into codes with parameters — a larger change and a product decision. Happy to do it if you want it.

The rescan's two `enrichDetectedEngines()` calls are collapsed into one over the combined list. It maps entry by entry, so splitting it bought nothing and only left room for the two halves to drift.
