### PR TITLE
fix(byoa): a warning's version number must not satisfy the secure floor

### DIFF
--- a/server/src/__tests__/cli-version-noise.test.ts
+++ b/server/src/__tests__/cli-version-noise.test.ts
@@ -1,0 +1,110 @@
+/**
+ * A CLI's reported version gates whether Cumora will run it in secure mode
+ * (`SECURE_ENGINE_MIN_VERSIONS`: claude ≥ 2.1.248, codex ≥ 0.138.0), so reading
+ * the WRONG number out of its output is a security question, not a cosmetic one.
+ *
+ * The probe merged stdout and stderr into one blob and took the first
+ * version-shaped token in it. Warnings arrive first and routinely carry a
+ * version:
+ *
+ *   npm warn EBADENGINE Unsupported engine {
+ *     required: { node: '>=20.19.0' }
+ *   }
+ *   claude 2.0.9 (Claude Code)
+ *
+ * That read as `20.19.0`, cleared the 2.1.248 floor, and a Claude Code that
+ * cannot be sandboxed was treated as one that can. The gate failed OPEN, which
+ * is the direction that matters.
+ *
+ * Run: node --import tsx --test server/src/__tests__/cli-version-noise.test.ts
+ */
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+process.env.CUMORA_RUNTIME_CLIENT = 'http'
+process.env.OPENAI_API_KEY ??= 'test-key'
+
+const { parseCliVersion, isCliVersionAtLeast, versionFromOutput } =
+  await import('../agents/computer/cli-version.js')
+
+const NPM_ENGINE_WARNING = [
+  'npm warn EBADENGINE Unsupported engine {',
+  "  required: { node: '>=20.19.0' },",
+  "  current: { node: 'v18.20.4' }",
+  '}',
+].join('\n')
+
+// ── the stream separation, which is the structural half ────────────────────
+
+test('a stderr warning cannot outrank the version on stdout', () => {
+  // The realistic shape: the CLI prints its version on stdout, the package
+  // manager complains on stderr. Merging them let the complaint win.
+  const out = { stdout: 'claude 2.0.9 (Claude Code)', stderr: NPM_ENGINE_WARNING, combined: '' }
+  assert.equal(versionFromOutput(out), '2.0.9')
+  assert.equal(isCliVersionAtLeast(versionFromOutput(out), '2.1.248'), false)
+})
+
+test('an engine that reports only on stderr is still read', () => {
+  // stderr is a fallback, not ignored — some CLIs really do print there, and
+  // dropping it would fail closed on a perfectly good engine.
+  assert.equal(versionFromOutput({ stdout: '', stderr: 'some-cli 1.4.0', combined: '' }), '1.4.0')
+})
+
+test('nothing anywhere reports nothing, rather than guessing', () => {
+  // The caller treats null as "could not verify", which fails closed at the
+  // secure floor. That is the right answer here.
+  assert.equal(versionFromOutput({ stdout: '', stderr: '', combined: '' }), null)
+  assert.equal(isCliVersionAtLeast(null, '2.1.248'), false)
+})
+
+// ── the line filter, for warnings that land on stdout ───────────────────────
+
+test('an npm warning on stdout does not become the version', () => {
+  assert.equal(parseCliVersion(`${NPM_ENGINE_WARNING}\nclaude 2.0.9 (Claude Code)`), '2.0.9')
+})
+
+test('a node deprecation notice does not become the version', () => {
+  assert.equal(
+    parseCliVersion('(node:12345) [DEP0040] DeprecationWarning: punycode is deprecated. Use 6.1.0.\nclaude 2.0.9'),
+    '2.0.9',
+  )
+})
+
+test('warnings alone yield null instead of a borrowed number', () => {
+  // Failing closed is the point: no version means the secure gate refuses.
+  assert.equal(parseCliVersion(NPM_ENGINE_WARNING), null)
+  assert.equal(parseCliVersion('(node:1) [DEP0040] DeprecationWarning: use 6.1.0'), null)
+})
+
+// ── the shapes that already worked must keep working ───────────────────────
+
+test('the ordinary version lines are unchanged', () => {
+  assert.equal(parseCliVersion('1.2.3'), '1.2.3')
+  assert.equal(parseCliVersion('claude 1.0.88 (Claude Code)'), '1.0.88')
+  assert.equal(parseCliVersion('v2.10.0'), '2.10.0')
+  assert.equal(parseCliVersion('codex-cli 0.5.1-alpha.2'), '0.5.1-alpha.2')
+  assert.equal(parseCliVersion('2026.08.30'), '2026.08.30')
+  assert.equal(parseCliVersion('no version here'), null)
+  assert.equal(parseCliVersion(''), null)
+  assert.equal(parseCliVersion(null), null)
+})
+
+test('a version whose own line merely contains the word warning still reads', () => {
+  // The filter keys on how a line STARTS, so a CLI whose banner mentions
+  // warnings in passing is not silenced.
+  assert.equal(parseCliVersion('codex 0.152.0 — no warnings configured'), '0.152.0')
+})
+
+// ── and the gate itself, on the numbers that matter ────────────────────────
+
+test('the secure floor still admits and refuses the right versions', () => {
+  // 248 vs 9 has to compare numerically; a string compare would put 2.1.9 above
+  // 2.1.248 and admit an engine a year too old.
+  assert.equal(isCliVersionAtLeast('2.1.248', '2.1.248'), true)
+  assert.equal(isCliVersionAtLeast('2.1.250', '2.1.248'), true)
+  assert.equal(isCliVersionAtLeast('2.1.9', '2.1.248'), false)
+  assert.equal(isCliVersionAtLeast('2.0.9', '2.1.248'), false)
+  assert.equal(isCliVersionAtLeast('3.0.0', '2.1.248'), true)
+  // A prerelease at the exact floor is below the release, per the doc comment.
+  assert.equal(isCliVersionAtLeast('2.1.248-alpha.1', '2.1.248'), false)
+})

