### PR TITLE
release: v0.11.1 — codex sandbox hotfix

### DIFF
--- a/agent-cli/package.json
+++ b/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cumora",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Run Cumora agents on your own machine with Claude Code, Codex, Grok Build, Cursor Agent, OpenCode, or pi (BYOA).",
   "license": "MIT",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cumora",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cumora",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1045.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cumora",
   "private": true,
-  "version": "0.11.0",
+  "version": "0.11.1",
   "type": "module",
   "main": "electron/main.cjs",
   "bin": {


### PR DESCRIPTION
0.11.0 broke every secure codex turn. This ships the fix.

## What 0.11.0 did

For six hours, 94,290 codex turns across **103 workspaces (103 computers, 299 agents)** died before the model read its prompt. Users saw agents that had lost the thread and could not answer; the error named `config.toml` and never named Cumora.

Two independent causes, both read off production rather than a maintainer's own install:

- `78,445 ×` `unknown configuration field \`projects."<agent home>"\`` — a dotted dynamic key that codex refuses under `--strict-config`. **252,589 rejections on POSIX across 121 computers**, including 35,721 on 0.151.0 and 13,153 on 0.152.0. POSIX has no shell in this path, so quote-stripping is ruled out and the spelling itself is the cause.
- `8,372 ×` `expected struct FilesystemPermissionsToml` — cmd.exe eating the quotes inside an inline TOML table. Windows only; zero on POSIX.

## What is in this release

- **#151** (@WhichPaths) — the codex `trust_level` override becomes an inline table, `projects={"<home>"={trust_level="untrusted"}}`. Keeps the security boundary rather than dropping it, and avoids the spelling codex refuses. Its test pins the *intent* (this home is named, and marked untrusted) so the next forced rewrite does not look like a regression.
- **6a70087** (@bingqilinweimaotai) — bypass cmd.exe on Windows by invoking codex's npm entry point through Node, so structured `-c` values keep their quoting.
- **#152** (@WhichPaths) — the standing prompt now describes the surface the agent actually has. Secure mode deliberately removes the shell CLI, and the prompt still said "You act on Cumora through the `cumora` CLI on your PATH", so a secure agent could reason and draft a reply but not publish it. Its posting advice also told agents to use `--file`, which the MCP bridge explicitly refuses. Compatibility-mode wording is asserted byte-identical.
- **#150** (@bingqilinweimaotai) — Windows engine test fixtures follow platform executable conventions, so they test the fake CLI rather than whatever is installed.
- A once-per-daemon diagnostic that names Cumora as the author of a rejected config, quotes what codex said, and points at `CUMORA_BYOA_ALLOW_UNSANDBOXED`.

## Deliberately not in this release

**#146** (immediate engine refresh via an SSE control stream) is good work and merges cleanly, but it opens a persistent connection per daemon across ~830 machines and its author notes it was not tested end to end. Mixing an unverified new channel into a hotfix would make it impossible to tell whether the fleet recovered because of the codex fix. It goes in the next release, once this one is confirmed.

## Verification

1,005 unit tests, 0 failures · `typecheck`, `server:typecheck`, `lint` (439 files), all guards clean.

The fleet auto-updates, so daemons pick this up on their own.