### PR TITLE
fix(byoa): secure Codex must not pass a dotted dynamic key under --strict-config

### DIFF
--- a/server/src/__tests__/agents-computer-codex-strict-config.test.ts
+++ b/server/src/__tests__/agents-computer-codex-strict-config.test.ts
@@ -1,0 +1,135 @@
+/**
+ * The secure Codex override set has to survive `--strict-config` (#144).
+ *
+ * Codex 0.150/0.151 refuses a quoted dynamic map key in a dotted `-c` override:
+ *
+ *   Error loading config.toml: unknown configuration field
+ *     `projects."<agent-home>"` in -c/--config override
+ *
+ * That killed every secure Codex wake before the model ran, and because the
+ * undelivered message stays durable the daemon retried the same failure
+ * forever. The inline-table form parses on every version anyone has checked.
+ *
+ * What these can and cannot do: Codex is not installed in CI, so they pin the
+ * argv this repo *builds*, not what a particular Codex release accepts. The
+ * parse behaviour was checked by hand against 0.134.0 and 0.152.0 locally and
+ * by the reporter against 0.150.1 and 0.151.0-alpha. So the value here is
+ * catching a regression back to a shape known to break, and pinning the
+ * security intent that shape exists to express.
+ *
+ * Run: node --import tsx --test server/src/__tests__/agents-computer-codex-strict-config.test.ts
+ */
+import { chmod, mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { delimiter, join } from 'node:path'
+import { afterEach, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { getAdapter } from '../agents/computer/engine.js'
+
+const IS_WIN = process.platform === 'win32'
+const ORIGINAL_PATH = process.env.PATH
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  process.env.PATH = ORIGINAL_PATH
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+/** Echoes its own argv as JSON so the test can read what was built. */
+const FAKE_CODEX = `#!/usr/bin/env node
+'use strict'
+process.stdout.write(JSON.stringify({ argv: process.argv.slice(2) }) + '\\n')
+`
+
+interface Fixture { root: string; home: string; env: NodeJS.ProcessEnv }
+
+async function fixture(homeName: string): Promise<Fixture> {
+  const root = await mkdtemp(join(tmpdir(), 'cumora-codex-cfg-'))
+  tempDirs.push(root)
+  const binDir = join(root, 'bin')
+  // The reporter asked specifically for a home with ordinary separators and
+  // spaces: that is where the quoting in the override has to hold up.
+  const home = join(root, homeName)
+  await mkdir(binDir)
+  await mkdir(home, { recursive: true })
+  const fake = join(binDir, 'codex')
+  await writeFile(fake, FAKE_CODEX, 'utf8')
+  await chmod(fake, 0o755)
+  return {
+    root, home,
+    env: {
+      ...process.env,
+      PATH: `${binDir}${delimiter}${ORIGINAL_PATH ?? ''}`,
+      CUMORA_AGENT_IPC_DIR: join(root, 'ipc'),
+      CUMORA_AGENT_MCP_SHIM: join(root, 'shim.mjs'),
+    },
+  }
+}
+
+async function secureArgv(f: Fixture): Promise<string[]> {
+  const logs: string[] = []
+  await getAdapter('codex').run({
+    home: f.home,
+    prompt: 'hello',
+    env: f.env,
+    model: 'test-model',
+    fastModel: null,
+    onLog: (line) => logs.push(line),
+    signal: new AbortController().signal,
+  })
+  const last = logs.map((l) => l.trim()).filter((l) => l.startsWith('{')).at(-1) ?? '{}'
+  return (JSON.parse(last) as { argv?: string[] }).argv ?? []
+}
+
+test('the project trust override is an inline table, not a dotted dynamic key', { skip: IS_WIN }, async () => {
+  const f = await fixture('agent home')
+  const argv = await secureArgv(f)
+
+  const dotted = argv.filter((a) => a.startsWith('projects.'))
+  assert.deepEqual(
+    dotted, [],
+    'a dotted `projects."<home>".…` override is what Codex 0.150/0.151 refuses under --strict-config',
+  )
+  const inline = argv.find((a) => a.startsWith('projects='))
+  assert.ok(inline, `no projects override at all: ${JSON.stringify(argv)}`)
+  assert.equal(inline, `projects={${JSON.stringify(f.home)}={trust_level="untrusted"}}`)
+})
+
+test('a home containing spaces is still quoted correctly', { skip: IS_WIN }, async () => {
+  // The whole reason the key is dynamic: it is a real filesystem path, and the
+  // one in the report had spaces in it.
+  const f = await fixture('agent home with spaces')
+  const argv = await secureArgv(f)
+  const inline = argv.find((a) => a.startsWith('projects='))
+  assert.ok(inline)
+  assert.ok(inline.includes('agent home with spaces'))
+  // JSON.stringify is the TOML basic-string escape this builder uses; the point
+  // is that the path is quoted at all, so the space cannot split the key.
+  assert.ok(inline.includes(`{${JSON.stringify(f.home)}=`), `path not quoted: ${inline}`)
+})
+
+test('--strict-config is still on, which is what makes the shape matter', { skip: IS_WIN }, async () => {
+  // Without it Codex would tolerate an unrecognised override instead of
+  // refusing to start, and this whole class of failure would be invisible
+  // rather than fixed.
+  const f = await fixture('agent home')
+  assert.ok((await secureArgv(f)).includes('--strict-config'))
+})
+
+test('the untrusted marking survives alongside the rest of the secure set', { skip: IS_WIN }, async () => {
+  // --strict-config validates every override together, so the trust key has to
+  // coexist with the permission, feature and environment ones rather than
+  // merely be well-formed on its own.
+  const f = await fixture('agent home')
+  const argv = await secureArgv(f)
+  for (const expected of [
+    'default_permissions="cumora"',
+    'permissions.cumora.network.enabled=false',
+    'shell_environment_policy.inherit="none"',
+    'web_search="disabled"',
+    'features.hooks=false',
+  ]) {
+    assert.ok(argv.includes(expected), `missing from the secure set: ${expected}`)
+  }
+  assert.ok(argv.some((a) => a.startsWith('projects=') && a.includes('trust_level="untrusted"')))
+})

--- a/server/src/__tests__/agents-computer-engine.test.ts
+++ b/server/src/__tests__/agents-computer-engine.test.ts
@@ -397,7 +397,15 @@ test('Codex one-shot paths send prompts through stdin', async () => {
   assert.equal(runCapture.argv?.some((arg) => arg.includes(`${join(root, 'private-ipc', 'responses')}"="write`)), false)
   assert.ok(runCapture.argv?.includes('web_search="disabled"'))
   assert.ok(runCapture.argv?.includes('features.hooks=false'))
-  assert.ok(runCapture.argv?.includes(`projects.${JSON.stringify(home)}.trust_level="untrusted"`))
+  // Assert the INTENT — this home is marked untrusted — not one spelling of it.
+  // The dotted `projects."<home>".trust_level=…` form used to be here and had
+  // to change because Codex 0.150/0.151 refuses to start on it under
+  // --strict-config (#144); pinning the exact string is what would make the
+  // next necessary rewrite look like a regression.
+  const trustArg = runCapture.argv?.find((arg) => arg.startsWith('projects='))
+  assert.ok(trustArg, `no projects override in argv: ${JSON.stringify(runCapture.argv)}`)
+  assert.ok(trustArg.includes(JSON.stringify(home)), 'the override must name this agent home')
+  assert.ok(trustArg.includes('trust_level="untrusted"'), 'the agent home must be untrusted')
   assert.ok(runCapture.argv?.some((arg) =>
     arg.startsWith('mcp_servers.cumora={')
       && arg.includes(`command=${JSON.stringify(process.execPath)}`)

--- a/server/src/agents/computer/engine.ts
+++ b/server/src/agents/computer/engine.ts
@@ -1669,7 +1669,20 @@ function codexSecureExecArgs(args: { home: string; env: NodeJS.ProcessEnv }, rea
     // Untrusted projects skip project-local config, hooks, and rules. This is a
     // CLI override (highest precedence), so a model cannot plant a more
     // privileged .codex layer for the next one-shot wake.
-    '-c', `projects.${tomlString(args.home)}.trust_level="untrusted"`,
+    //
+    // Written as an inline table rather than the dotted `projects."<home>".…`
+    // form, because Codex 0.150/0.151 rejects a quoted dynamic map key in a
+    // dotted override under --strict-config and refuses to start at all:
+    //   Error loading config.toml: unknown configuration field
+    //     `projects."<agent-home>"` in -c/--config override
+    // Every wake then failed before the model ran, and the undelivered message
+    // stayed durable, so the daemon retried the same failure forever (#144).
+    //
+    // The inline form parses on every version anyone has checked — 0.134.0 and
+    // 0.152.0 here, 0.150.1 and 0.151.0-alpha on the report — whereas the
+    // dotted form does not, so this is the strictly better-supported spelling
+    // rather than a trade.
+    '-c', `projects={${tomlString(args.home)}={trust_level="untrusted"}}`,
     ...codexToolEnvironmentArgs(args),
   ]
   if (!readOnly) {


### PR DESCRIPTION
Closes #144.

Codex 0.150/0.151 refuses a quoted dynamic map key in a dotted `-c` override under `--strict-config`:

```
Error loading config.toml: unknown configuration field `projects."<agent-home>"` in -c/--config override
```

So every secure Codex wake died **before the model started**. And because the undelivered message stays durable, the daemon retried the same failure on every tick rather than degrading once — the failure mode repeats rather than resolves.

The override becomes an inline table, exactly as @vincigiramondo-coder verified in the report:

```diff
-'-c', `projects.${tomlString(args.home)}.trust_level="untrusted"`,
+'-c', `projects={${tomlString(args.home)}={trust_level="untrusted"}}`,
```

## What I could confirm, and what I could not

I have Codex 0.134.0 and installed 0.152.0 to check this, and **I could not reproduce the failure on either** — not with a single override, not with the full secure set, and not with a `config.toml` that already carries a `[projects]` table. Both spellings parse on both versions. It appears to have been fixed upstream after 0.151.

What that *does* establish is the direction of the trade. Feeding the real 14-override set this code builds to both binaries:

```
0.152.0: exit 1  config-parse-error=false
0.134.0: exit 1  config-parse-error=false
```

(exit 1 is the later auth failure — no credentials — which is expected and is not a config error.)

So the inline form parses on every version anyone has checked — **0.134.0 and 0.152.0 here, 0.150.1 and 0.151.0-alpha on the report** — and the dotted form does not. This is the better-supported spelling rather than swapping one risk for another, which is why I am comfortable applying a fix for a failure I could not personally trigger.

The one claim I am taking on the reporter's word is that project-local `.codex` / `AGENTS.md` stays skipped under the new form. Confirming that needs an authenticated turn, which I cannot run. They state they checked it, and the security direction of the difference is benign either way: `projects={…}` sets the whole map rather than one leaf, so any *other* project entry it displaces falls back to codex's default — less trusted, not more.

## The assertion that would have hidden this

The existing test pinned the exact string:

```ts
assert.ok(runCapture.argv?.includes(`projects.${JSON.stringify(home)}.trust_level="untrusted"`))
```

A test written that way makes a *necessary* rewrite look like a regression. It now asserts the intent instead — the override names this agent home, and marks it untrusted — so the security property is pinned while the spelling is free to change when a CLI forces it.

## Regression coverage

`agents-computer-codex-strict-config.test.ts`, four cases, built against the real adapter with a fake `codex` on PATH that echoes its argv:

- no `projects.`-prefixed override survives — a revert to the shape Codex refuses fails here
- a home **containing spaces** is still quoted correctly (the reporter asked for this specifically; it is the case where the quoting has to hold)
- `--strict-config` is still on, since that is what makes the shape matter at all
- the trust key coexists with the rest of the secure set, because `--strict-config` validates every override together rather than each alone

Reverting the one-line fix fails 3 of the 4.

These pin what this repo *builds*, not what a given Codex release accepts — Codex is not installed in CI. The parse behaviour is the manual check above.

## Not addressed here

#145 is the other half of the same report: with this fixed the turn starts, but the standing prompt points the model at a `cumora` CLI that secure mode deliberately made unreachable. That is a prompt/tool-contract change rather than a one-line fix, and it deserves its own discussion.
