### PR TITLE
fix(antigravity): resolve model catalog discovery and pairing engine assignment

### DIFF
--- a/server/src/__tests__/agent-computer-pairing-token.test.ts
+++ b/server/src/__tests__/agent-computer-pairing-token.test.ts
@@ -149,3 +149,29 @@ test('daemon run mode (supervised) is persisted on pair and heartbeat', async ()
   assert.equal(hb.params[1], '0.1.122')
   assert.equal(hb.params[2], false)
 })
+
+test('pairComputer accepts antigravity engine as primary and stores it in available_engines', async () => {
+  const calls = installPoolMock(({ sql }) => {
+    if (/SELECT pair_token FROM companies/.test(sql)) return { rows: [{ pair_token: 'company-token' }] }
+    if (/SELECT id, company_id/.test(sql)) return { rows: [] }
+    if (/SELECT id AS company_id, owner_user_id FROM companies/.test(sql)) {
+      return { rows: [{ company_id: 'co-1', owner_user_id: 'u-1' }] }
+    }
+    if (/SELECT id FROM computers/.test(sql)) return { rows: [{ id: 'comp-antigravity' }] }
+    if (/UPDATE computers\s+SET credential_hash/.test(sql)) return { rowCount: 1 }
+    throw new Error(`unexpected query: ${sql}`)
+  })
+
+  const paired = await registry.pairComputer({
+    code: 'company-token',
+    hostName: 'Dev Box',
+    engines: ['antigravity', 'claude'],
+    deferBroadcast: true,
+  })
+  assert.equal(paired?.computerId, 'comp-antigravity')
+
+  const update = calls.find((c) => /UPDATE computers\s+SET credential_hash/.test(c.sql))
+  assert.ok(update)
+  assert.equal(update.params[1], JSON.stringify(['antigravity', 'claude']))
+})
+

--- a/server/src/__tests__/agents-computer-model-catalog.test.ts
+++ b/server/src/__tests__/agents-computer-model-catalog.test.ts
@@ -93,3 +93,19 @@ test('Claude settings ignore a relative config-root override instead of reading 
     prefersLocalDefault: false,
   })
 })
+
+test('Antigravity catalog parses tab-separated models, ignores fetching banner, and marks recommendations', () => {
+  const output = [
+    'Fetching available models...',
+    'gemini-3.8-flash-high\tGemini 3.8 Flash (High)',
+    'gemini-3.1-pro-high\tGemini 3.1 Pro (High)',
+    'claude-sonnet-4-6\tClaude Sonnet 4.6 (Thinking)',
+  ].join('\n')
+
+  const out = parseListedModels(output, 'antigravity')
+  assert.deepEqual(out, [
+    { id: 'gemini-3.8-flash-high', label: 'Gemini 3.8 Flash (High)', description: null, recommendedFor: ['small'] },
+    { id: 'gemini-3.1-pro-high', label: 'Gemini 3.1 Pro (High)', description: null, recommendedFor: ['big'] },
+    { id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6 (Thinking)', description: null, recommendedFor: ['big'] },
+  ])
+})

--- a/server/src/agents/computer/daemon.ts
+++ b/server/src/agents/computer/daemon.ts
@@ -2201,7 +2201,7 @@ class AgentRunner {
     if (this.adapter.id === 'qwen') return 'qwen3-coder-flash'
     if (this.adapter.id === 'opencode') return this.agent.model ?? '<opencode-default>'
     if (this.adapter.id === 'pi') return this.agent.model ?? '<pi-default>'
-    if (this.adapter.id === 'antigravity') return this.agent.model ?? '<antigravity-default>'
+    if (this.adapter.id === 'antigravity') return this.agent.model ?? 'gemini-3.8-flash-high'
     if (this.adapter.id === 'cursor') return this.agent.model ?? '<cursor-default>'
     return this.agent.model ?? '<cursor-default>'
   }

--- a/server/src/agents/computer/model-catalog.ts
+++ b/server/src/agents/computer/model-catalog.ts
@@ -98,19 +98,29 @@ const PRESETS: Record<EngineId, EngineModelCatalog> = {
     source: 'presets',
   },
   qwen: {
-    models: [],
+    models: [
+      { id: 'qwen3-coder-plus', label: 'Qwen3 Coder Plus', recommendedFor: ['big'] },
+      { id: 'qwen3-coder-flash', label: 'Qwen3 Coder Flash', recommendedFor: ['small'] },
+      { id: 'qwen2.5-coder-32b-instruct', label: 'Qwen 2.5 Coder 32B Instruct' },
+    ],
     defaultModel: null,
-    defaultFastModel: null,
+    defaultFastModel: 'qwen3-coder-flash',
     supportsCustom: true,
-    fastModelScope: 'computer',
+    fastModelScope: 'agent',
     source: 'presets',
   },
   antigravity: {
-    models: [],
+    models: [
+      { id: 'gemini-3.8-flash-high', label: 'Gemini 3.8 Flash (High)', recommendedFor: ['small'] },
+      { id: 'gemini-3.7-flash-high', label: 'Gemini 3.7 Flash (High)', recommendedFor: ['small'] },
+      { id: 'gemini-3.1-pro-high', label: 'Gemini 3.1 Pro (High)', recommendedFor: ['big'] },
+      { id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6 (Thinking)', recommendedFor: ['big'] },
+      { id: 'claude-opus-4-6-thinking', label: 'Claude Opus 4.6 (Thinking)', recommendedFor: ['big'] },
+    ],
     defaultModel: null,
-    defaultFastModel: null,
+    defaultFastModel: 'gemini-3.8-flash-high',
     supportsCustom: true,
-    fastModelScope: 'computer',
+    fastModelScope: 'agent',
     source: 'presets',
   },
 }
@@ -206,14 +216,16 @@ function runText(command: string, args: string[]): Promise<string> {
   })
 }
 