--- a/server/src/agents/computer/cli-version.ts
+++ b/server/src/agents/computer/cli-version.ts
@@ -141,10 +141,50 @@ export function clearLatestCache(): void {
 
 /** Pull the first version-looking token out of CLI output. Accepts both semver
  *  and the CalVer some vendors print (`2026.08.30`). */
+/** Lines that carry a version number but never the CLI's OWN version.
+ *
+ *  `npm warn EBADENGINE Unsupported engine { required: { node: '>=20.19.0' } }`
+ *  and `(node:1234) [DEP0040] DeprecationWarning: …` both routinely precede a
+ *  CLI's real output, and both contain something that looks exactly like a
+ *  version. Taking the first match in the combined stream then reads the
+ *  warning's number as the engine's version — which is how a Claude Code 2.0.9
+ *  came back as "20.19.0" and satisfied the 2.1.248 secure floor. The gate that
+ *  exists to refuse an un-sandboxable CLI failed OPEN on unrelated noise. */
+const VERSION_NOISE_LINE =
+  /^\s*(?:npm\s+(?:warn|WARN|notice|err)|\(node:\d+\)|warning:|warn\b|deprecat|debugger\s|\[dep\d)/i
+
+const VERSION_TOKEN = /v?(\d{4}\.\d{2}\.\d{2}(?:-[\w.]+)?|\d+\.\d+\.\d+(?:[-+][\w.]+)?)/i
+
+/** The version a command reported. stdout is what a CLI prints its own version
+ *  on, so it is asked first; stderr is only a fallback for the engines that
+ *  report there, and can no longer outrank the real answer. */
+export function versionFromOutput(out: CommandOutput): string | null {
+  return parseCliVersion(out.stdout) ?? parseCliVersion(out.stderr)
+}
+
+/** The version a CLI reported, ignoring lines that are someone else's version.
+ *
+ *  Scans line by line rather than the blob so a warning cannot win merely by
+ *  arriving first. */
 export function parseCliVersion(text: string | null | undefined): string | null {
   if (!text) return null
-  const m = text.match(/v?(\d{4}\.\d{2}\.\d{2}(?:-[\w.]+)?|\d+\.\d+\.\d+(?:[-+][\w.]+)?)/i)
-  return m ? m[1] : null
+  // Warnings are frequently multi-line, and only the FIRST line carries the
+  // marker — npm's EBADENGINE puts the version on an indented continuation:
+  //   npm warn EBADENGINE Unsupported engine {
+  //     required: { node: '>=20.19.0' }
+  //   }
+  // So a line is noise if it announces itself as one, or if it is a
+  // continuation of one: indented, or a bare closing brace. Suppression only
+  // ever begins after a marker line, so output with no warnings is untouched.
+  let inNoise = false
+  for (const line of String(text).split(/\r?\n/)) {
+    if (VERSION_NOISE_LINE.test(line)) { inNoise = true; continue }
+    if (inNoise && (/^\s+\S/.test(line) || /^\s*[)}\]]+[,;]?\s*$/.test(line) || line.trim() === '')) continue
+    inNoise = false
+    const m = line.match(VERSION_TOKEN)
+    if (m) return m[1]
+  }
+  return null
 }
 
 function versionParts(v: string): number[] {
@@ -234,9 +274,21 @@ export function parseGrokCheck(text: string): string | null {
   }
 }
 
