### PR TITLE
fix: improve text overflow handling in SystemRow component

### DIFF
--- a/src/components/Message.tsx
+++ b/src/components/Message.tsx
@@ -1561,7 +1561,7 @@ export function SystemRow({ msg, delay = 0, animate = true }: { msg: { body: str
       <div className={cn('flex justify-center my-3', riseCls)} style={riseStyle}>
         <div className="max-w-[min(100%,540px)] flex items-start gap-2 px-3 py-1.5 rounded-md bg-coral-soft/60 border border-coral-soft text-coral-deep text-[11.5px] font-display">
           <span className="leading-[1.4] shrink-0">⚠</span>
-          <span className="leading-[1.4]">{payload.text}</span>
+          <span className="leading-[1.4] min-w-0 whitespace-pre-wrap" style={{ overflowWrap: 'anywhere' }}>{payload.text}</span>
         </div>
       </div>
     )


### PR DESCRIPTION
- Add min-w-0 to allow element to shrink below minimum content width
- Add whitespace-pre-wrap to preserve whitespace while allowing wrapping
- Add overflowWrap: anywhere to break text at any character preventing overflow

before
<img width="776" height="238" alt="屏幕截图 2026-09-03 151646" src="https://github.com/user-attachments/assets/516644d7-3148-4137-8476-ac82d5e8ea55" />

after
<img width="657" height="259" alt="屏幕截图 2026-09-03 151950" src="https://github.com/user-attachments/assets/a402ef49-eddd-4f93-bfc1-9e04faf9bb6e" />
