### PR TITLE
fix(db): explain why migration 0002 refuses to run

### DIFF
--- a/server/src/__tests__/migration-0002-precheck.test.ts
+++ b/server/src/__tests__/migration-0002-precheck.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+process.env.CUMORA_RUNTIME_CLIENT = 'http'
+process.env.OPENAI_API_KEY ??= 'test-key'
+
+const { checkConversationMembersResolvable } = await import('../db/migrate.js')
+
+const fakeClient = (summary: Record<string, unknown>, samples: Array<Record<string, unknown>> = []) => {
+  const statements: string[] = []
+  return {
+    statements,
+    async query(sql: string) {
+      statements.push(sql)
+      return { rows: sql.includes('LIMIT') ? samples : [summary] }
+    },
+  }
+}
+
+test('the 0002 precheck is read-only and passes when every member resolves', async () => {
+  const client = fakeClient({ pairs: '0', null_company_conversations: '0' })
+  await checkConversationMembersResolvable(client)
+  assert.equal(client.statements.length, 1)
+  for (const sql of client.statements) {
+    assert.doesNotMatch(sql, /\b(?:CREATE|ALTER|DROP|INSERT|UPDATE|DELETE)\b/i)
+  }
+})
+
+test('the 0002 precheck fails closed with counts and a masked sample', async () => {
+  const errors: string[] = []
+  const originalError = console.error
+  console.error = (...args: unknown[]) => { errors.push(args.map(String).join(' ')) }
+  try {
+    const client = fakeClient(
+      { pairs: '3', conversations: '2', member_ids: '2', missing_everywhere: '2', other_tenant: '1', user_rows: '0',
+        company_members_without_participant: '0', personal_tenant: '1', authored_messages: '1', null_company_conversations: '0' },
+      [
+        { conversation_id: 'c1', company_id: 'personal', member_id: 'agent-gone', participant_elsewhere: false, is_user: false, authored: true },
+        { conversation_id: 'c2', company_id: 'acme', member_id: 'someone@example.com', participant_elsewhere: true, is_user: false, authored: false },
+      ],
+    )
+    await assert.rejects(
+      checkConversationMembersResolvable(client),
+      (err: unknown) => (err as { code?: string }).code === '23503'
+        && /3 conversation member id\(s\) in 2 conversation\(s\)/.test((err as Error).message),
+    )
+    assert.equal(client.statements.length, 2)
+  } finally {
+    console.error = originalError
+  }
+  assert.match(errors[0], /pairs=3 conversations=2 member_ids=2 missing_everywhere=2 other_tenant=1/)
+  assert.match(errors[1], /conversation=c1 company=personal member=agent-gone \[no-participant-anywhere,authored-messages-here\]/)
+  assert.match(errors[2], /member=som…@example\.com \[participant-in-other-tenant\]/)
+  assert.doesNotMatch(errors.join('\n'), /someone@example\.com/)
+})
+
+test('a conversation without a tenant is reported even when every member resolves', async () => {
+  const client = fakeClient({ pairs: '0', null_company_conversations: '4' })
+  const originalError = console.error
+  console.error = () => {}
+  try {
+    await assert.rejects(
+      checkConversationMembersResolvable(client),
+      (err: unknown) => /4 conversation\(s\) have no company_id/.test((err as Error).message),
+    )
+  } finally {
+    console.error = originalError
+  }
+})

--- a/server/src/db/migrate.ts
+++ b/server/src/db/migrate.ts
@@ -2231,7 +2231,123 @@ async function applyLegacyBaseline(client: import('pg').PoolClient): Promise<voi
   await verifyRequiredIndexes(client, BASELINE_REQUIRED_SCHEMA_INDEXES)
 }
 
