### PR TITLE
fix(byoa): complete engine registry wiring and default model pins for gemini and qwen

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,19 @@ OPENAI_API_KEY=sk-...
 # OPENAI_COMPACTION_MODEL=gpt-5.4-mini
 # OPENAI_IMAGE_MODEL=gpt-image-2
 
+# ─── BYOA default model pins (optional) ──────────────────────────────────
+# Deploy-level default models for paired BYOA computers when an agent row has
+# no explicit model override. See docs/COORDINATION.md.
+# CUMORA_DEFAULT_CLAUDE_MODEL=claude-opus-4-7
+# CUMORA_DEFAULT_CODEX_MODEL=
+# CUMORA_DEFAULT_GROK_MODEL=
+# CUMORA_DEFAULT_CURSOR_MODEL=
+# CUMORA_DEFAULT_OPENCODE_MODEL=
+# CUMORA_DEFAULT_PI_MODEL=
+# CUMORA_DEFAULT_GEMINI_MODEL=
+# CUMORA_DEFAULT_QWEN_MODEL=
+# CUMORA_DEFAULT_ANTIGRAVITY_MODEL=
+
 # ─── OrcaRouter (optional) ─────────────────────────────────────────────────
 # OpenAI-compatible AI gateway (https://www.orcarouter.ai). An agent opts in
 # by prefixing its model id with `orcarouter/`, e.g. `orcarouter/openai/gpt-4o-mini`.

--- a/docs/COORDINATION.md
+++ b/docs/COORDINATION.md
@@ -673,6 +673,10 @@ one and re-test. Don't pile on.
 | `CUMORA_DEFAULT_GROK_MODEL` | unset | Same shape for Grok Build. |
 | `CUMORA_DEFAULT_CURSOR_MODEL` | unset | Same shape for Cursor Agent; blank lets Cursor use Auto. |
 | `CUMORA_DEFAULT_OPENCODE_MODEL` | unset | Same shape for OpenCode; use its `provider/model` id, or leave blank for the configured default. |
+| `CUMORA_DEFAULT_PI_MODEL` | unset | Same shape for pi; leave blank for the configured default. |
+| `CUMORA_DEFAULT_GEMINI_MODEL` | unset | Same shape for Gemini CLI; leave blank for the configured default. |
+| `CUMORA_DEFAULT_QWEN_MODEL` | unset | Same shape for Qwen Code; leave blank for the configured default. |
+| `CUMORA_DEFAULT_ANTIGRAVITY_MODEL` | unset | Same shape for Antigravity; leave blank for the configured default. |
 | `CUMORA_BYOA_MAX_CONCURRENT_BIG_BRAIN` | 6 | Per-computer big-brain turn cap. Drop to 2-4 for very tight quotas; raise for higher tiers. |
 | `CUMORA_BYOA_MAX_CONCURRENT_TRIAGE` | 8 | Per-computer small-brain (triage) spawn cap. Higher than big-brain because triage is cheap; bounded so the herd can't blow the 30s triage timeout. |
 | `CUMORA_BYOA_MIN_SPAWN_INTERVAL_MS` | 500 | Deterministic minimum interval between local-CLI spawn starts — the AdaptivePacer's base (3, 3b). |

--- a/scripts/guard-engine-registry.mjs
+++ b/scripts/guard-engine-registry.mjs
@@ -156,6 +156,34 @@ const CHECKS = [
     needle: (id) => `'byoa-${id}'`,
     fix: "widen ApiTriageSource with 'byoa-<id>'",
   },