-/** Parse model-list output shared by OpenCode, pi and Cursor. Exported so new
+/** Parse model-list output shared by OpenCode, pi, Cursor and Antigravity. Exported so new
  * adapters can add fixtures without spawning a real account-bound CLI. */
-export function parseListedModels(text: string, style: 'provider' | 'pi' | 'cursor'): EngineModelOption[] {
+export function parseListedModels(text: string, style: 'provider' | 'pi' | 'cursor' | 'antigravity'): EngineModelOption[] {
   const models: EngineModelOption[] = []
   for (const raw of text.split(/\r?\n/)) {
     const line = raw.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '').trim()
-    if (!line || /^(available\s+)?models?\b/i.test(line) || /^provider\s+model\b/i.test(line)) continue
+    if (!line || /^(available\s+)?models?\b/i.test(line) || /^provider\s+model\b/i.test(line) || /^fetching\b/i.test(line)) continue
     let id: string | null = null
+    let label: string | null = null
+    let recommendedFor: Array<'big' | 'small'> | undefined
     if (style === 'provider') {
       id = line.match(/(?:^|\s)([a-z0-9][\w.-]*\/[\w./:@+-]+)/i)?.[1] ?? null
     } else if (style === 'pi') {
@@ -224,12 +236,35 @@ export function parseListedModels(text: string, style: 'provider' | 'pi' | 'curs
           id = `${pair[0]}/${pair[1]}`
         }
       }
+    } else if (style === 'antigravity') {
+      const tabIdx = line.indexOf('\t')
+      const idPart = (tabIdx >= 0 ? line.slice(0, tabIdx) : line).trim()
+      const labelPart = (tabIdx >= 0 ? line.slice(tabIdx + 1) : idPart).trim()
+      const candidate = idPart.replace(/^[*✓>•-]+\s*/, '').match(/^([a-z0-9][\w./:@+-]*)/i)?.[1] ?? null
+      if (candidate) {
+        id = candidate
+        label = labelPart || candidate
+        const isSmall = /(?:^|[-_/])(?:flash|mini|haiku|lite)(?:[-_/]|$)/i.test(candidate)
+        const isBig = /(?:^|[-_/])(?:pro|opus|sonnet|120b)(?:[-_/]|$)/i.test(candidate)
+          || (!isSmall && /(?:^|[-_/])(?:thinking|plus|large)(?:[-_/]|$)/i.test(candidate))
+        const recs: Array<'big' | 'small'> = []
+        if (isBig) recs.push('big')
+        if (isSmall) recs.push('small')
+        if (recs.length) recommendedFor = recs
+      }
     } else {
       const candidate = line.replace(/^[*✓>•-]+\s*/, '').match(/^([a-z0-9][\w./:@+-]*)/i)?.[1] ?? null
       if (candidate && !/^(available|current|default|name|model)$/i.test(candidate)) id = candidate
     }
     const normalized = clean(id, 160)
-    if (normalized) models.push({ id: normalized, label: normalized })
+    if (normalized) {
+      models.push({
+        id: normalized,
+        label: clean(label, 160) ?? normalized,
+        description: null,
+        recommendedFor,
+      })
+    }
   }
   return mergeModels(models, [])
 }