+/** Structural so the unit test can drive the precheck with a fake client. */
+export type MigrationPrecheckClient = {
+  query(sql: string): Promise<{ rows: Array<Record<string, unknown>> }>
+}
+
+const MIGRATION_0002_SAMPLE_LIMIT = 15
+
+// Member ids that migration 0002 cannot place in conversation_members: no
+// participant row with that id in the conversation's tenant, and not one of
+// the synthetic external:<addr> markers the migration strips on purpose.
+const UNRESOLVABLE_MEMBERS_CTE = `
+  WITH orphan AS (
+    SELECT c.id AS conversation_id, c.company_id, member.id AS member_id
+      FROM conversations c
+      CROSS JOIN LATERAL jsonb_array_elements_text(c.members) member(id)
+      LEFT JOIN participants p
+        ON p.id = member.id AND p.company_id = c.company_id
+     WHERE c.company_id IS NOT NULL
+       AND p.id IS NULL
+       AND member.id NOT LIKE 'external:%'
+  )`
+
+/**
+ * Read-only precondition report for migration 0002.
+ *
+ * The migration itself fails closed (23503) when a legacy JSONB member does
+ * not resolve to a same-tenant participant, which is the right call — but a
+ * bare "foreign or missing participant" from the pre-deploy Job tells the
+ * operator nothing about what the data looks like or how much of it there
+ * is. That is exactly where the first v0.14.1 adoption stopped (2026-09-03).
+ * This runs before the immutable SQL, on the same connection, and only reads:
+ * it counts the unresolvable (conversation, member) pairs, classifies them
+ * (id gone from participants entirely, id owned by another tenant, id that is
+ * a users row, id that authored messages in that conversation, …), prints a
+ * bounded sample, and raises the same 23503 with an actionable message. It
+ * lives outside the migration string so the v2 checksum is untouched.
+ */
+export async function checkConversationMembersResolvable(client: MigrationPrecheckClient): Promise<void> {
+  const { rows: [summary] } = await client.query(`${UNRESOLVABLE_MEMBERS_CTE}
+    SELECT
+      (SELECT count(*) FROM orphan)                                  AS pairs,
+      (SELECT count(DISTINCT conversation_id) FROM orphan)           AS conversations,
+      (SELECT count(DISTINCT member_id) FROM orphan)                 AS member_ids,
+      (SELECT count(*) FROM orphan o
+        WHERE NOT EXISTS (SELECT 1 FROM participants p WHERE p.id = o.member_id)) AS missing_everywhere,
+      (SELECT count(*) FROM orphan o
+        WHERE EXISTS (SELECT 1 FROM participants p
+                       WHERE p.id = o.member_id AND p.company_id <> o.company_id)) AS other_tenant,
+      (SELECT count(*) FROM orphan o
+        WHERE EXISTS (SELECT 1 FROM users u WHERE u.id = o.member_id))            AS user_rows,
+      (SELECT count(*) FROM orphan o
+        WHERE EXISTS (SELECT 1 FROM company_members cm
+                       WHERE cm.user_id = o.member_id AND cm.company_id = o.company_id)) AS company_members_without_participant,
+      (SELECT count(*) FROM orphan o WHERE o.company_id = 'personal')          AS personal_tenant,
+      (SELECT count(*) FROM orphan o
+        WHERE EXISTS (SELECT 1 FROM messages m
+                       WHERE m.conversation_id = o.conversation_id AND m.author_id = o.member_id)) AS authored_messages,
+      (SELECT count(*) FROM conversations WHERE company_id IS NULL)          AS null_company_conversations
+  `)
+  const n = (value: unknown): number => Number(value ?? 0)
+  const pairs = n(summary?.pairs)
+  const nullCompanies = n(summary?.null_company_conversations)
+  if (pairs === 0 && nullCompanies === 0) {
+    console.log('[db] migration 0002 precheck: every conversation member resolves to a same-tenant participant')
+    return
+  }
+
+  const { rows: samples } = await client.query(`${UNRESOLVABLE_MEMBERS_CTE}
+    SELECT o.conversation_id, o.company_id, o.member_id,
+           EXISTS (SELECT 1 FROM participants p WHERE p.id = o.member_id)   AS participant_elsewhere,
+           EXISTS (SELECT 1 FROM users u WHERE u.id = o.member_id)          AS is_user,
+           EXISTS (SELECT 1 FROM messages m
+                    WHERE m.conversation_id = o.conversation_id AND m.author_id = o.member_id) AS authored
+      FROM orphan o
+     ORDER BY o.company_id, o.conversation_id, o.member_id
+     LIMIT ${MIGRATION_0002_SAMPLE_LIMIT}
+  `)
+
+  // Ids are opaque, but never print a whole email address into a CI log.
+  const mask = (id: string): string => (id.includes('@') ? id.replace(/^(.{0,3}).*@/, '$1…@') : id)
+  const counts = [
+    `pairs=${pairs}`,
+    `conversations=${n(summary?.conversations)}`,
+    `member_ids=${n(summary?.member_ids)}`,
+    `missing_everywhere=${n(summary?.missing_everywhere)}`,
+    `other_tenant=${n(summary?.other_tenant)}`,
+    `user_rows=${n(summary?.user_rows)}`,
+    `company_members_without_participant=${n(summary?.company_members_without_participant)}`,
+    `personal_tenant=${n(summary?.personal_tenant)}`,
+    `authored_messages=${n(summary?.authored_messages)}`,
+    `null_company_conversations=${nullCompanies}`,
+  ]
+  console.error(`[db] migration 0002 precheck failed: ${counts.join(' ')}`)
+  for (const sample of samples) {
+    const flags = [
+      sample.participant_elsewhere ? 'participant-in-other-tenant' : 'no-participant-anywhere',
+      sample.is_user ? 'users-row' : null,
+      sample.authored ? 'authored-messages-here' : null,
+    ].filter(Boolean).join(',')
+    console.error(
+      `[db]   conversation=${String(sample.conversation_id)} company=${String(sample.company_id)} member=${mask(String(sample.member_id))} [${flags}]`,
+    )
+  }
+  const detail = [
+    pairs > 0
+      ? `${pairs} conversation member id(s) in ${n(summary?.conversations)} conversation(s) do not resolve to a same-tenant participant`
+      : null,
+    nullCompanies > 0 ? `${nullCompanies} conversation(s) have no company_id` : null,
+  ].filter(Boolean).join(' and ')
+  throw Object.assign(
+    new Error(`migration 0002 precondition failed: ${detail} — repair the data, then rerun the migration Job (see the precheck lines above and ADR 0004)`),
+    { code: '23503' },
+  )
+}
+
 async function applyNormalizedConversationMembers(client: import('pg').PoolClient): Promise<void> {
+  await checkConversationMembersResolvable(client)
   await client.query(NORMALIZED_CONVERSATION_MEMBERS_SQL)
 }
 


