### PR TITLE
fix(byoa): a turn that cannot succeed must stop retrying on both paths

### DIFF
--- a/server/src/__tests__/agents-computer-turn-outcome.test.ts
+++ b/server/src/__tests__/agents-computer-turn-outcome.test.ts
@@ -1,0 +1,122 @@
+/**
+ * A wake that cannot succeed has to stop retrying on EVERY path, not just one.
+ *
+ * The fifteen-minute operator pause was measured into existence: nine computers
+ * whose Claude was signed out produced 1,988 failed turns in forty minutes. But
+ * it was wired into the chat wake only. The proactive agenda heartbeat — which
+ * fires on its own every AGENDA_CHECK_MS whether or not anyone is talking to the
+ * agent — published the failure notice and then came straight back a minute
+ * later, and again, for as long as the engine stayed signed out.
+ *
+ * So the agents that kept spinning were precisely the ones nobody was chatting
+ * with, and the notice is deduplicated over the same fifteen minutes the pause
+ * covers: roughly fifteen dead spawns per agent per message the operator sees.
+ * The pause looked like it worked because the path that proved it was the path
+ * that had it.
+ *
+ * The two paths now ask one classifier and assign through one method, so they
+ * can no longer hold different opinions about what a failure means.
+ *
+ * Run: node --import tsx --test server/src/__tests__/agents-computer-turn-outcome.test.ts
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+process.env.CUMORA_RUNTIME_CLIENT = 'http'
+process.env.OPENAI_API_KEY ??= 'test-key'
+
+const { classifyTurnOutcome, backoffUntilFor, needsOperatorFix } =
+  await import('../agents/computer/daemon.js')
+
+const RATE_LIMIT_MS = 60_000
+const OPERATOR_FIX_MS = 15 * 60_000
+
+// ── what a finished turn means ─────────────────────────────────────────────
+
+test('the failures measured in production classify as needing a human', () => {
+  for (const err of [
+    'local claude failed (exit 1): engine turn error (success): Not logged in · Please run /login',
+    'local claude failed (exit 1): engine turn error (success): Credit balance is too low',
+    'Invalid API key provided',
+    'unauthorized',
+  ]) {
+    assert.equal(classifyTurnOutcome(err), 'operator-fix', err)
+  }
+})
+
+test('a clean turn is ok, including the empty-string shape a caller can pass', () => {
+  // The old code keyed on `!engineError`, so '' counted as success. Changing
+  // that here would silently pause agents that had done nothing wrong.
+  for (const err of [null, undefined, '']) assert.equal(classifyTurnOutcome(err), 'ok', String(err))
+})
+
+test('an unexplained failure stays transient and keeps retrying', () => {
+  for (const err of [
+    // A broken install is real, but not unambiguous enough to stop an agent
+    // for fifteen minutes on — it may be an npm run that has not finished.
+    'Missing optional dependency @openai/codex-darwin-arm64',
+    'process exited with code 1',
+    'engine turn error (error_during_execution): see log',
+    // Must not fire on a turn that merely talked about logging in.
+    'the user asked how to run /login later',
+  ]) {
+    assert.equal(classifyTurnOutcome(err), 'transient', err)
+  }
+})
+
+test('a throttle outranks an operator fix, exactly as the old chat path did', () => {
+  // The old order was `!rateLimited && needsOperatorFix(...)`, so a message
+  // matching both took the short cooldown and stayed out of the user's chat.
+  // "insufficient quota" is both — inverting this would put a self-clearing
+  // throttle behind a fifteen-minute wall and post a notice about it.
+  const both = 'insufficient quota for this request'
+  assert.equal(needsOperatorFix(both), true, 'precondition: also reads as an operator fix')
+  assert.equal(classifyTurnOutcome(both), 'rate-limited')
+})
+
+// ── what that means for the pause ──────────────────────────────────────────
+
+test('each outcome maps to its own deadline', () => {
+  assert.equal(backoffUntilFor('ok', 1_000), 0)
+  assert.equal(backoffUntilFor('rate-limited', 1_000), 1_000 + RATE_LIMIT_MS)
+  assert.equal(backoffUntilFor('operator-fix', 1_000), 1_000 + OPERATOR_FIX_MS)
+})
+
+test('a human-cleared failure waits far longer than a throttle', () => {
+  // The two windows serve different things: a throttle clears itself in
+  // seconds, a signed-out CLI does not clear at all. Collapsing them would
+  // bring back the spin at a slower rate.
+  const rate = backoffUntilFor('rate-limited', 0) ?? 0
+  const operator = backoffUntilFor('operator-fix', 0) ?? 0
+  assert.ok(operator > rate * 5, `${operator} should dwarf ${rate}`)
+})
+
+test('a transient failure leaves an existing pause alone rather than clearing it', () => {
+  // null is deliberately not 0. An agent paused for a signed-out engine can
+  // still fail some other way on its next attempt; if that cleared the pause,
+  // the spin would resume with an extra step in it.
+  assert.equal(backoffUntilFor('transient', 1_000), null)
+})
+
+// ── and that both paths actually go through it ─────────────────────────────
+
+const DAEMON = readFileSync(
+  fileURLToPath(new URL('../agents/computer/daemon.ts', import.meta.url)),
+  'utf8',
+)
+
+test('nothing sets the pause except the one method', () => {
+  // This is the property the bug violated. Pure functions cannot catch a path
+  // that simply does not call them, so assert the shape of the source: a second
+  // assignment is how the chat wake and the agenda heartbeat drifted apart.
+  const assignments = DAEMON.match(/this\.engineBackoffUntil\s*=/g) ?? []
+  assert.equal(assignments.length, 1, `expected one assignment, found ${assignments.length}`)
+  assert.match(DAEMON, /private applyTurnBackoff\(outcome: TurnOutcome\): void \{/)
+})
+
+test('both turn paths end in it', () => {
+  const calls = DAEMON.match(/this\.applyTurnBackoff\(outcome\)/g) ?? []
+  assert.equal(calls.length, 2, `expected the chat and agenda paths, found ${calls.length}`)
+})

--- a/server/src/agents/computer/daemon.ts
+++ b/server/src/agents/computer/daemon.ts
@@ -245,6 +245,50 @@ const OPERATOR_FIX_RE = /not logged in|please run \/login|credit balance is too 
 export function needsOperatorFix(err: string | null | undefined): boolean {
   return !!err && OPERATOR_FIX_RE.test(err)
 }
+
+/** What a finished engine turn says about trying again, in one place.
+ *
+ *  A turn ends on one of two paths — the chat wake, and the proactive agenda
+ *  heartbeat that fires every AGENDA_CHECK_MS on its own — and both end at this
+ *  same question. They used to answer it differently: the chat path put a
+ *  signed-out engine to sleep for fifteen minutes, and the agenda path did not.
+ *  So an agent nobody happened to be chatting with kept exactly the spin the
+ *  pause exists to stop, one dead spawn a minute, indefinitely.
+ *
+ *  Classifying once is what keeps the two paths honest. A path can still fail to
+ *  ASK — which is one grep away — but it can no longer hold a different opinion
+ *  than the other about what a given failure means.
+ *
+ *  Order matters: a throttle that also mentions quota is a throttle. It clears
+ *  itself, so it takes the short cooldown and stays out of the user's chat. */
+export type TurnOutcome =
+  /** Clean turn — cancel any pause this agent was under. */
+  | 'ok'
+  /** Provider throttle. Clears itself: short cooldown, no user-facing notice. */
+  | 'rate-limited'
+  /** Only a human can clear it. Long pause, and tell someone. */
+  | 'operator-fix'
+  /** Cause unknown. Keep retrying, and leave any existing pause alone. */
+  | 'transient'
+
+export function classifyTurnOutcome(engineError: string | null | undefined): TurnOutcome {
+  if (!engineError) return 'ok'
+  if (isRateLimited(engineError)) return 'rate-limited'
+  if (needsOperatorFix(engineError)) return 'operator-fix'
+  return 'transient'
+}
+
+/** The engine backoff deadline a finished turn implies, or null to leave the
+ *  current one untouched. Null is not zero: an unexplained failure must not
+ *  cancel a pause an earlier, well-understood one established. */
+export function backoffUntilFor(outcome: TurnOutcome, now: number): number | null {
+  switch (outcome) {
+    case 'ok': return 0
+    case 'rate-limited': return now + ENGINE_BACKOFF_AFTER_RATE_LIMIT_MS
+    case 'operator-fix': return now + ENGINE_BACKOFF_AFTER_OPERATOR_FIX_MS
+    case 'transient': return null
+  }
+}
 // Neutral cwd for LOCAL small-brain triage: no persona CLAUDE.md / skills / MCP,
 // so the cerebellum completion is fast and tool-free.
 const TRIAGE_DIR = join(CONFIG_DIR, 'triage')
