### PR TITLE
release: v0.12.0

### DIFF
--- a/agent-cli/package.json
+++ b/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cumora",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Run Cumora agents on your own machine with Claude Code, Codex, Grok Build, Cursor Agent, OpenCode, or pi (BYOA).",
   "license": "MIT",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cumora",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cumora",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1045.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cumora",
   "private": true,
-  "version": "0.11.1",
+  "version": "0.12.0",
   "type": "module",
   "main": "electron/main.cjs",
   "bin": {


### PR DESCRIPTION
Follows the v0.11.1 hotfix, which is confirmed working: zero config rejections on every 0.11.1 daemon in production.

## The user report this closes

Three symptoms from one workspace, three different causes:

- **"上下文不记得，前一句沟通的都没印象"** — `CodexAdapter.startSession` returned null unless BYOA was explicitly unsandboxed, so every codex turn was a fresh session and agents answered each message having forgotten the previous one. The `-c` overrides are global flags and do apply to `app-server`, so the persistent path now runs under the same filesystem/network/environment/feature profile as the one-shot path — the same override set production has run clean since 0.11.1. A session that dies without consuming any tokens now retries that turn one-shot and latches onto the one-shot path, so the worst case is the pre-persistent behaviour rather than an outage.
- **"上传zip压缩包一直说收不到"** — `daemon.ts` contained no reference to `attachment` anywhere. The file was in `messages.attachment`, was selected by `loadInbox`, reached the daemon, and was then dropped when the digest line was built from `row.body` alone. The agent saying it saw only text was accurate. Name, type, size and the signed URL now ride the line, bounded, http(s) only.
- The third, a Feishu bridge, is not Cumora code — no Feishu integration exists in this repo.

## Also in

- **#138** (@WhichPaths) — the Computers card now says *why* an installed engine is not being used ("version 2.0.9 is older than the secure minimum 2.1.248", "missing sandbox dependency: bubblewrap"). That reason existed and only ever reached the daemon's own stdout. Reporting only: blocked ids never enter the list that picks an adapter.
- **#146** (@bingqilinweimaotai) — engine refresh reaches an online daemon immediately over an SSE control stream instead of waiting up to 30s for the next heartbeat. Held out of the hotfix on purpose; the DB flag is still written first, so Redis or SSE failing degrades to exactly today's heartbeat.
- **#124** (@wg2038) — turns per human message, the other half of the #70 ledger, merged with its reported aggregate bug fixed: `avg`/`percentile_cont` read the raw LEFT JOIN column and SQL aggregates skip NULLs, so zero-turn messages vanished from the two numbers the panel exists to report. Verified against Postgres — 4 messages, 6 turns, avg 1.50, median 1.00.

## Verification

1,030 unit tests, 0 failures · `typecheck`, `server:typecheck`, `lint` (447 files), guards clean.