### PR TITLE
fix(byoa): refresh engine inventory immediately

### DIFF
--- a/server/src/__integration__/computer-control-stream.test.ts
+++ b/server/src/__integration__/computer-control-stream.test.ts
@@ -1,0 +1,77 @@
+/** Real Redis wire tests for the paired Computer daemon control stream. */
+import { randomUUID } from 'node:crypto'
+import { EventEmitter } from 'node:events'
+import { after, test } from 'node:test'
+import assert from 'node:assert/strict'
+import type { Response } from 'express'
+import {
+  attachComputerControlStream,
+  deliverEngineDetect,
+} from '../agents/computer/control-bus.js'
+import { parseComputerControlEvent } from '../agents/computer/control-event.js'
+import { teardownAll } from './_helpers.js'
+
+function makeFakeSseResponse(): Response & {
+  written: string[]
+  closed: boolean
+  triggerClose(): void
+} {
+  const events = new EventEmitter()
+  const written: string[] = []
+  const fake = Object.assign(events, {
+    written,
+    closed: false,
+    setHeader: () => undefined,
+    flushHeaders: () => undefined,
+    write: (value: string) => { if (!fake.closed) written.push(value); return true },
+    end: () => { if (!fake.closed) { fake.closed = true; events.emit('close') } },
+    triggerClose: () => { if (!fake.closed) { fake.closed = true; events.emit('close') } },
+  }) as unknown as Response & { written: string[]; closed: boolean; triggerClose(): void }
+  return fake
+}
+
+function engineDetectFrame(writes: string[]): string | null {
+  const block = writes.join('').split('\n\n').find((value) => value.startsWith('event: engine.detect\n'))
+  const data = block?.split('\n').find((line) => line.startsWith('data: '))?.slice(6)
+  return data ?? null
+}
+
+after(async () => {
+  await teardownAll()
+})
+
+test('[integration] engine refresh publishes through Redis to the device SSE stream', async () => {
+  const computerId = `computer-${randomUUID()}`
+  const response = makeFakeSseResponse()
+  await attachComputerControlStream(computerId, response)
+
+  assert.ok((await deliverEngineDetect(computerId)) >= 1)
+  await new Promise((resolve) => setTimeout(resolve, 50))
+
+  const raw = engineDetectFrame(response.written)
+  assert.ok(raw, 'the daemon stream should receive an engine.detect frame')
+  assert.equal(parseComputerControlEvent(raw)?.kind, 'engine.detect')
+  response.triggerClose()
+})
+
+test('[integration] revoked device streams close before receiving a refresh', async () => {
+  const computerId = `computer-${randomUUID()}`
+  const response = makeFakeSseResponse()
+  await attachComputerControlStream(computerId, response, { authorize: async () => false })
+
+  await deliverEngineDetect(computerId)
+  await new Promise((resolve) => setTimeout(resolve, 50))
+
+  assert.equal(response.closed, true)
+  assert.equal(engineDetectFrame(response.written), null)
+})
+
+test('[integration] a disconnected stream reports no immediate receiver', async () => {
+  const computerId = `computer-${randomUUID()}`
+  const response = makeFakeSseResponse()
+  await attachComputerControlStream(computerId, response)
+  response.triggerClose()
+  await new Promise((resolve) => setTimeout(resolve, 50))
+
+  assert.equal(await deliverEngineDetect(computerId), 0)
+})