@@ -359,6 +394,9 @@ export async function discoverEngineModelCatalog(
     if (models.length) catalog = withPreset(id, models, 'cli', null)
   } else if (id === 'pi') {
     const models = parseListedModels(await runText(binPath, ['--list-models']), 'pi')
+    if (models.length) catalog = withPreset(id, models, 'cli', null)
+  } else if (id === 'antigravity') {
+    const models = parseListedModels(await runText(binPath, ['models']), 'antigravity')
     if (models.length) catalog = withPreset(id, models, 'cli', null)
   }
 

--- a/server/src/agents/computer/registry.ts
+++ b/server/src/agents/computer/registry.ts
@@ -63,7 +63,7 @@ const PAIRABLE: Record<Exclude<EngineId, 'managed'>, true> = {
   qwen: true,
   antigravity: true,
 }
-const PAIRABLE_ENGINES: ReadonlySet<string> = new Set<string>(Object.keys(PAIRABLE))
+export const PAIRABLE_ENGINES: ReadonlySet<string> = new Set<string>(Object.keys(PAIRABLE))
 
 type Queryable = {
   query<T extends object = Record<string, unknown>>(

--- a/server/src/api/router.ts
+++ b/server/src/api/router.ts
@@ -40,6 +40,7 @@ import {
   listComputers, revokeComputer, assignAgentToComputer, heartbeatComputer,
   cloudComputerId, issueRepairCode, requestEngineDetect, reportDetectedEngines,
   setComputerDefaultEngine,
+  PAIRABLE_ENGINES, type EngineId,
 } from '../agents/computer/registry.js'
 import { attachComputerControlStream, deliverEngineDetect } from '../agents/computer/control-bus.js'
 import { companyTier } from '../tier.js'
@@ -1252,11 +1253,7 @@ api.post('/computers/pair', safe(async (req, res) => {
   // and any adopted agent are created with. Fall back to Claude if unreported.
   try {
     if ((await companyTier(paired.companyId)) === 'free') {
-      const engine = (
-        engines[0] === 'claude' || engines[0] === 'codex' || engines[0] === 'grok' ||
-        engines[0] === 'cursor' || engines[0] === 'opencode' || engines[0] === 'pi' ||
-        engines[0] === 'gemini' || engines[0] === 'qwen'
-      ) ? engines[0] : 'claude'
+      const engine: EngineId = PAIRABLE_ENGINES.has(engines[0]) ? (engines[0] as EngineId) : 'claude'
       // Adopt only agents that are stranded on the managed Cumora Cloud (or
       // unassigned) onto the just-paired machine — earlier builds' boot backfill
       // wrongly seeded free starters on cloud, where free can't run them. Agents


### PR DESCRIPTION
## Summary

This PR addresses two related gaps affecting Antigravity engine support in Cumora:

1. **Antigravity Model Catalog Discovery & Small-Brain Triage Selection**:
   - In PR #175 (`feat(byoa): add account-specific model selection`), Antigravity was defined with an empty preset array (`models: []`), no discovery handler in `discoverEngineModelCatalog`, and `fastModelScope: 'computer'`. This resulted in an empty model dropdown in the UI (only "Follow engine default") and hid the fast-model triage picker.
   - Discovers dynamic model catalog via the built-in `agy models` CLI command, parsing tab-separated ID and human-readable label.
   - Categorizes models into recommended big/small tiers (using boundary-delimited matching to avoid false positives like `gemini` matching `mini`).
   - Adds standard fallback presets for `antigravity` and `qwen`, and configures `fastModelScope: 'agent'` so agents on Antigravity/Qwen hosts can configure their triage model.
   - Provides a default triage model fallback in `daemon.ts`.

2. **Fix Default Engine on Computer Pairing**:
   - In `server/src/api/router.ts` (`POST /computers/pair`), a hardcoded disjunction enumerated pairable engines for free-tier auto-onboarding but omitted `'antigravity'`.
   - Pairing a machine with `--engine antigravity` caused `engine` to incorrectly fall back to `'claude'`, inappropriately setting stranded and newly seeded starter agents to `'claude'` on machines without Claude installed.
   - Replaces the hardcoded check with the authoritative `PAIRABLE_ENGINES` set exported from `registry.ts`.

## Verification

- `npm run lint`: Checked 478 files, 0 errors, 0 warnings.
- `npm run typecheck`: Passed (0 errors).
- `npm run server:typecheck`: Passed (0 errors).
- `npm run guard:engine-registry`: Passed.
- `npm run guard:big-brain`: Passed.
- `npm run guard:llm-tracked`: Passed.
- Full test suite: **1106 passed**, 0 failed, 4 skipped.