@@ -1532,9 +1576,14 @@ class AgentRunner {
   // expires. Without this, we'd re-attempt on every poll + SSE wake (each
   // burning a real call against the same throttle that just rejected us)
   // and the loop is visible to the user as 100+ rate-limit log lines and
-  // 30-65s end-to-end latency per turn. Set to now + ENGINE_BACKOFF_*
-  // when isRateLimited(engineError); cleared by the next successful spawn.
+  // 30-65s end-to-end latency per turn. A signed-out engine earns the same
+  // treatment for longer, since retrying it cannot succeed at all. Assigned
+  // only by applyTurnBackoff(), from the outcome BOTH turn paths classify.
   private engineBackoffUntil = 0
+  /** Why this agent is paused, for the skip log. A fifteen-minute operator
+   *  pause used to print as a rate-limit cooldown, which sends whoever is
+   *  reading the daemon log looking for a throttle that was never there. */
+  private engineBackoffWhy = 'rate limit'
   private stopped = false
   private lastWakeConvo: string | null = null
   /** Synthetic work delivered with a wake has no durable chat row. Preserve it
@@ -1902,6 +1951,16 @@ class AgentRunner {
       console.log(`[computer] ${this.agent.id} engine session ${this.sessionId ? `respawned (resume ${this.sessionId.slice(0, 8)})` : 'spawned fresh'} — persistent, no per-wake cold start`)
     }
     return this.engineSession
+  }
+
+  /** Enter, or clear, this agent's engine pause for a finished turn. Both turn
+   *  paths call this and nothing else assigns engineBackoffUntil, so the chat
+   *  wake and the agenda heartbeat cannot drift apart again. */
+  private applyTurnBackoff(outcome: TurnOutcome): void {
+    const until = backoffUntilFor(outcome, Date.now())
+    if (until === null) return
+    this.engineBackoffUntil = until
+    this.engineBackoffWhy = outcome === 'operator-fix' ? 'operator action needed' : 'rate limit'
   }
 
   private visibleEngineError(exitCode: number, detail?: string): string {
@@ -2383,14 +2442,14 @@ class AgentRunner {
     if (now - this.lastTurnEndedAt < AGENDA_QUIET_MS) return
     if (now - this.lastAgendaCheckAt < AGENDA_CHECK_MS) return
     this.lastAgendaCheckAt = now
-    // Same cooldown guard as runTurn — if this agent was just rate-limited
-    // on a chat turn, skip the agenda heartbeat too (it'd hit the same
-    // throttle). Re-fires on the next AGENDA_CHECK_MS tick after cooldown.
+    // Same pause guard as runTurn — a throttle or a signed-out engine hit on a
+    // chat turn stops the heartbeat too, because it would hit exactly the same
+    // wall. Re-fires on the next AGENDA_CHECK_MS tick once the pause expires.
     // Place this BEFORE the /agenda fetch + /runs row creation so we don't
     // leak a 'running' run row that the stale-run sweeper later reaps.
     if (Date.now() < this.engineBackoffUntil) {
       const leftS = Math.round((this.engineBackoffUntil - Date.now()) / 1000)
-      console.log(`[computer] ${this.agent.id} agenda skip: engine rate-limit cooldown, ${leftS}s left`)
+      console.log(`[computer] ${this.agent.id} agenda skip: engine paused (${this.engineBackoffWhy}), ${leftS}s left`)
       return
     }
     const ag = await runtimeGet<{ actionable?: boolean; brief?: string; focus?: string }>(
@@ -2467,18 +2526,24 @@ class AgentRunner {
     // Rate-limit: same as chat-turn path — suppress the user-facing notice
     // and just defer (no inbox state to keep here since agenda turns are
     // proactive; next heartbeat re-evaluates after cooldown).
-    const agendaRateLimited = engineError ? isRateLimited(engineError) : false
-    if (engineError && !agendaRateLimited) {
+    const outcome = classifyTurnOutcome(engineError)
+    if (engineError && outcome !== 'rate-limited') {
       await this.publishEngineFailure({ token, runId: run?.runId, conversationId: null, error: engineError, exitCode })
     }
-    if (engineError && agendaRateLimited) {
-      this.engineBackoffUntil = Date.now() + ENGINE_BACKOFF_AFTER_RATE_LIMIT_MS
+    if (outcome === 'rate-limited') {
       spawnPacer.onRateLimited()
       console.warn(`[computer] ${this.agent.id} agenda engine RATE-LIMITED — cooling down ${Math.round(ENGINE_BACKOFF_AFTER_RATE_LIMIT_MS / 1000)}s, pacer now ${spawnPacer.intervalMs}ms`)
-    } else if (!engineError) {
-      this.engineBackoffUntil = 0
+    } else if (outcome === 'operator-fix') {
+      // This heartbeat used to be the one path that published the notice and
+      // then came straight back a minute later, and again, for as long as the
+      // engine stayed signed out — fifteen dead spawns per agent inside the
+      // single window the notice is deduplicated over, so the fleet burned its
+      // error budget while the operator saw one message about it.
+      console.warn(`[computer] ${this.agent.id} agenda engine needs operator action — pausing ${Math.round(ENGINE_BACKOFF_AFTER_OPERATOR_FIX_MS / 60000)}min: ${engineError?.slice(0, 160)}`)
+    } else if (outcome === 'ok') {
       spawnPacer.onOk()
     }
+    this.applyTurnBackoff(outcome)
     // Finalize the run — WITHOUT this the row stays 'running' and the 10-min
     // stale-run sweeper reaps EVERY agenda turn as "orphaned" (the bug behind the
     // recurring Failed/orphaned runs), no matter how fast the turn actually was.
@@ -2629,7 +2694,7 @@ class AgentRunner {
         // kept (no ack), so the next wake AFTER the cooldown will pick it up.
         if (Date.now() < this.engineBackoffUntil) {
           const leftS = Math.round((this.engineBackoffUntil - Date.now()) / 1000)
-          console.log(`[computer] ${this.agent.id} skip (${reason}): engine rate-limit cooldown, ${leftS}s left`)
+          console.log(`[computer] ${this.agent.id} skip (${reason}): engine paused (${this.engineBackoffWhy}), ${leftS}s left`)
           break
         }
         const turnStart = Date.now()
@@ -2918,14 +2983,14 @@ class AgentRunner {
         // user from seeing a row of "byoa_engine_failed" markers in chat for
         // what is really a transient provider throttle. Persist a quieter
         // signal to the run row instead so it shows up in observability.
-        const rateLimited = engineError ? isRateLimited(engineError) : false
+        const outcome = classifyTurnOutcome(engineError)
+        const rateLimited = outcome === 'rate-limited'
         // An engine nobody has logged into will fail the same way on the next
         // poll, and the one after that. Cool down like a rate limit so the
         // machine stops spinning, but tell the user — a silent backoff on a
         // fixable problem is just a slower way of never working.
-        if (engineError && !rateLimited && needsOperatorFix(engineError)) {
-          this.engineBackoffUntil = Date.now() + ENGINE_BACKOFF_AFTER_OPERATOR_FIX_MS
-          console.warn(`[computer] ${this.agent.id} engine needs operator action — pausing ${Math.round(ENGINE_BACKOFF_AFTER_OPERATOR_FIX_MS / 60000)}min: ${engineError.slice(0, 160)}`)
+        if (outcome === 'operator-fix') {
+          console.warn(`[computer] ${this.agent.id} engine needs operator action — pausing ${Math.round(ENGINE_BACKOFF_AFTER_OPERATOR_FIX_MS / 60000)}min: ${engineError?.slice(0, 160)}`)
         }
         if (engineError && !rateLimited) {
           await this.publishEngineFailure({
@@ -2945,15 +3010,14 @@ class AgentRunner {
           // ALSO tell the global adaptive pacer to slow down — multiple
           // agents hitting rate-limit means the current interval is too
           // aggressive for the account's actual burst quota.
-          this.engineBackoffUntil = Date.now() + ENGINE_BACKOFF_AFTER_RATE_LIMIT_MS
           this.pendingRerun = false
           spawnPacer.onRateLimited()
           console.warn(`[computer] ${this.agent.id} engine RATE-LIMITED (sem queue depth was ${semQueueDepth}) — cooling down ${Math.round(ENGINE_BACKOFF_AFTER_RATE_LIMIT_MS / 1000)}s, pacer now ${spawnPacer.intervalMs}ms`)
-        } else if (!engineError) {
-          // Clean turn → clear any prior engine backoff + signal pacer.
-          this.engineBackoffUntil = 0
+        } else if (outcome === 'ok') {
+          // Clean turn → signal the pacer; the backoff itself is cleared below.
           spawnPacer.onOk()
         }
+        this.applyTurnBackoff(outcome)
         if (run?.runId) {
           await runtimeBest(this.cfg.serverUrl, `/runs/${run.runId}/finish`, token, {
             status: exitCode === 0 ? 'completed' : 'failed',


### PR DESCRIPTION
The fifteen-minute operator pause was measured into existence, and the measurement is in its own doc comment: nine computers whose Claude was signed out produced **1,988 failed turns in forty minutes**, with no backoff and nothing telling their operator why.

It was wired into the chat wake only.

`maybeAgendaTurn()` is the second path a turn ends on. It fires on its own every `AGENDA_CHECK_MS` (60s) whether or not anyone is talking to the agent, and it classified the same failure differently:

```ts
// chat path
if (engineError && !rateLimited && needsOperatorFix(engineError)) {
  this.engineBackoffUntil = Date.now() + ENGINE_BACKOFF_AFTER_OPERATOR_FIX_MS   // pause
}

// agenda path — the whole branch is absent
if (engineError && agendaRateLimited) { … } else if (!engineError) { … }
```

With `engineError` set and `agendaRateLimited` false, neither arm runs. The pause is never entered, so the next tick sixty seconds later spawns the signed-out engine again, and the one after that, for as long as it stays signed out.

So the agents that kept spinning were **precisely the ones nobody was chatting with** — the pause looked like it worked because the path that demonstrated it was the path that had it.

The notice is deduplicated over `dedupeTtlSec: 900`, the same fifteen minutes the pause covers. That sets the ratio: roughly **fifteen dead spawns per agent per message the operator actually sees**. Quietly burning the fleet's error budget is the failure mode the constant's doc comment already names.

### What changes

One classifier, one assignment site.

```ts
export type TurnOutcome = 'ok' | 'rate-limited' | 'operator-fix' | 'transient'
export function classifyTurnOutcome(engineError: string | null | undefined): TurnOutcome
export function backoffUntilFor(outcome: TurnOutcome, now: number): number | null
```

and one private method both paths end in:

```ts
private applyTurnBackoff(outcome: TurnOutcome): void
```

`this.engineBackoffUntil` is now assigned in exactly one place in the file. A path can still fail to *ask* — that is one grep away — but the two can no longer hold different opinions about what a failure means, which is how they drifted.

Three details preserved deliberately:

- **A throttle still outranks an operator fix.** The old order was `!rateLimited && needsOperatorFix(…)`; `"insufficient quota"` matches both, and it must stay the short self-clearing cooldown that does not post to chat. There is a test pinning that precedence.
- **`transient` returns `null`, not `0`.** An unexplained failure must not *cancel* a pause an earlier, well-understood one established — otherwise the spin comes back with an extra step in it.
- **`''` still counts as a clean turn**, because the old code keyed on `!engineError` and changing it would pause agents that had done nothing wrong.

### Also, a log line that misled

Both skip guards printed `engine rate-limit cooldown` regardless of cause, so an operator pause announced itself as a throttle for fifteen minutes — sending whoever reads the daemon log looking for a rate limit that was never there. This was already true on the chat path before this change. They now print `engine paused (operator action needed)` / `(rate limit)`.

### Verification

- New test, 9 cases: the classification table, the throttle-outranks precedence, the three deadlines, and `null ≠ 0`.
- **Confirmed it fails on the old shape.** Reverting only the agenda arm turns the two structural assertions red (`expected one assignment, found 2`; `expected the chat and agenda paths, found 1`), then green again on restore. Pure functions cannot catch a path that simply does not call them, so those two read the source — the same thing `engine-stdin-safety.test.ts` and `electron-renderer-url.test.ts` do.
- The existing `agents-computer-operator-fix-backoff.test.ts` is untouched and still green; every string in it classifies as before.
- Full unit suite: zero new failures against `main` — identical failure sets, all of them needing a live Postgres locally.
- `tsc --noEmit`, `biome lint .`, and all three source guards clean.
- I also walked the import graph of all 39 integration files: none of them reach `computer/daemon.ts`, so that suite neither exercises this nor can be disturbed by it. Saying so beats reporting a run that proves nothing.

What I did **not** do: reproduce a live signed-out agenda turn end to end — I have no BYOA engine credentials to sign out. The reasoning above is from the source and the maintainer's own measurement; the structural assertions are what pin it.

Deliberately **not** in scope: widening `OPERATOR_FIX_RE` itself. `argvRejection()` already detects an engine CLI too old for the flags we send — a failure that also cannot succeed on retry — but it is only wired into the probes, and the negative cases in the existing test show the bar for that regex is intentionally high. That is a separate argument, worth making separately.