--- a/server/src/__tests__/agents-computer-control.test.ts
+++ b/server/src/__tests__/agents-computer-control.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Immediate Computer control-stream protocol and refresh coalescing.
+ *
+ * Run: node --import tsx --test server/src/__tests__/agents-computer-control.test.ts
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { parseComputerControlEvent } from '../agents/computer/control-event.js'
+import { createEngineRescanQueue } from '../agents/computer/daemon.js'
+
+test('engine detection control events validate the complete wire payload', () => {
+  const raw = JSON.stringify({ kind: 'engine.detect', id: 'engine.detect-123', at: 1_725_000_000_000 })
+  assert.deepEqual(parseComputerControlEvent(raw), {
+    kind: 'engine.detect',
+    id: 'engine.detect-123',
+    at: 1_725_000_000_000,
+  })
+})
+
+test('malformed and unknown control events are ignored', () => {
+  assert.equal(parseComputerControlEvent('not-json'), null)
+  assert.equal(parseComputerControlEvent(JSON.stringify({ kind: 'engine.detect', id: '', at: Date.now() })), null)
+  assert.equal(parseComputerControlEvent(JSON.stringify({ kind: 'engine.detect', id: 'x' })), null)
+  assert.equal(parseComputerControlEvent(JSON.stringify({ kind: 'daemon.stop', id: 'x', at: Date.now() })), null)
+})
+
+test('an immediate forced refresh arriving during a scan gets a forced follow-up', async () => {
+  let releaseFirst!: () => void
+  const firstGate = new Promise<void>((resolve) => { releaseFirst = resolve })
+  const calls: boolean[] = []
+  const queue = createEngineRescanQueue(async (force) => {
+    calls.push(force)
+    if (calls.length === 1) await firstGate
+  })
+
+  const ordinary = queue()
+  const immediate = queue(true)
+  assert.equal(immediate, ordinary, 'concurrent callers must share one queue')
+  assert.deepEqual(calls, [false])
+
+  releaseFirst()
+  await immediate
+  assert.deepEqual(calls, [false, true])
+})
+
+test('a burst of immediate refreshes coalesces to one follow-up scan', async () => {
+  let releaseFirst!: () => void
+  const firstGate = new Promise<void>((resolve) => { releaseFirst = resolve })
+  const calls: boolean[] = []
+  const queue = createEngineRescanQueue(async (force) => {
+    calls.push(force)
+    if (calls.length === 1) await firstGate
+  })
+
+  const running = queue()
+  queue(true)
+  queue(true)
+  queue(true)
+  releaseFirst()
+  await running
+
+  assert.deepEqual(calls, [false, true])
+})
+
+test('the refresh queue is reusable after a failed scan', async () => {
+  let attempts = 0
+  const queue = createEngineRescanQueue(async () => {
+    attempts += 1
+    if (attempts === 1) throw new Error('transient detection failure')
+  })
+
+  await assert.rejects(queue(), /transient detection failure/)
+  await queue(true)
+  assert.equal(attempts, 2)
+})

