### PR TITLE
release: v0.11.0

### DIFF
--- a/agent-cli/package.json
+++ b/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cumora",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Run Cumora agents on your own machine with Claude Code, Codex, Grok Build, Cursor Agent, OpenCode, or pi (BYOA).",
   "license": "MIT",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cumora",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cumora",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1045.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cumora",
   "private": true,
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "main": "electron/main.cjs",
   "bin": {


### PR DESCRIPTION
Everything merged since v0.10.0, plus the security work that landed alongside it.

## New engines and providers

- **#113 — Qwen Code as a BYOA engine.** Qwen Code is a Gemini CLI fork that shares its flags but emits Claude Code's envelope, so the wake path needs no parser of its own and only triage does. Triage runs `--safe-mode` (qwen's own "ignore every customization" switch, the counterpart to `--strict-mcp-config` on the Claude path) and honours `CUMORA_TRIAGE_MODEL`. 16 tests cover the envelope, per-message hops, session resume, error precedence, and the argv override.
- **#111 — OrcaRouter as a named model-prefix provider.** Mirrors the existing Novita route: prefix a model id with `orcarouter/` and the call is forwarded with the prefix stripped. Fully opt-in and inert without `ORCAROUTER_API_KEY`, which degrades to the tenant's normal client rather than sending a bare bearer upstream.

## Fixes

- **#131 — skill installs are atomic and CRLF-tolerant.** `parseSkillMd` rejected `---\r\n` frontmatter outright, so a Windows-authored `SKILL.md` was silently discarded as malformed. Installs now also verify the root `SKILL.md` frontmatter and that its `name` matches the manifest's before touching storage — they share a path, so a mismatch installed a skill under one name while it declared another — reject duplicate and unsafe relative paths, and run inside a transaction so a failed write cannot leave a half-installed skill.
- **a11y regression from #129 (this branch).** That PR dropped `role="button"` and `aria-expanded` from the Computers card header instead of the attribute Biome objected to, leaving a bare clickable `<div>`. The rule was right — a conditional role cannot be resolved statically — so the role is now static, split across a real disclosure control and an inert container, and the header gained the keyboard path it never had.
- Two 1-second spawn polls in the Pi forced-stop test raised to 5s. They bound a process launch, not the behaviour under test; the suite has grown enough that they lost the race on a loaded machine while still passing in CI.

## Hardening merged since v0.10.0

`#126` skill installs restricted to the configured hub · `#127` OG preview requests pinned to validated IPs · `#128` runtime tokens revoked after tenant moves · `#132` BYOA model execution sandboxed · `#133` writes bound to live membership · `#134` authentication before large-body parsing · `#135` observability writes bound to run owners.

## Also in

- **#129** — 30 Biome accessibility rules are now CI errors, with the ARIA conformance fixes to match.
- **#122**'s `useButtonType`, kept and extended.
- BYOA engine versions refresh on demand.

## Verification on this branch

- 990 unit tests, 0 failures
- `typecheck`, `server:typecheck`, `lint` (434 files, 30 new a11y rules), `guard:big-brain`, `guard:llm-tracked`, `guard:engine-registry`, `vite build` all clean

## Not included

**#124** (turns per human message) is still blocked on a reported aggregate bug: `avg` and `percentile_cont` read the raw `LEFT JOIN` column, so zero-turn messages drop out of exactly the two numbers the panel exists to report. **#123** is a draft.