### PR TITLE
fix(codex): restore secure project configuration on Windows

### DIFF
--- a/docs/BYOA.md
+++ b/docs/BYOA.md
@@ -264,9 +264,11 @@ fail-closed host boundary:
 - Codex runs one-shot with user config and exec-policy rules ignored. A custom
   permission profile permits minimal runtime reads and writes only under the
   agent home, disables command network, and gives model-spawned commands only
-  an explicit non-secret environment. The agent home is marked untrusted at
-  CLI precedence, and hooks, apps, remote plugins, multi-agent tools, web
-  search, and shell snapshots are disabled. Codex 0.138.0 or newer is required.
+  an explicit non-secret environment. Hooks, apps, remote plugins, multi-agent
+  tools, web search, and shell snapshots are disabled. Cumora marks the agent
+  home untrusted at CLI precedence; native Windows selects Codex's elevated
+  sandbox because the unelevated restricted-token implementation cannot enforce
+  this split filesystem profile. Codex 0.138.0 or newer is required.
 
 Grok, Cursor, OpenCode, pi, Gemini, and Claude on native Windows remain
 available only as a backwards-compatibility escape hatch. They are not merely

--- a/server/src/__tests__/agents-computer-engine.test.ts
+++ b/server/src/__tests__/agents-computer-engine.test.ts
@@ -399,6 +399,7 @@ test('Codex one-shot paths send prompts through stdin', async () => {
   const runCapture = JSON.parse(logs.at(-1) ?? '{}') as { argv?: string[]; stdin?: string }
   assert.ok(runCapture.argv?.includes('default_permissions="cumora"'))
   assert.ok(runCapture.argv?.includes('permissions.cumora.network.enabled=false'))
+  if (IS_WIN) assert.ok(runCapture.argv?.includes('windows.sandbox="elevated"'))
   assert.ok(runCapture.argv?.includes('shell_environment_policy.inherit="none"'))
   assert.equal(runCapture.argv?.some((arg) => arg.includes(`${join(root, 'private-ipc', 'requests')}"="write`)), false)
   assert.equal(runCapture.argv?.some((arg) => arg.includes(`${join(root, 'private-ipc', 'responses')}"="write`)), false)

--- a/server/src/agents/computer/engine.ts
+++ b/server/src/agents/computer/engine.ts
@@ -1615,6 +1615,9 @@ type CodexRpcMsg = {
 
 const CODEX_SECURE_CONFIG_ARGS = [
   '--strict-config',
+  // The unelevated restricted-token sandbox cannot enforce Cumora's split
+  // filesystem profile. Native Windows uses Codex's elevated sandbox instead.
+  ...(IS_WIN ? ['-c', 'windows.sandbox="elevated"'] : []),
   '-c', 'default_permissions="cumora"',
   '-c', 'permissions.cumora.network.enabled=false',
   '-c', 'shell_environment_policy.inherit="none"',


### PR DESCRIPTION
## Summary

- restore the documented `projects.<agent-home>.trust_level="untrusted"` override
- use Codex's elevated sandbox on native Windows so Cumora's split filesystem profile can be enforced
- retain once-per-daemon diagnostics for rejected Cumora-authored config overrides
- update BYOA documentation and regression coverage

## Context

The production incident combined two separate failures.

The `projects.<path>.trust_level` field is valid and strictly parses across the supported Codex versions tested. Removing it weakened the intended defense-in-depth boundary without addressing the reported Windows `permissions` parsing failure.

After preserving structured TOML arguments on Windows, current Codex also refuses Cumora's split filesystem profile under the unelevated restricted-token sandbox. Selecting `windows.sandbox="elevated"` allows the existing permission profile to run without falling back to unsandboxed execution.

No server-side API or schema changes are required.

## Validation

- `npm run server:typecheck`
- Biome lint on the changed TypeScript files
- Codex config rejection tests: 4/4 passed
- relevant engine adapter tests: 2/2 passed
- strict config parsing verified with Codex 0.138.0 and 0.151.0
- real `cumora agent computer --doctor` verification with Codex 0.152.0:
  - big brain: passed
  - small brain: passed