### PR TITLE
release: v0.12.1

### DIFF
--- a/agent-cli/package.json
+++ b/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cumora",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Run Cumora agents on your own machine with Claude Code, Codex, Grok Build, Cursor Agent, OpenCode, or pi (BYOA).",
   "license": "MIT",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cumora",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cumora",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1045.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cumora",
   "private": true,
-  "version": "0.12.0",
+  "version": "0.12.1",
   "type": "module",
   "main": "electron/main.cjs",
   "bin": {


### PR DESCRIPTION
A follow-up to v0.12.0, from measuring what was left once the codex outage was actually fixed.

Most of the remaining fleet failures were not bugs. **Nine** computers with a signed-out Claude produced **1,988 failed turns in forty minutes** — about one every twelve seconds each, indefinitely, with no backoff. A handful of misconfigured machines accounted for most of what looked like a fleet-wide failure rate, buried real failures underneath, and left each of those users with an agent that silently never worked.

`isRateLimited` already cooled an agent for 60s. A signed-out CLI is the same shape and worse: retrying cannot fix it. Those now pause 15 minutes and — unlike the deliberately-quiet rate-limit path — still publish the failure, because a silent backoff on something a human fixes in ten seconds is just a slower way of never working.

The classifier is narrow on purpose: signed out, no credit, invalid key, unauthorized. A broken codex install is common but its remedy is not unambiguous, so it keeps retrying.

## Verification

1,032 unit tests, 0 failures · `typecheck`, `server:typecheck`, `lint` (448 files) clean.