### PR TITLE
release: v0.14.0

### DIFF
--- a/agent-cli/package.json
+++ b/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cumora",
-  "version": "0.13.2",
+  "version": "0.14.0",
   "description": "Run Cumora agents on your own machine with Claude Code, Codex, Antigravity, and other BYOA engines.",
   "license": "MIT",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cumora",
-  "version": "0.13.2",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cumora",
-      "version": "0.13.2",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1045.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cumora",
   "private": true,
-  "version": "0.13.2",
+  "version": "0.14.0",
   "type": "module",
   "main": "electron/main.cjs",
   "bin": {


### PR DESCRIPTION
## Highlights

- **Versioned schema migrations (ADR 0003).** Startup no longer runs DDL; it verifies the supported schema range. Production applies migrations through one pre-deploy Job before the Deployment is patched (#167). `npm run migrate` runs them locally, and `dev:all` / `electron:dev` invoke it first (#171).
- **Normalized conversation membership (ADR 0004).** `conversation_members` is the authorization and routing source; `conversations.members` is a rebuildable projection with expand-phase triggers so the previous release keeps working during rollout (#168).
- **Workspace member and deletion management.** Owners change roles, owners/admins remove members within role boundaries, owner-only deletion with exact-name confirmation, atomic access revocation, durable post-delete cleanup jobs (migration 0003), and a recovery screen for users with no workspace (#147).
- **BYOA account-specific model selection.** Daemons discover the model catalog behind each engine login (Codex `model/list`, Cursor/OpenCode/pi list commands, presets otherwise); the agent editor offers searchable dropdowns with custom entry, clears incompatible pins on host/engine change, and saves host, engine and pins atomically. Per-agent small-brain pins now drive the real triage path (#175).

## Fixes

- fix(agents): create and assign agents atomically, with tenant-scoped idempotent retries (#164)
- fix(realtime): durable events go through a transactional outbox with leased draining (#165)
- fix(agents): fail closed on host resolution instead of silently placing on cloud (#166)
- fix(byoa): a warning's version number must not satisfy the secure floor (#169)
- fix(byoa): don't cut the reason off the end of an engine's failure (#172)
- fix(byoa): a turn that cannot succeed stops retrying on both the chat and agenda paths (#173)
- fix(byoa): complete engine registry wiring and default model pins for gemini and qwen (#163)
- fix: long system messages wrap inside the SystemRow pill (#174)

## Operator notes

- The deploy workflow now runs a candidate migration Job (copying the live cloud-sql-proxy sidecar) before patching the Deployment, and removes the per-replica migrate init container. A failed migration leaves the current ReplicaSet untouched.
- New env: `WORKSPACE_RUNTIME_CLEANUP_ENABLED` (set to `true` in the k8s manifests) gates deletion of agent pods/PVCs for deleted workspaces; `WORKSPACE_CLEANUP_INTERVAL_MS` tunes the worker. `CUMORA_DEFAULT_{PI,GEMINI,QWEN,ANTIGRAVITY}_MODEL` are documented in `.env.example`.

## Verification

- Local gates on the merged tree (lint, typecheck, server:typecheck, three guards, unit tests) pass; the only unit failures are the two environment-bound tests (real Postgres, email-gate worker) that CI covers.
- PR CI was green on #147 and #175 after merging main into each.

https://claude.ai/code/session_01SevbW9qCBbzrjfLMy14A31
