### PR TITLE
release: v0.13.1

### DIFF
--- a/agent-cli/package.json
+++ b/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cumora",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Run Cumora agents on your own machine with Claude Code, Codex, Antigravity, and other BYOA engines.",
   "license": "MIT",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cumora",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cumora",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1045.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cumora",
   "private": true,
-  "version": "0.13.0",
+  "version": "0.13.1",
   "type": "module",
   "main": "electron/main.cjs",
   "bin": {


### PR DESCRIPTION
A one-fix patch on top of v0.13.0.

- **#153** (@bingqilinweimaotai) — Codex on native Windows now selects `windows.sandbox="elevated"`. The unelevated restricted-token sandbox cannot enforce Cumora's split filesystem profile and codex refuses to run rather than run unsandboxed, so Windows daemons could not host codex at all. The arg is behind `IS_WIN`; POSIX argv is byte-identical to v0.13.0. The key strict-parses on codex 0.138.0, 0.140.0 and 0.144.6, and on a machine without the one-time elevated setup codex falls back to the state it is in today, so nothing gets worse.

## Verification

`typecheck`, `server:typecheck`, `lint` (451 files), all three guards clean on the merged tree; 1,037 unit tests pass locally, the 2 remaining failures need a local Postgres / the worker's own deps and are green in CI.

https://claude.ai/code/session_01SevbW9qCBbzrjfLMy14A31
