### PR TITLE
release: v0.14.2

### DIFF
--- a/agent-cli/package.json
+++ b/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cumora",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Run Cumora agents on your own machine with Claude Code, Codex, Antigravity, and other BYOA engines.",
   "license": "MIT",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cumora",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cumora",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1045.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cumora",
   "private": true,
-  "version": "0.14.1",
+  "version": "0.14.2",
   "type": "module",
   "main": "electron/main.cjs",
   "bin": {


### PR DESCRIPTION
## v0.14.2

Diagnostic-only patch on top of v0.14.1; no schema or behavior change for a database that adopts cleanly.

### Fixed

- **Migration 0002 now says why it refuses to run** (#180). The v0.14.1 pre-deploy Job on production applied the frozen baseline (ledger at version 1) and then stopped in migration 0002 with a bare `cannot normalize conversation membership: foreign or missing participant`. A read-only precheck now runs before the immutable 0002 SQL (checksum untouched): it counts the unresolvable conversation member ids, classifies them (gone from `participants`, owned by another tenant, `users`/`company_members` rows without a participant, `personal` tenant, authors of messages in that conversation), reports NULL-tenant conversations, prints a masked sample and fails closed with the same `23503`.

### Operational state

- Production is still running v0.13.2 code. v0.14.1 left the schema ledger at version 1 with all baseline objects present; the Deployment was not patched. This release exists so the next deploy attempt reports exactly which rows block migration 0002.

https://claude.ai/code/session_01SevbW9qCBbzrjfLMy14A31