--- a/server/src/agents/computer/control-bus.ts
+++ b/server/src/agents/computer/control-bus.ts
@@ -1,0 +1,148 @@
+/**
+ * Cluster-wide control channel for one paired Computer daemon.
+ *
+ * The database remains the durable source of truth for requested work; this bus
+ * is only the low-latency nudge that lets an online daemon react immediately
+ * instead of waiting for its next heartbeat.
+ */
+import { randomUUID } from 'node:crypto'
+import type { Response } from 'express'
+import { redis, sub as redisSub } from '../../redis.js'
+import { parseComputerControlEvent, type ComputerControlEvent } from './control-event.js'
+
+const CH_COMPUTER_CONTROL_PREFIX = 'cumora:computer-control:'
+const SSE_MAX_BUFFERED_BYTES = 1 * 1024 * 1024
+
+interface Subscriber {
+  res: Response
+  closed: boolean
+  authorize?: () => Promise<boolean>
+  delivery: Promise<void>
+  revoke(): void
+}
+
+const subscribers = new Map<string, Set<Subscriber>>()
+let redisSubscriberInstalled = false
+
+async function deliverTo(subscriber: Subscriber, event: ComputerControlEvent): Promise<void> {
+  if (subscriber.closed) return
+  if (subscriber.authorize) {
+    try {
+      if (!(await subscriber.authorize())) { subscriber.revoke(); return }
+    } catch {
+      subscriber.revoke()
+      return
+    }
+  }
+  if (subscriber.closed) return
+  if (subscriber.res.socket && subscriber.res.socket.writableLength > SSE_MAX_BUFFERED_BYTES) {
+    subscriber.revoke()
+    return
+  }
+  try {
+    subscriber.res.write(`event: ${event.kind}\n`)
+    subscriber.res.write(`id: ${event.id}\n`)
+    subscriber.res.write(`data: ${JSON.stringify(event)}\n\n`)
+  } catch {
+    subscriber.revoke()
+  }
+}
+
+function installRedisSubscriber(): void {
+  if (redisSubscriberInstalled) return
+  redisSubscriberInstalled = true
+  redisSub.on('message', (channel, raw) => {
+    if (!channel.startsWith(CH_COMPUTER_CONTROL_PREFIX)) return
+    const computerId = channel.slice(CH_COMPUTER_CONTROL_PREFIX.length)
+    const set = subscribers.get(computerId)
+    if (!set || set.size === 0) return
+    const event = parseComputerControlEvent(raw)
+    if (!event) return
+    for (const subscriber of set) {
+      subscriber.delivery = subscriber.delivery
+        .then(() => deliverTo(subscriber, event))
+        .catch(() => subscriber.revoke())
+    }
+  })
+}
+
+/** Publish an immediate engine-detection nudge. A zero return means no daemon
+ * stream is connected; the persisted heartbeat request remains the fallback. */
+export async function deliverEngineDetect(computerId: string): Promise<number> {
+  const event: ComputerControlEvent = {
+    kind: 'engine.detect',
+    id: `engine.detect-${randomUUID()}`,
+    at: Date.now(),
+  }
+  return redis.publish(CH_COMPUTER_CONTROL_PREFIX + computerId, JSON.stringify(event))
+}
+
+/** Attach the authenticated daemon's long-lived SSE control stream. */
+export async function attachComputerControlStream(
+  computerId: string,
+  res: Response,
+  options: { authorize?: () => Promise<boolean> } = {},
+): Promise<void> {
+  installRedisSubscriber()
+
+  res.setHeader('Content-Type', 'text/event-stream')
+  res.setHeader('Cache-Control', 'no-cache, no-transform')
+  res.setHeader('Connection', 'keep-alive')
+  res.setHeader('X-Accel-Buffering', 'no')
+  res.flushHeaders?.()
+
+  let set = subscribers.get(computerId)
+  if (!set) { set = new Set(); subscribers.set(computerId, set) }
+  const isFirst = set.size === 0
+  let ping: ReturnType<typeof setInterval> | null = null
+  const subscriber: Subscriber = {
+    res,
+    closed: false,
+    authorize: options.authorize,
+    delivery: Promise.resolve(),
+    revoke: () => { /* assigned after cleanup is defined */ },
+  }
+  set.add(subscriber)
+
+  const cleanup = (): void => {
+    if (subscriber.closed && !set!.has(subscriber)) return
+    subscriber.closed = true
+    if (ping) clearInterval(ping)
+    set!.delete(subscriber)
+    const last = set!.size === 0
+    if (last) subscribers.delete(computerId)
+    if (last) {
+      void redisSub.unsubscribe(CH_COMPUTER_CONTROL_PREFIX + computerId).catch((error) => {
+        console.warn('[computer-control] Redis unsubscribe failed:', error instanceof Error ? error.message : String(error))
+      })
+    }
+  }
+  subscriber.revoke = () => {
+    if (subscriber.closed) return
+    try { res.end() } catch { /* ignore */ }
+    cleanup()
+  }
+  res.on('close', cleanup)
+  res.on('error', cleanup)
+
+  // Subscribe before announcing readiness so a request cannot fall into a gap.
+  if (isFirst) await redisSub.subscribe(CH_COMPUTER_CONTROL_PREFIX + computerId)
+  if (subscriber.closed) return
+  res.write(`event: ready\ndata: {"computerId":${JSON.stringify(computerId)},"at":${Date.now()}}\n\n`)
+
+  ping = setInterval(() => {
+    if (subscriber.closed) return
+    void (async () => {
+      if (subscriber.authorize) {
+        try {
+          if (!(await subscriber.authorize())) { subscriber.revoke(); return }
+        } catch {
+          subscriber.revoke()
+          return
+        }
+      }
+      try { res.write(`: ping ${Date.now()}\n\n`) } catch { subscriber.revoke() }
+    })()
+  }, 25_000)
+  ping.unref?.()
+}