+  {
+    file: 'server/src/agents/computer/registry.ts',
+    what: 'ENGINE_BINS',
+    body: (s) => extract(s, /const ENGINE_BINS(?::[^=]*)? = \{([\s\S]*?)\n\}/),
+    needle: (id) => `${id}:`,
+    fix: 'add the binary mapping to ENGINE_BINS',
+  },
+  {
+    file: 'server/src/agents/computer/registry.ts',
+    what: 'listAgentsForComputer default model fallback',
+    body: (s) => extract(s, /export async function listAgentsForComputer[\s\S]*?return rows\.map\(\(r\) => \{([\s\S]*?)\n\s{2}\}\)/),
+    needle: (id) => `r.engine === '${id}'`,
+    fix: "add a default model fallback for '<id>' in listAgentsForComputer",
+  },
+  {
+    file: 'server/src/agents/computer/daemon.ts',
+    what: 'authFailureHint',
+    body: (s) => extract(s, /export function authFailureHint[\s\S]*?\{([\s\S]*?)\n\}/),
+    needle: (id) => `engine === '${id}'`,
+    fix: "add an auth failure hint for '<id>' in authFailureHint",
+  },
+  {
+    file: 'server/src/agents/computer/daemon.ts',
+    what: 'triageModel',
+    body: (s) => extract(s, /private triageModel\(\): string \{([\s\S]*?)\n\s{2}\}/),
+    needle: (id) => `this.adapter.id === '${id}'`,
+    fix: "add triage model resolution for '<id>' in triageModel",
+  },
 ]
 
 /** The spawn guard keys on BINARY names, not engine ids (cursor's binary is

--- a/server/src/__tests__/agents-computer-daemon-auth-hint.test.ts
+++ b/server/src/__tests__/agents-computer-daemon-auth-hint.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { authFailureHint } from '../agents/computer/daemon.js'
+import { ENGINE_IDS, type EngineId } from '../agents/computer/engine.js'
+
+test('authFailureHint provides specific guidance for every supported engine', () => {
+  for (const engine of ENGINE_IDS) {
+    const hint = authFailureHint(engine as EngineId, '401 invalid api key or unauthorized')
+    assert.ok(hint.length > 0, `hint for ${engine} should not be empty`)
+    // None of the non-codex engines should mention Codex
+    if (engine !== 'codex') {
+      assert.ok(!hint.includes('Open Codex'), `hint for ${engine} should not tell the user to Open Codex: "${hint}"`)
+    }
+  }
+})
+
+test('authFailureHint correctly mentions the relevant CLI/tool for each engine', () => {
+  assert.match(authFailureHint('claude', 'quota exceeded'), /Claude Code/)
+  assert.match(authFailureHint('codex', 'quota exceeded'), /Codex/)
+  assert.match(authFailureHint('grok', 'quota exceeded'), /grok/)
+  assert.match(authFailureHint('cursor', 'quota exceeded'), /cursor-agent/)
+  assert.match(authFailureHint('opencode', 'quota exceeded'), /opencode/)
+  assert.match(authFailureHint('pi', 'quota exceeded'), /pi/)
+  assert.match(authFailureHint('gemini', 'quota exceeded'), /gemini/)
+  assert.match(authFailureHint('qwen', 'quota exceeded'), /qwen/)
+  assert.match(authFailureHint('antigravity', 'quota exceeded'), /agy/)
+})
+
+test('authFailureHint handles context overflow and poisoned body sentinels', () => {
+  assert.match(authFailureHint('gemini', 'context window overflowed max tokens'), /context window/)
+  assert.match(authFailureHint('qwen', 'lone surrogate split emoji poisoned'), /poisoned/)
+  assert.match(authFailureHint('gemini', 'unrelated socket reset error'), /daemon terminal for details/)
+})

--- a/server/src/__tests__/agents-computer-engine-detect.test.ts
+++ b/server/src/__tests__/agents-computer-engine-detect.test.ts
@@ -8,6 +8,8 @@ import assert from 'node:assert/strict'
 
 process.env.CUMORA_RUNTIME_CLIENT = 'http'
 process.env.CUMORA_DEFAULT_CLAUDE_MODEL = 'claude-opus-4-7'
+process.env.CUMORA_DEFAULT_GEMINI_MODEL = 'gemini-2.5-pro'
+process.env.CUMORA_DEFAULT_QWEN_MODEL = 'qwen3-coder-plus'
 process.env.CUMORA_DEFAULT_ANTIGRAVITY_MODEL = 'Gemini 3.5 Flash (High)'
 process.env.OPENAI_API_KEY ??= 'test-key'
 
@@ -68,6 +70,8 @@ test('listAgentsForComputer keeps an explicit model and pins CUMORA_DEFAULT_* wh
         { id: 'bram', name: 'Bram', role: 'engineer', systemPrompt: null, engine: 'claude', model: 'stale-pin', fastModel: 'haiku' },
         { id: 'saga', name: 'Saga', role: 'writer', systemPrompt: null, engine: 'claude', model: null, fastModel: null },
         { id: 'aster', name: 'Aster', role: 'reviewer', systemPrompt: null, engine: 'antigravity', model: null, fastModel: null },
+        { id: 'atlas', name: 'Atlas', role: 'analyst', systemPrompt: null, engine: 'gemini', model: null, fastModel: null },
+        { id: 'orion', name: 'Orion', role: 'coder', systemPrompt: null, engine: 'qwen', model: null, fastModel: null },
       ] }
     }
     return { rows: [] }
@@ -79,6 +83,10 @@ test('listAgentsForComputer keeps an explicit model and pins CUMORA_DEFAULT_* wh
   assert.equal(agents[1]?.engine, 'claude')
   assert.equal(agents[2]?.model, 'Gemini 3.5 Flash (High)')
   assert.equal(agents[2]?.engine, 'antigravity')
+  assert.equal(agents[3]?.model, 'gemini-2.5-pro')
+  assert.equal(agents[3]?.engine, 'gemini')
+  assert.equal(agents[4]?.model, 'qwen3-coder-plus')
+  assert.equal(agents[4]?.engine, 'qwen')
 })
 
 test('reportDetectedEngines keeps the previous default first when it is still installed', async () => {

--- a/server/src/agents/computer/daemon.ts
+++ b/server/src/agents/computer/daemon.ts
@@ -704,7 +704,7 @@ export function isStaleResumeError(err: string): boolean {
   return STALE_RESUME_RE.test(engineDiagnosticProse(err))
 }
 
-function authFailureHint(engine: EngineId, detail: string): string {
+export function authFailureHint(engine: EngineId, detail: string): string {
   if (CONTEXT_OVERFLOW_RE.test(detail)) {
     return 'The agent filled up its context window. Its session has been reset automatically — just wake the agent again and it will start fresh.'
   }
@@ -716,6 +716,9 @@ function authFailureHint(engine: EngineId, detail: string): string {
   }
   if (engine === 'claude') {
     return 'Open Claude Code on that computer and sign in, refresh quota, or add credits, then wake the agent again.'
+  }
+  if (engine === 'codex') {
+    return 'Open Codex on that computer and refresh its login or quota, then wake the agent again.'
   }
   if (engine === 'grok') {
     return 'Open Grok Build on that computer and run `grok login`, or set XAI_API_KEY, then wake the agent again.'
@@ -729,10 +732,16 @@ function authFailureHint(engine: EngineId, detail: string): string {
   if (engine === 'pi') {
     return 'Open pi on that computer and run `/login` for its provider (or fix the API key / quota), then wake the agent again.'
   }
+  if (engine === 'gemini') {
+    return 'Open Gemini CLI on that computer and run `gemini` to refresh its login, API key, or quota, then wake the agent again.'
+  }
+  if (engine === 'qwen') {
+    return 'Open Qwen Code on that computer and run `qwen` to refresh its login, API key, or quota, then wake the agent again.'
+  }
   if (engine === 'antigravity') {
     return 'Open Antigravity on that computer and run `agy` to refresh its login, model access, or quota, then wake the agent again.'
   }
-  return 'Open Codex on that computer and refresh its login or quota, then wake the agent again.'
+  return 'Check the daemon terminal for details, then wake the agent again.'
 }
 
 function missingEngineMessage(): string {
@@ -2093,16 +2102,19 @@ class AgentRunner {
   }
 
   /** Triage model id for pricing, honoring CUMORA_TRIAGE_MODEL. Cursor,
-   *  OpenCode and pi have no universal cheap alias, so a reported/pinned stream
+   *  OpenCode, pi and Antigravity have no universal cheap alias, so a reported/pinned stream
    *  model wins and the agent model is only a fallback. */
   private triageModel(): string {
     if (process.env.CUMORA_TRIAGE_MODEL) return process.env.CUMORA_TRIAGE_MODEL
     if (this.adapter.id === 'claude') return 'haiku'
     if (this.adapter.id === 'grok') return 'grok-4.5'
     if (this.adapter.id === 'codex') return 'gpt-5.4-mini'
+    if (this.adapter.id === 'gemini') return 'gemini-2.5-flash-lite'
+    if (this.adapter.id === 'qwen') return 'qwen3-coder-flash'
     if (this.adapter.id === 'opencode') return this.agent.model ?? '<opencode-default>'
     if (this.adapter.id === 'pi') return this.agent.model ?? '<pi-default>'
     if (this.adapter.id === 'antigravity') return this.agent.model ?? '<antigravity-default>'
+    if (this.adapter.id === 'cursor') return this.agent.model ?? '<cursor-default>'
     return this.agent.model ?? '<cursor-default>'
   }
 

