### PR TITLE
fix(scripts): run schema migrations before starting electron:dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,8 +25,8 @@ command also runs `workers/email-gate` tests, whose dependencies live in the
 Worker's separate `package.json`.
 
 Open http://localhost:5180 for the web app, or `npm run electron:dev` for the
-desktop shell. The database schema is created idempotently on boot and seeded
-with a starter team. Everything else (OAuth login, email, storage, push, the
+desktop shell. Database migrations are applied via `npm run migrate` (run
+automatically by `dev:all` and `electron:dev`), and seeded on boot with a starter team. Everything else (OAuth login, email, storage, push, the
 sub2api LLM gateway) soft-disables when its env vars are unset — see
 [`.env.example`](.env.example).
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ npm run dev:all       # Vite renderer on :5180 + API server on :5181
 
 Then open http://localhost:5180 (PWA mode) or run `npm run electron:dev` for the desktop window.
 
-The schema is created idempotently on boot. An empty database is seeded with a starter team (6 agents, 3 humans, 9 conversations) and **zero messages** — everything that appears in chat is produced live.
+Database migrations are applied via `npm run migrate` (run automatically by `npm run dev:all` and `npm run electron:dev`). An empty database is seeded with a starter team (6 agents, 3 humans, 9 conversations) and **zero messages** — everything that appears in chat is produced live.
 
 ### Environment
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test:integration": "node server/run-integration-tests.mjs",
     "migrate": "tsx server/src/migrate-bin.ts",
     "icons": "python3 scripts-make-mac-icon.py && npx -y electron-icon-builder -i build/icon.png -o build --flatten && node scripts-sync-electron-dev-icon.mjs",
-    "electron:dev": "concurrently -k -n web,api,electron -c blue,magenta,cyan \"npm:dev\" \"npm:server:dev\" \"wait-on tcp:5180 tcp:5181 && cross-env-shell ELECTRON_RENDERER_URL=http://localhost:5180 electron .\"",
+    "electron:dev": "npm run migrate && concurrently -k -n web,api,electron -c blue,magenta,cyan \"npm:dev\" \"npm:server:dev\" \"wait-on tcp:5180 tcp:5181 && cross-env-shell ELECTRON_RENDERER_URL=http://localhost:5180 electron .\"",
     "electron:start": "electron .",
     "electron:build": "npm run build && electron-builder",
     "electron:build:mac": "npm run build && electron-builder --mac",


### PR DESCRIPTION
## Summary

- Prefix `electron:dev` with `npm run migrate &&` to match `dev:all` introduced in #167 (ADR 0003).
- Avoid `MigrationHistoryError: schema_migrations is missing; run npm run migrate before starting the server` when launching the desktop development app against an unmigrated database.
- Update `README.md` and `CONTRIBUTING.md` to reflect that schema migrations are applied via `npm run migrate` rather than created automatically on application boot.

Fixes #170

## Validation

- `npm run lint` (466 files checked, 0 errors)
- `npm run typecheck` (0 errors)
- `npm run server:typecheck` (0 errors)
- `npm run guard:big-brain` (passed)
- `npm run guard:llm-tracked` (passed)
- `npm run guard:engine-registry` (passed)
- `npm test` (1070 passed, 4 platform-gated skips)
- `npm run test:integration` (284 passed, 5 credential-gated skips)