-/** Run a command and return its combined output, or '' on any failure. Never
- *  rejects: a missing or wedged CLI must not take down the rescan. */
-function spawnText(cmd: string, args: string[], timeoutMs: number): Promise<string> {
+export interface CommandOutput {
+  stdout: string
+  stderr: string
+  /** stdout first — the order every combined-text caller wants. */
+  combined: string
+}
+
+/** Run a command and return its output, or empty strings on any failure. Never
+ *  rejects: a missing or wedged CLI must not take down the rescan.
+ *
+ *  The streams are returned APART because they mean different things: a CLI
+ *  prints its version on stdout and its warnings on stderr, and merging them
+ *  let an `npm warn EBADENGINE … node: '>=20.19.0'` line stand in for an
+ *  engine's version at the secure floor. */
+function spawnCommand(cmd: string, args: string[], timeoutMs: number): Promise<CommandOutput> {
   return new Promise((resolve) => {
     let settled = false
     let child: ReturnType<typeof spawn>
@@ -248,14 +300,24 @@ function spawnText(cmd: string, args: string[], timeoutMs: number): Promise<stri
         windowsVerbatimArguments: invocation.windowsVerbatimArguments === true,
       })
     } catch {
-      resolve('')
+      resolve({ stdout: '', stderr: '', combined: '' })
       return
     }
-    let out = ''
-    const onChunk = (buf: Buffer) => { out += buf.toString('utf8') }
-    child.stdout?.on('data', onChunk)
-    child.stderr?.on('data', onChunk)
-    const finish = (value: string) => {
+    // Kept apart, then joined stdout-first. A CLI prints its version on stdout
+    // and its warnings on stderr, so scanning stdout first means a warning
+    // cannot win by arriving earlier — which is what let an npm EBADENGINE
+    // line stand in for an engine's version at the secure floor. Some engines
+    // do report the version on stderr, so it stays in the text, just after.
+    let stdout = ''
+    let stderr = ''
+    child.stdout?.on('data', (buf: Buffer) => { stdout += buf.toString('utf8') })
+    child.stderr?.on('data', (buf: Buffer) => { stderr += buf.toString('utf8') })
+    const captured = (): CommandOutput => ({
+      stdout: stdout.trim(),
+      stderr: stderr.trim(),
+      combined: `${stdout}\n${stderr}`.trim(),
+    })
+    const finish = (value: CommandOutput) => {
       if (settled) return
       settled = true
       clearTimeout(timer)
@@ -263,10 +325,10 @@ function spawnText(cmd: string, args: string[], timeoutMs: number): Promise<stri
     }
     const timer = setTimeout(() => {
       try { child.kill() } catch { /* already gone */ }
-      finish(out.trim())
+      finish(captured())
     }, timeoutMs)
-    child.on('error', () => finish(''))
-    child.on('close', () => finish(out.trim()))
+    child.on('error', () => finish({ stdout: '', stderr: '', combined: '' }))
+    child.on('close', () => finish(captured()))
   })
 }
 