### PR DESCRIPTION
## Why

The v0.14.1 deploy (run 33746384310) applied the frozen baseline to production (49 s, ledger now at version 1) and then stopped in migration 0002 with only:

```
[migrate-bin] failed: error: cannot normalize conversation membership: foreign or missing participant
```

Failing closed there is correct (#168, ADR 0004), but the bare 23503 tells an operator nothing about *what* the data looks like or *how much* of it there is, and the pre-deploy Job is the only place we get to look at production (deploy.yml, ADR 0003).

## What

A read-only precheck in `applyNormalizedConversationMembers`, run on the same connection **before** the immutable 0002 SQL, so the v2 checksum stays untouched (no history edit). It:

- counts the unresolvable `(conversation, member)` pairs — JSONB member ids with no `participants(id, company_id)` row in the conversation's tenant, ignoring `external:%` markers;
- classifies them: id gone from `participants` entirely, id owned by another tenant, id that is a `users` row, id that is a `company_members` row without a participant, conversations under the `personal` tenant, ids that authored `messages` in that conversation;
- reports conversations with a NULL `company_id` separately (0002's `SET NOT NULL` would trip on them first);
- prints ≤15 sample rows with email-like ids masked, then throws the same `23503` with an actionable message.

When everything resolves it logs one line and the SQL runs as before.

## Verification

- Unit tests (fake client): passes and issues a single read-only statement when clean; fails closed with counts, the sample, masking, and code `23503`; reports NULL-tenant conversations even with zero orphans.
- v0.13.2-shaped `pgvector/pgvector:pg16` database seeded with a foreign participant, a vanished participant that authored a message, and a users-only member under `personal`:

```
[db] applying migration 2 0002_normalized_conversation_members
[db] migration 0002 precheck failed: pairs=3 conversations=2 member_ids=3 missing_everywhere=2 other_tenant=1 user_rows=1 company_members_without_participant=1 personal_tenant=1 authored_messages=1 null_company_conversations=0
[db]   conversation=c-bad1 company=acme member=p-foreign [participant-in-other-tenant]
[db]   conversation=c-bad1 company=acme member=p-gone [no-participant-anywhere,authored-messages-here]
[db]   conversation=c-bad2 company=personal member=u-1 [no-participant-anywhere,users-row]
[migrate-bin] failed: Error: migration 0002 precondition failed: 3 conversation member id(s) in 2 conversation(s) do not resolve to a same-tenant participant — repair the data, then rerun the migration Job (see the precheck lines above and ADR 0004)
```

  Ledger stays at version 1; after repairing the rows the rerun applies v2 (42 ms) and v3.
- Fresh database adopts v1→v3 unchanged; `schema-migrations`, `migration-ownership`, `conversation-membership-source`, `migrate-client-release` suites pass against Postgres; lint, typecheck, server:typecheck green.

https://claude.ai/code/session_01SevbW9qCBbzrjfLMy14A31
