### PR TITLE
fix(db): a table the DDL later drops is not a schema expectation

### DIFF
--- a/server/src/__tests__/db-schema-sentinels.test.ts
+++ b/server/src/__tests__/db-schema-sentinels.test.ts
@@ -49,3 +49,18 @@ test('commented-out DDL does not become a phantom expectation', () => {
     assert.match(c.column, /^[a-z_][a-z0-9_]*$/)
   }
 })
+
+test('a table the DDL creates and later drops is not an expectation', () => {
+  const { tables, columns } = ddlExpectations()
+  // The DDL still carries `CREATE TABLE IF NOT EXISTS email_verification_tokens`
+  // followed by the migration that dropped it when password auth was removed.
+  // Deriving expectations from the CREATEs alone made it a phantom: production
+  // could never be "current", the 40P01 shortcut never fired, and the v0.13.1
+  // rollout on 2026-09-02 crash-looped its migrate init container under load.
+  for (const t of ['email_verification_tokens', 'password_reset_tokens', 'notion_pages', 'github_branches']) {
+    assert.ok(!tables.includes(t), `${t} is dropped by the DDL and must not be expected`)
+    assert.ok(!columns.some((c) => c.table === t), `no column of dropped table ${t} may be expected`)
+  }
+  // The live tables next to them are still promised.
+  for (const t of ['users', 'sessions', 'user_identities']) assert.ok(tables.includes(t), `${t} must be expected`)
+})

--- a/server/src/db/migrate.ts
+++ b/server/src/db/migrate.ts
@@ -2203,10 +2203,30 @@ export async function releaseMigrationClient(client: MigrationClient): Promise<v
  *  cannot become a phantom expectation. */
 export function ddlExpectations(): { tables: string[]; columns: Array<{ table: string; column: string }> } {
   const sql = DDL.replace(/--[^\n]*/g, '')
+  // A table the DDL creates and LATER drops (the retired auth-token tables) is
+  // not a promise — it is history. Left in, it is a phantom expectation that can
+  // never be satisfied: `schemaAlreadyCurrent` answers "not current" on every
+  // boot, the lock-contention shortcut below never fires, and a deploy under
+  // sustained traffic crash-loops on 40P01 with nothing to actually apply.
+  // That is exactly how the v0.13.1 rollout wedged on 2026-09-02.
+  // "Later" is by position in the DDL: a DROP that precedes a CREATE of the same
+  // name is a reset, and the re-created table is still promised.
+  const lastDropAt = new Map<string, number>()
+  for (const m of sql.matchAll(/DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?([a-z_][a-z0-9_]*)/gi)) {
+    lastDropAt.set((m[1] as string).toLowerCase(), m.index ?? 0)
+  }
+  for (const m of sql.matchAll(/ALTER\s+TABLE\s+([a-z_][a-z0-9_]*)\s+DROP\s+COLUMN\s+(?:IF\s+EXISTS\s+)?([a-z_][a-z0-9_]*)/gi)) {
+    lastDropAt.set(`${(m[1] as string).toLowerCase()}.${(m[2] as string).toLowerCase()}`, m.index ?? 0)
+  }
+  const droppedAfter = (key: string, at: number) => (lastDropAt.get(key) ?? -1) > at
   const tables = [...sql.matchAll(/CREATE\s+TABLE\s+IF\s+NOT\s+EXISTS\s+([a-z_][a-z0-9_]*)/gi)]
-    .map((m) => m[1] as string)
+    .map((m) => ({ name: (m[1] as string).toLowerCase(), at: m.index ?? 0 }))
+    .filter((t) => !droppedAfter(t.name, t.at))
+    .map((t) => t.name)
   const columns = [...sql.matchAll(/ALTER\s+TABLE\s+([a-z_][a-z0-9_]*)\s+ADD\s+COLUMN\s+IF\s+NOT\s+EXISTS\s+([a-z_][a-z0-9_]*)/gi)]
-    .map((m) => ({ table: m[1] as string, column: m[2] as string }))
+    .map((m) => ({ table: (m[1] as string).toLowerCase(), column: (m[2] as string).toLowerCase(), at: m.index ?? 0 }))
+    .filter((c) => !droppedAfter(c.table, c.at) && !droppedAfter(`${c.table}.${c.column}`, c.at))
+    .map((c) => ({ table: c.table, column: c.column }))
   return { tables: [...new Set(tables)], columns }
 }
 


### PR DESCRIPTION
## What broke

The v0.13.1 deploy (run 33617801994) timed out: the new pod's `migrate` init container crash-looped with

```
[db] schema is NOT current — missing: email_verification_tokens
[migrate-bin] transient lock error 40P01 (attempt 1/8) — retrying …
…
[migrate-bin] failed: error: deadlock detected
```

Old pods kept serving; nothing user-facing changed. The release itself (#153, a Windows-only codex arg) has no migration.

## Why

ec7d557 derives the schema sentinels from the DDL text. The DDL still contains `CREATE TABLE IF NOT EXISTS email_verification_tokens` **and**, further down, `DROP TABLE IF EXISTS email_verification_tokens` (password auth removal). The derivation only reads the CREATEs, so production can never be "current". That disables the whole 40P01/55P03 shortcut: when the idempotent DDL batch deadlocks against live traffic — which it does under sustained load, every attempt — there is no escape hatch, and the pod never starts. v0.13.0 deployed through the same code only because its batch happened not to deadlock.

## Fix

`ddlExpectations()` now drops any table or column whose last `DROP TABLE` / `DROP COLUMN` in the DDL comes after its CREATE/ADD (order-aware, so a drop-then-recreate is still a promise). The new test fails on main and passes here; it pins the four retired tables out and `users` / `sessions` / `user_identities` in.

## Verification

`db-schema-sentinels` 4/4 (the new case fails without the fix), `server:typecheck`, biome clean. Derived expectations: 60 tables, 71 columns, no phantom.

https://claude.ai/code/session_01SevbW9qCBbzrjfLMy14A31