--- a/server/src/agents/computer/control-event.ts
+++ b/server/src/agents/computer/control-event.ts
@@ -1,0 +1,23 @@
+/** Wire protocol shared by the API server and the standalone Computer daemon. */
+export interface ComputerControlEvent {
+  kind: 'engine.detect'
+  id: string
+  at: number
+}
+
+export function parseComputerControlEvent(raw: string): ComputerControlEvent | null {
+  try {
+    const value = JSON.parse(raw) as Partial<ComputerControlEvent> | null
+    if (
+      !value
+      || value.kind !== 'engine.detect'
+      || typeof value.id !== 'string'
+      || value.id.length === 0
+      || typeof value.at !== 'number'
+      || !Number.isFinite(value.at)
+    ) return null
+    return value as ComputerControlEvent
+  } catch {
+    return null
+  }
+}

--- a/server/src/agents/computer/daemon.ts
+++ b/server/src/agents/computer/daemon.ts
@@ -37,6 +37,7 @@ import {
   uniqueProjectIds,
 } from '../memory-scope.js'
 import { parseSseStream, wakeStreamWasStable } from '../runtime/sse-parse.js'
+import { parseComputerControlEvent } from './control-event.js'
 import {
   mergeWakeBackgroundBriefs,
   parseWakeData,
@@ -48,6 +49,33 @@ import { finalizeTriage, isRateLimited, parseTriage } from '../triage-core.js'
 import { allowUnsandboxedByoa, detectEnginesWithStatus, ENGINE_IDS, type EngineHopReport, type EngineId, type EngineRunResult, type EngineSession, type EngineUsage, enrichDetectedEngines, evaluateRunnableEngines, getAdapter, runEngineDoctor, snapshotDetectedEngines } from './engine.js'
 
 export { conversationHeader }
+
+/** Serialize engine scans and coalesce duplicate requests. A forced refresh that
+ * arrives during an ordinary scan schedules exactly one follow-up forced report,
+ * so the UI acknowledgement cannot be swallowed by older work. */
+export function createEngineRescanQueue(
+  scan: (forceReport: boolean) => Promise<void>,
+): (forceReport?: boolean) => Promise<void> {
+  let inFlight: Promise<void> | null = null
+  let forcedPending = false
+  return (forceReport = false): Promise<void> => {
+    forcedPending ||= forceReport
+    if (inFlight) return inFlight
+    const running = (async () => {
+      let first = true
+      while (first || forcedPending) {
+        first = false
+        const force = forcedPending
+        forcedPending = false
+        await scan(force)
+      }
+    })().finally(() => {
+      if (inFlight === running) inFlight = null
+    })
+    inFlight = running
+    return running
+  }
+}
 
 const CONFIG_DIR = join(homedir(), '.cumora')
 const CONFIG_PATH = join(CONFIG_DIR, 'computer.json')
@@ -3120,25 +3148,7 @@ async function doRun(serverOverride?: string): Promise<void> {
   // Timer/startup/requested scans can land together. Share an in-flight scan;
   // if a forced request arrives during it, run once more so its acknowledgement
   // cannot be swallowed by the older scan finishing afterward.
-  let rescanInFlight: Promise<void> | null = null
-  let forcedRescanPending = false
-  const rescanEngines = (forceReport = false): Promise<void> => {
-    forcedRescanPending ||= forceReport
-    if (rescanInFlight) return rescanInFlight
-    const running = (async () => {
-      let first = true
-      while (first || forcedRescanPending) {
-        first = false
-        const force = forcedRescanPending
-        forcedRescanPending = false
-        await scanEnginesOnce(force)
-      }
-    })().finally(() => {
-      if (rescanInFlight === running) rescanInFlight = null
-    })
-    rescanInFlight = running
-    return running
-  }
+  const rescanEngines = createEngineRescanQueue(scanEnginesOnce)
 
   const heartbeat = async (): Promise<void> => {
     try {
@@ -3159,6 +3169,44 @@ async function doRun(serverOverride?: string): Promise<void> {
     } catch { /* transient — next tick retries */ }
   }
 
+  let shuttingDown = false
+  const controlStreamAbort = new AbortController()
+  const controlStreamLoop = async (): Promise<void> => {
+    let backoff = 1000
+    while (!shuttingDown) {
+      let connectedAt: number | null = null
+      try {
+        const response = await fetch(`${cfg.serverUrl}/api/computers/me/control-stream`, {
+          headers: { Authorization: `Bearer ${cfg.deviceToken}`, Accept: 'text/event-stream' },
+          signal: controlStreamAbort.signal,
+        })
+        if (!response.ok || !response.body) throw new Error(`computer control-stream HTTP ${response.status}`)
+        connectedAt = Date.now()
+        console.log('[computer] control-stream connected')
+        for await (const event of parseSseStream(response.body as unknown as AsyncIterable<unknown>)) {
+          if (shuttingDown) break
+          if (event.event === 'ready') {
+            // Pick up a durable request that may have been persisted while this
+            // stream was disconnected, without waiting for the next 30s tick.
+            void heartbeat()
+            continue
+          }
+          if (event.event === 'engine.detect' && event.data && parseComputerControlEvent(event.data)) {
+            void rescanEngines(true)
+          }
+        }
+        if (!shuttingDown) console.warn(`[computer] control-stream closed by server · retry in ${backoff}ms`)
+      } catch (error) {
+        if (shuttingDown || controlStreamAbort.signal.aborted) break
+        console.warn(`[computer] control-stream error: ${error instanceof Error ? error.message : String(error)} · retry in ${backoff}ms`)
+      }
+      if (shuttingDown) break
+      if (wakeStreamWasStable(connectedAt === null ? null : Date.now() - connectedAt)) backoff = 1000
+      await new Promise((resolve) => setTimeout(resolve, backoff))
+      backoff = Math.min(backoff * 2, 30_000)
+    }
+  }
+
   await heartbeat()
   await sync()
   if (runners.size === 0) {
@@ -3172,6 +3220,7 @@ async function doRun(serverOverride?: string): Promise<void> {
   // on CLI spawns. Fill in the versions right after startup instead of leaving
   // the card blank until the first 5-minute tick.
   void rescanEngines()
+  void controlStreamLoop()
   // Keep the service log from filling the disk: rotate at boot, then periodically.
   void rotateLogsIfNeeded()
   const logrot = setInterval(() => { void rotateLogsIfNeeded() }, LOG_ROTATE_MS)
@@ -3180,7 +3229,6 @@ async function doRun(serverOverride?: string): Promise<void> {
   let upd: ReturnType<typeof setInterval> | undefined
   let idleWatch: ReturnType<typeof setInterval> | undefined
   let controlWatch: ReturnType<typeof setInterval> | undefined
-  let shuttingDown = false
   const anyBusy = (): boolean => [...runners.values()].some((r) => r.isBusy)
 
   // Graceful shutdown: stop accepting new wakes, give any in-flight turn a brief
@@ -3190,6 +3238,7 @@ async function doRun(serverOverride?: string): Promise<void> {
   const shutdown = async (why: string): Promise<void> => {
     if (shuttingDown) return
     shuttingDown = true
+    controlStreamAbort.abort()
     clearInterval(poll); clearInterval(beat); clearInterval(logrot); clearInterval(rescan)
     if (upd) clearInterval(upd)
     if (idleWatch) clearInterval(idleWatch)

--- a/server/src/api/router.ts
+++ b/server/src/api/router.ts
@@ -38,6 +38,7 @@ import {
   cloudComputerId, issueRepairCode, requestEngineDetect, reportDetectedEngines,
   setComputerDefaultEngine,
 } from '../agents/computer/registry.js'
+import { attachComputerControlStream, deliverEngineDetect } from '../agents/computer/control-bus.js'
 import { companyTier } from '../tier.js'
 import { createShippingRouter } from './shipping-router.js'
 
@@ -156,13 +157,16 @@ function userId(req: Request & AuthedRequest): string {
   return requireAuth(req)
 }
 
+function deviceBearerToken(req: Request): string {
+  const auth = req.headers.authorization
+  return typeof auth === 'string' && auth.startsWith('Bearer ') ? auth.slice(7).trim() : ''
+}
+
 /** Resolve the calling Computer daemon from its device-token Bearer header,
  *  or throw 401. Used by daemon-facing endpoints that carry no user session —
  *  the device token (issued at pairing) is the credential. */
 async function requireDevice(req: Request & AuthedRequest): Promise<{ computerId: string; companyId: string }> {
-  const auth = req.headers.authorization
-  const token = typeof auth === 'string' && auth.startsWith('Bearer ') ? auth.slice(7).trim() : ''
-  const dev = await resolveDevice(token)
+  const dev = await resolveDevice(deviceBearerToken(req))
   if (!dev) throw new HttpError(401, 'invalid or revoked device token')
   return dev
 }
@@ -1240,9 +1244,18 @@ api.post('/computers/pair', safe(async (req, res) => {
 
 api.post('/computers/:id/detect', safe(async (req, res) => {
   const { companyId } = await requireCompanyRole(req)
-  const ok = await requestEngineDetect({ computerId: String(req.params.id), companyId })
+  const computerId = String(req.params.id)
+  // Persist first: Redis/SSE is the fast path, while the existing heartbeat flag
+  // guarantees eventual delivery across deploys, disconnects and Redis outages.
+  const ok = await requestEngineDetect({ computerId, companyId })
   if (!ok) throw new HttpError(404, 'computer not found')
-  res.json({ ok: true })
+  let delivered = false
+  try {
+    delivered = (await deliverEngineDetect(computerId)) > 0
+  } catch (error) {
+    console.warn('[computers] immediate engine detection signal failed:', error instanceof Error ? error.message : String(error))
+  }
+  res.json({ ok: true, delivered })
 }))
 
 api.post('/computers/:id/default-engine', safe(async (req, res) => {
@@ -1261,6 +1274,16 @@ api.post('/computers/me/engines', safe(async (req, res) => {
   const ok = await reportDetectedEngines({ computerId, engines, detected: req.body?.detected })
   if (!ok) throw new HttpError(404, 'computer not found')
   res.json({ ok: true })
+}))
+
+// One device-level control stream per daemon. Unlike per-agent wake streams,
+// this also works when the computer currently hosts zero agents.
+api.get('/computers/me/control-stream', safe(async (req, res) => {
+  const token = deviceBearerToken(req)
+  const { computerId } = await requireDevice(req)
+  await attachComputerControlStream(computerId, res, {
+    authorize: async () => (await resolveDevice(token))?.computerId === computerId,
+  })
 }))
 
 // Agents assigned to the calling computer (daemon discovery on boot).


### PR DESCRIPTION
## Summary

- add a device-scoped SSE control stream so online Computer daemons receive engine refresh requests immediately
- persist refresh requests before publishing the real-time signal, retaining the existing heartbeat as a durable fallback
- reconnect control streams with bounded backoff and recover pending requests on connection
- serialize and coalesce concurrent engine scans so an immediate refresh cannot be swallowed by an in-progress scan
- revalidate device authorization and enforce SSE backpressure limits
- add protocol, concurrency, disconnection, revocation, and Redis wire tests

## Problem

Engine refresh requests were stored in the database and only observed during the daemon's next 30-second heartbeat. As a result, clicking Refresh could leave the UI waiting for a long time even while the daemon was online.

## Testing

- `npm run server:typecheck`
- `npm run typecheck`
- targeted engine refresh regression tests: 28/28 passed
- Biome lint passed for all changed files
- Redis integration coverage added for delivery, revocation, and disconnection behavior

BTW,End-to-end testing was not performed locally because this change requires the updated server-side control stream and a matching Computer daemon.