### PR TITLE
fix: normalize llm guard paths

### DIFF
--- a/scripts/guard-llm-tracked.mjs
+++ b/scripts/guard-llm-tracked.mjs
@@ -50,7 +50,7 @@ function* walk(dir) {
   const abs = join(ROOT, dir)
   for (const entry of readdirSync(abs)) {
     const p = join(abs, entry)
-    const rel = p.slice(ROOT_LEN)
+    const rel = p.slice(ROOT_LEN).replaceAll('\\', '/')
     if (SKIP.test(rel)) continue
     const st = statSync(p)
     if (st.isDirectory()) yield* walk(rel)


### PR DESCRIPTION
## Summary

- normalize walked repository-relative paths to forward slashes
- make the existing `ALLOW` set and `SKIP` regex match on native Windows
- keep the guard policy and call-site allowlist unchanged

Closes #142.

## Validation

Before this change, `npm run guard:llm-tracked` reported all six explicitly allowlisted call sites as violations on Windows. After the change:

- `npm run guard:llm-tracked`
- `npm run guard:big-brain`
- `npm run guard:engine-registry`
- `npm run lint`
- `npm run typecheck`
- `npm run server:typecheck`
- `git diff --check`

All pass on native Windows.