@@ -291,10 +353,10 @@ async function probeLatest(id: string, spec: EngineVersionSpec, binPath: string 
   let version: string | null = null
   try {
     if (spec.latestVia === 'cursor-about' && binPath) {
-      const about = await spawnText(binPath, ['about'], 10_000)
+      const about = (await spawnCommand(binPath, ['about'], 10_000)).combined
       version = parseCursorAbout(about) || parseCliVersion(about)
     } else if (spec.latestVia === 'grok-check' && binPath) {
-      const check = await spawnText(binPath, ['update', '--check', '--json'], 12_000)
+      const check = (await spawnCommand(binPath, ['update', '--check', '--json'], 12_000)).combined
       version = parseGrokCheck(check)
     }
     if (!version && spec.npm) version = await npmLatest(spec.npm)
@@ -320,7 +382,7 @@ export async function probeEngineVersion(id: string, binPath: string | null): Pr
   const empty: EngineVersionInfo = { version: null, latest: null, outdated: false, updateCommand: null }
   if (!spec || !binPath) return empty
 
-  const version = parseCliVersion(await spawnText(binPath, spec.versionArgs, 6000))
+  const version = versionFromOutput(await spawnCommand(binPath, spec.versionArgs, 6000))
   const latest = await probeLatest(id, spec, binPath)
   const outdated = isCliOutdated(version, latest)
   return {
@@ -336,5 +398,5 @@ export async function probeEngineVersion(id: string, binPath: string | null): Pr
 export async function probeLocalEngineVersion(id: string, binPath: string | null): Promise<string | null> {
   const spec = ENGINE_VERSION_SPECS[id]
   if (!spec || !binPath) return null
-  return parseCliVersion(await spawnText(binPath, spec.versionArgs, 6000))
+  return versionFromOutput(await spawnCommand(binPath, spec.versionArgs, 6000))
 }


### PR DESCRIPTION
The version probe merged stdout and stderr into one blob and took the **first** version-shaped token in it. Warnings arrive first, and routinely carry a version of their own:

```
npm warn EBADENGINE Unsupported engine {
  required: { node: '>=20.19.0' }
}
claude 2.0.9 (Claude Code)
```

That parses as `20.19.0`.

`SECURE_ENGINE_MIN_VERSIONS` requires `claude >= 2.1.248`. `20 > 2`, so a Claude Code that **predates `--restricted`** — the flag the whole secure mode rests on — was accepted as one that has it.

Measured against the real functions before the change:

```
20.19.0    passes 2.1.248 gate: true    npm engine warning before the version
6.1.0      passes 2.1.248 gate: true    node deprecation warning first
2.0.9      passes 2.1.248 gate: false   clean output (same CLI!)
```

The same binary passes or fails the security gate depending on whether npm happened to print a warning. It fails **open**, which is the direction that matters, and the trigger is nothing more exotic than an old Node plus a global npm install.

It also means the version on the Computers card can be someone else's, and `isCliOutdated` compares against it.

## Two changes, because either alone leaves a hole

**Streams apart.** `spawnCommand` now returns `stdout` and `stderr` separately, and the version is read from stdout first. A CLI prints its version on stdout and its complaints on stderr, so a complaint can no longer win by arriving earlier. stderr stays as a fallback — some engines really do report there, and dropping it would fail *closed* on a perfectly good engine.

**Line filtering, for warnings that land on stdout.** `parseCliVersion` scans line by line and skips lines that announce themselves as warnings *and their indented continuations*. That second part is necessary: npm's EBADENGINE puts the number on a continuation line carrying no marker of its own, so a per-line keyword filter misses exactly the case that started this. Suppression only ever begins after a marker line, so output with no warnings is untouched.

## Failing closed

Warnings with no real version now yield `null` instead of a borrowed number, and `isCliVersionAtLeast(null, …)` is already `false` — so "could not read a version" refuses secure mode rather than guessing at it.

## Tests

9 new cases in `cli-version-noise.test.ts`: a stderr warning not outranking stdout, an engine that reports *only* on stderr still being read, nothing-anywhere yielding null, the npm block and the node deprecation notice on stdout, warnings-alone yielding null, every previously-working shape unchanged, a version line that merely mentions the word "warning" still being read, and the numeric floor itself (2.1.9 must not clear 2.1.248 — a string compare would admit an engine a year too old).

Restoring the merged-blob parse fails 3 of them. The existing 10 version tests still pass unchanged.

## Scope

I have not changed `isCliVersionAtLeast`; its numeric comparison and its prerelease rule are correct as they stand, and the new tests pin both. The bug was entirely in deciding *which number* to hand it.
