### PR TITLE
docs: update benchmark scenario status

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -18,7 +18,7 @@ fallback, etc.
 | `werewolf` | Multi-round role-playing with judge-driven state machine. Structural scoring: winner declared + ≥1 phase cycle + death announcements. No semantic quality judging. | ✅ implemented |
 | `kanban` | Pull-group on a pre-created card; success = card moves to done-pattern column AND ≥2 distinct agent contributors. Requires `BENCH_KANBAN_BOARD_ID` pointing at an existing board with todo + done columns. | ✅ implemented |
 
-The two implemented scenarios are **shape-duals** on purpose:
+The chain and counting scenarios are **shape-duals** on purpose:
 chain proves the team adapts to absence (lap when needed);
 counting proves the team respects an explicit cap (don't lap when
 explicitly forbidden). A regression that breaks the principle in either
@@ -66,7 +66,7 @@ export BENCH_USER=u-<your-user-id>          # the participant ID you want to act
 export BENCH_COMPANY=co-<your-company-id>   # the company under which test convos are created
 npx tsx run.ts chain                         # one scenario
 npx tsx run.ts chain counting                # multiple
-npx tsx run.ts --all                         # everything (incl. stubs that always fail)
+npx tsx run.ts --all                         # all four scenarios
 ```
 
 The runner writes one JSON result file per scenario into

--- a/benchmarks/run.ts
+++ b/benchmarks/run.ts
@@ -25,8 +25,8 @@ import { kanbanScenario } from './games/kanban.ts'
 const REGISTRY: Record<string, Scenario> = {
   chain: chainScenario,
   counting: countingScenario,
-  werewolf: werewolfScenario,  // stub
-  kanban: kanbanScenario,      // stub
+  werewolf: werewolfScenario,
+  kanban: kanbanScenario,
 }
 
 function usage(): never {


### PR DESCRIPTION
## Summary

- remove stale `stub` comments from the implemented werewolf and kanban registry entries
- describe chain/counting as the specific shape-dual pair without implying they are the only implemented scenarios
- document `--all` as running all four scenarios

Closes #140.

## Validation

- `cd benchmarks && npm ci && npx tsc --noEmit`
- `npm run lint`
- `npm run typecheck`
- `npm run server:typecheck`
- `workers/email-gate: npm run typecheck`
- `workers/r2-gate: npm run typecheck`
- `git diff --check`

The real-LLM benchmark runner was intentionally not executed because the repository documents that it wakes real agents and incurs provider cost.
