### PR TITLE
release: v0.14.1

### DIFF
--- a/agent-cli/package.json
+++ b/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cumora",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Run Cumora agents on your own machine with Claude Code, Codex, Antigravity, and other BYOA engines.",
   "license": "MIT",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cumora",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cumora",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1045.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cumora",
   "private": true,
-  "version": "0.14.0",
+  "version": "0.14.1",
   "type": "module",
   "main": "electron/main.cjs",
   "bin": {


### PR DESCRIPTION
## v0.14.1

Patch release so production can adopt the versioned migration ledger introduced in v0.14.0.

### Fixed

- **db:** the pre-deploy migration Job could never complete on production. The frozen legacy baseline (migration 1) was sent as one implicit transaction holding AccessExclusiveLocks on ~30 tables, which deadlocked (`40P01`) against live traffic on every attempt. The baseline is now run one statement at a time with per-statement lock retries; later versions keep their single-transaction atomicity (#178).

### Notes

- v0.14.0 was never rolled out: both deploy attempts stopped before touching the Deployment (one on a transient production `/api/health` 503, one on the migration Job). This release carries everything from v0.14.0 plus the fix.

https://claude.ai/code/session_01SevbW9qCBbzrjfLMy14A31