--- a/server/src/agents/computer/registry.ts
+++ b/server/src/agents/computer/registry.ts
@@ -94,7 +94,7 @@ export function mergeDetectedEngines(current: string[], detected: string[]): str
   return same ? null : next
 }
 
-const ENGINE_BINS: Record<string, string> = {
+const ENGINE_BINS: Record<Exclude<EngineId, 'managed'>, string> = {
   claude: 'claude',
   codex: 'codex',
   grok: 'grok',
@@ -157,7 +157,7 @@ function sanitizeVersionFields(rec: Record<string, unknown>): Partial<DetectedEn
 /** An engine we know is advertised but have no PATH/version report for. */
 function unreportedEngine(id: string): DetectedEngine {
   return {
-    id, bin: ENGINE_BINS[id] ?? id, path: null,
+    id, bin: ENGINE_BINS[id as keyof typeof ENGINE_BINS] ?? id, path: null,
     version: null, latest: null, outdated: false, updateCommand: null, blockedReason: null,
   }
 }
@@ -188,7 +188,7 @@ export function sanitizeDetectedEngines(
     const rec = item as Record<string, unknown>
     const id = typeof rec.id === 'string' ? rec.id : ''
     if (!PAIRABLE_ENGINES.has(id) || !allowed.includes(id)) continue
-    const bin = typeof rec.bin === 'string' && rec.bin.trim() ? rec.bin.trim() : (ENGINE_BINS[id] ?? id)
+    const bin = typeof rec.bin === 'string' && rec.bin.trim() ? rec.bin.trim() : (ENGINE_BINS[id as keyof typeof ENGINE_BINS] ?? id)
     const path = typeof rec.path === 'string' && rec.path.trim() ? rec.path.trim() : null
     // A reason is only meaningful on an engine we actually refused. Accepting
     // one on a runnable engine would let a daemon mark a working engine broken.
@@ -563,6 +563,7 @@ export async function mintAgentRuntimeToken(args: {
  *  (CUMORA_DEFAULT_CLAUDE_MODEL / CUMORA_DEFAULT_CODEX_MODEL /
  *  CUMORA_DEFAULT_GROK_MODEL / CUMORA_DEFAULT_CURSOR_MODEL /
  *  CUMORA_DEFAULT_OPENCODE_MODEL / CUMORA_DEFAULT_PI_MODEL /
+ *  CUMORA_DEFAULT_GEMINI_MODEL / CUMORA_DEFAULT_QWEN_MODEL /
  *  CUMORA_DEFAULT_ANTIGRAVITY_MODEL) so every BYOA
  *  daemon gets a consistent pin — independent of whatever model the local
  *  engine CLI happens to default to today. Critical: a model
@@ -583,6 +584,8 @@ export async function listAgentsForComputer(computerId: string): Promise<
   const cursorDefault = process.env.CUMORA_DEFAULT_CURSOR_MODEL?.trim() || null
   const openCodeDefault = process.env.CUMORA_DEFAULT_OPENCODE_MODEL?.trim() || null
   const piDefault = process.env.CUMORA_DEFAULT_PI_MODEL?.trim() || null
+  const geminiDefault = process.env.CUMORA_DEFAULT_GEMINI_MODEL?.trim() || null
+  const qwenDefault = process.env.CUMORA_DEFAULT_QWEN_MODEL?.trim() || null
   const antigravityDefault = process.env.CUMORA_DEFAULT_ANTIGRAVITY_MODEL?.trim() || null
   return rows.map((r) => {
     if (r.model) return r
@@ -598,9 +601,13 @@ export async function listAgentsForComputer(computerId: string): Promise<
               ? openCodeDefault
               : r.engine === 'pi'
                 ? piDefault
-                : r.engine === 'antigravity'
-                  ? antigravityDefault
-                : null
+                : r.engine === 'gemini'
+                  ? geminiDefault
+                  : r.engine === 'qwen'
+                    ? qwenDefault
+                    : r.engine === 'antigravity'
+                      ? antigravityDefault
+                    : null
     return dflt ? { ...r, model: dflt } : r
   })
 }


### PR DESCRIPTION
### Summary

When Bring-Your-Own-Agent (BYOA) engines `gemini` and `qwen` were added, several downstream mapping and fallback sites were not updated:

1. **`daemon.ts` auth failure hints**: `authFailureHint()` lacked branches for `gemini` and `qwen`, falling through to `return 'Open Codex on that computer and refresh its login or quota, then wake the agent again.'`.
2. **`daemon.ts` triage model resolution**: `triageModel()` lacked branches for `gemini` and `qwen`, falling through to `<cursor-default>` in the LLM cost ledger (`llm_calls`) rather than using their respective triage models (`gemini-2.5-flash-lite` and `qwen3-coder-flash`).
3. **`registry.ts` default model pins**: `listAgentsForComputer()` did not handle `CUMORA_DEFAULT_GEMINI_MODEL` and `CUMORA_DEFAULT_QWEN_MODEL`, causing agents without explicit model overrides to receive `null` instead of the deploy-level default.
4. **`registry.ts` type safety**: `ENGINE_BINS` was declared as `Record<string, string>`. It is now typed as `Record<Exclude<EngineId, 'managed'>, string>` (consistent with `PAIRABLE`) so missing engines are caught at compile time.
5. **`guard-engine-registry.mjs`**: Extended to assert `authFailureHint`, `triageModel`, `listAgentsForComputer`, and `ENGINE_BINS` across all engines in `ENGINE_IDS`.
6. **Documentation & Env Example**: Updated `docs/COORDINATION.md` and `.env.example` with `CUMORA_DEFAULT_PI_MODEL`, `CUMORA_DEFAULT_GEMINI_MODEL`, `CUMORA_DEFAULT_QWEN_MODEL`, and `CUMORA_DEFAULT_ANTIGRAVITY_MODEL`.

### Testing

- `npm run lint`: 452 files checked, 0 errors, 0 warnings.
- `npm run typecheck` & `npm run server:typecheck`: 0 errors.
- `npm run guard:big-brain`, `guard:llm-tracked`, `guard:engine-registry`: all passed.
- `npm test`: 1058 passing (added `server/src/__tests__/agents-computer-daemon-auth-hint.test.ts` and updated `agents-computer-engine-detect.test.ts`).
- `npm run test:integration`: 269 passing.