### PR TITLE
release: v0.13.0

### DIFF
--- a/agent-cli/package.json
+++ b/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cumora",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Run Cumora agents on your own machine with Claude Code, Codex, Antigravity, and other BYOA engines.",
   "license": "MIT",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cumora",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cumora",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1045.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cumora",
   "private": true,
-  "version": "0.12.1",
+  "version": "0.13.0",
   "type": "module",
   "main": "electron/main.cjs",
   "bin": {


### PR DESCRIPTION
- **#155** (@Aubrey45) — Antigravity (`agy`) as a BYOA engine, wired into every registry list so the guard passes rather than a half-wired engine billing its runs to Claude. It deliberately does not claim `SANDBOXED_ENGINE_IDS` membership until its surface is independently proven, and normalizes cumulative session usage into per-turn deltas so resuming does not rebill prior turns.
- **#157** (@WhichPaths) — monthly and yearly recurrence stepped forward from the *previous* occurrence, so one impossible date moved the entire series permanently: "monthly on the 31st" became "the 3rd of every month, starting in March", and a Feb 29 yearly became Mar 1 forever. Now indexed from the seed with the day-of-month clamped per target month. Biweekly-with-weekdays was broken by the same root cause.

## Verification

1,054 unit tests, 0 failures · `typecheck`, `server:typecheck`, `lint` (451 files), all guards clean.