### PR TITLE
release: v0.13.2

### DIFF
--- a/agent-cli/package.json
+++ b/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cumora",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Run Cumora agents on your own machine with Claude Code, Codex, Antigravity, and other BYOA engines.",
   "license": "MIT",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cumora",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cumora",
-      "version": "0.13.1",
+      "version": "0.13.2",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1045.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cumora",
   "private": true,
-  "version": "0.13.1",
+  "version": "0.13.2",
   "type": "module",
   "main": "electron/main.cjs",
   "bin": {


### PR DESCRIPTION
The v0.13.1 rollout never reached production: its migrate init container crash-looped on `40P01 deadlock detected` because the schema-current sentinel could never be satisfied. This patch carries the fix and re-ships v0.13.1's change.

- **#161** — `ddlExpectations()` derived every `CREATE TABLE IF NOT EXISTS` as a promise, including `email_verification_tokens`, which the same DDL drops further down. Production can never have it, so `schemaAlreadyCurrent` was permanently false, the 40P01/55P03 escape hatch never fired, and a deploy under sustained traffic had no way through. Expectations now exclude anything the DDL drops after creating it (order-aware). The regression test fails on the previous main.
- **#153** (@bingqilinweimaotai, from v0.13.1) — Codex on native Windows selects `windows.sandbox="elevated"`; POSIX argv unchanged.

## Verification

`typecheck`, `server:typecheck`, `lint`, all three guards and the full unit + integration suite green in CI on #161; `db-schema-sentinels` 4/4 locally with the new case failing without the fix.

https://claude.ai/code/session_01SevbW9qCBbzrjfLMy14A31
