### PR TITLE
fix(seed): a fresh install must survive its own first boot

### DIFF
--- a/server/src/__integration__/fresh-database-seed.test.ts
+++ b/server/src/__integration__/fresh-database-seed.test.ts
@@ -1,0 +1,111 @@
+/**
+ * A fresh install has to survive its own first boot.
+ *
+ * `seedIfEmpty()` runs on the boot path, unconditionally, right after the
+ * read-only schema check — and it only does anything when `conversations` is
+ * empty, which is exactly the state a brand-new deployment starts in.
+ *
+ * Migration 0002 made `conversations.company_id` NOT NULL. The column has no
+ * default anywhere (it is added bare in the legacy baseline), and the seed's
+ * INSERT did not name it, so the first seeded row raised
+ *
+ *   error: null value in column "company_id" of relation "conversations"
+ *   violates not-null constraint
+ *   detail: Failing row contains (aurora, group, Aurora · Q3 Launch, …)
+ *
+ * which propagates out of seedIfEmpty() to main()'s catch and exits 1 — a boot
+ * crash-loop on every new install.
+ *
+ * Before 0.14 this was survivable by accident: the column was nullable, and
+ * boot ran the full DDL every time, including
+ * `UPDATE conversations SET company_id = 'personal' WHERE company_id IS NULL`.
+ * Moving migrations into a one-shot job removed both the tolerance and the
+ * repair, so the seed now has to be correct on the first attempt.
+ *
+ * Run: INTEGRATION_DATABASE_URL=… npm run test:integration
+ */
+import { after, before, beforeEach, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { pool } from '../db/pool.js'
+import { seedIfEmpty } from '../seed.js'
+import { ensureSchemaOnce, resetAllTables, teardownAll } from './_helpers.js'
+
+/** Put the database back into the shape a migrated-but-unused one has.
+ *
+ *  resetAllTables() also truncates `companies`, and the baseline DDL's
+ *  `INSERT INTO companies ('personal', …) ON CONFLICT DO NOTHING` only runs
+ *  with the migration — so restore that one row, or the seed fails on a
+ *  foreign key for a reason a real fresh install never hits. */
+async function asFreshInstall(): Promise<void> {
+  await resetAllTables()
+  await pool.query(
+    `INSERT INTO companies (id, name, slug) VALUES ('personal', 'Personal', 'personal')
+     ON CONFLICT (id) DO NOTHING`,
+  )
+}
+
+before(async () => { await ensureSchemaOnce() })
+beforeEach(async () => { await asFreshInstall() })
+after(async () => { await resetAllTables(); await teardownAll() })
+
+test('[integration] seeding an empty database does not abort the boot', async () => {
+  // The bug was a thrown 23502 here, not a wrong value — reaching the next
+  // line at all is most of the assertion.
+  await seedIfEmpty()
+  const { rows } = await pool.query<{ count: string }>(
+    `SELECT COUNT(*)::text AS count FROM conversations`,
+  )
+  assert.ok(Number(rows[0].count) > 0, 'seed inserted no conversations')
+})
+
+test('[integration] every seeded conversation carries a workspace', async () => {
+  await seedIfEmpty()
+  const { rows } = await pool.query<{ id: string; company_id: string | null }>(
+    `SELECT id, company_id FROM conversations ORDER BY id`,
+  )
+  assert.ok(rows.length > 0)
+  for (const row of rows) {
+    assert.equal(row.company_id, 'personal', `${row.id} landed in the wrong workspace`)
+  }
+})
+
+test('[integration] the membership trigger fills rows the seed never wrote', async () => {
+  // The seed still writes the legacy JSONB array; the AFTER INSERT trigger
+  // added by 0002 derives the normalized rows from it. Those rows are NOT NULL
+  // on company_id too, so a conversation seeded without one would fail here
+  // even if the conversation insert somehow succeeded.
+  await seedIfEmpty()
+  const { rows } = await pool.query<{ id: string; member_rows: string; projection_len: number }>(
+    `SELECT c.id,
+            COUNT(cm.participant_id)::text AS member_rows,
+            jsonb_array_length(c.members) AS projection_len
+       FROM conversations c
+       LEFT JOIN conversation_members cm
+         ON cm.conversation_id = c.id AND cm.company_id = c.company_id
+      GROUP BY c.id, c.members
+      ORDER BY c.id`,
+  )
+  assert.ok(rows.length > 0)
+  for (const row of rows) {
+    assert.equal(
+      Number(row.member_rows), row.projection_len,
+      `${row.id}: ${row.member_rows} normalized rows vs ${row.projection_len} in the projection`,
+    )
+  }
+  const orphans = await pool.query<{ count: string }>(
+    `SELECT COUNT(*)::text AS count FROM conversation_members WHERE company_id IS NULL`,
+  )
+  assert.equal(orphans.rows[0].count, '0')
+})
+
+test('[integration] a second boot leaves the seeded rows alone', async () => {
+  await seedIfEmpty()
+  const first = await pool.query<{ id: string; company_id: string | null }>(
+    `SELECT id, company_id FROM conversations ORDER BY id`,
+  )
+  await seedIfEmpty()
+  const second = await pool.query<{ id: string; company_id: string | null }>(
+    `SELECT id, company_id FROM conversations ORDER BY id`,
+  )
+  assert.deepEqual(second.rows, first.rows)
+})

--- a/server/src/seed.ts
+++ b/server/src/seed.ts
@@ -147,8 +147,12 @@ export async function seedIfEmpty(): Promise<void> {
 
     for (const c of SEED_CONVOS) {
       await client.query(
-        `INSERT INTO conversations (id, kind, title, subtitle, members, pinned, tag, pulled_by, project_id)
-         VALUES ($1,$2,$3,$4,$5::jsonb,$6,$7,$8::jsonb,$9)`,
+        // company_id is NOT NULL as of migration 0002 and has no column default,
+        // so omitting it aborts the seed — and the seed runs on the boot path.
+        // 'personal' is the same workspace the seeded participants and projects
+        // above are written into, and the baseline DDL creates that companies row.
+        `INSERT INTO conversations (id, company_id, kind, title, subtitle, members, pinned, tag, pulled_by, project_id)
+         VALUES ($1,'personal',$2,$3,$4,$5::jsonb,$6,$7,$8::jsonb,$9)`,
         [c.id, c.kind, c.title, c.subtitle ?? null, JSON.stringify(c.members), c.pinned ?? false, c.tag ?? null, c.pulledBy ? JSON.stringify(c.pulledBy) : null, c.projectId ?? null],
       )
       const maxSeq = SEED_MESSAGES.filter((m) => m.conversationId === c.id).reduce((a, b) => Math.max(a, b.sequence), 0)


### PR DESCRIPTION
A brand-new deployment does not boot.

Migration 0002 made `conversations.company_id` NOT NULL. The column has no default anywhere — the legacy baseline adds it bare, `ALTER TABLE conversations ADD COLUMN IF NOT EXISTS company_id TEXT` — and `seedIfEmpty()`'s INSERT never named it:

```ts
`INSERT INTO conversations (id, kind, title, subtitle, members, pinned, tag, pulled_by, project_id)
 VALUES ($1,$2,$3,$4,$5::jsonb,$6,$7,$8::jsonb,$9)`
```

`seedIfEmpty()` runs on the boot path, unconditionally, immediately after the read-only schema check (`server/src/index.ts:41-43`), and it only does anything when `conversations` is empty — which is exactly the state a fresh install is in. The exception propagates to `main().catch(…)`, which exits 1.

### Reproduced

Empty Postgres 16, migrations applied by the real `migrate-bin`, then boot:

```
$ node --import tsx server/src/migrate-bin.ts
[db] applied migration 2 in 8ms
[db] applying migration 3 0003_workspace_cleanup_jobs
[db] applied migration 3 in 4ms
[db] schema is current at version 3
[migrate-bin] ok · 343ms

$ node --import tsx boot.mts          # verifySchemaWithBootRetry() + seedIfEmpty()
[boot] schema version 3 is compatible
  code: '23502',
  table: 'conversations',
  column: 'company_id',
  detail: 'Failing row contains (aurora, group, Aurora · Q3 Launch, team · 5, …)'
```

That is the boot sequence, in order, on a database that has nothing wrong with it.

### Why it used to work

Not by design. Before 0.14 the column was nullable, and boot ran the entire DDL on every start — including

```sql
UPDATE conversations SET company_id = 'personal' WHERE company_id IS NULL
```

So a seeded row landed with NULL and was repaired on the way past. #178/#180's move to a one-shot migration Job plus 0002's `SET NOT NULL` removed the tolerance and the repair in the same release. `verifySchemaWithBootRetry()` is deliberately read-only — its own comment says it "contains no CREATE/ALTER/DROP path" — so nothing fixes it up any more. The seed has to be correct on the first attempt now.

### The fix

Name the column. `'personal'` is where the seeded participants and projects already go, and the baseline creates that `companies` row, so the conversation belongs in the same workspace.

With it set, 0002's `conversations_seed_members_after_insert` trigger derives the normalized rows correctly — nine conversations, every `conversation_members` count equal to its JSONB projection length, and zero rows with a NULL `company_id`:

```
      id      | company_id | member_rows | projection_len
--------------+------------+-------------+----------------
 aurora       | personal   |           5 |              5
 direct-atlas | personal   |           2 |              2
 …
```

### Verification

- **Reproduced the failure and confirmed the fix** against a real, freshly migrated Postgres 16 — not a mock.
- New integration test seeds against the migrated schema. **It fails without the fix**, with the production error verbatim on all four cases:
  ```
  not ok 1 - [integration] seeding an empty database does not abort the boot
    error: 'null value in column "company_id" of relation "conversations" violates not-null constraint'
  ```
  and passes with it.
- The test restores the baseline `companies` row after `resetAllTables()`, because that helper truncates `companies` too — without it the seed fails on a foreign key for a reason a real fresh install never hits, which would have made the test red for the wrong cause.
- Unit suite: zero new failures against `main`. (`agents-computer-engine.test.ts`'s detached-process-group case flaked once under full-suite load; it passes 5/5 in isolation on both `main` and this branch.)
- `tsc --noEmit`, `biome lint .`, and all three source guards clean.

### One thing I did not change

`seedIfEmpty()` plants nine demo conversations and a dev login (`yetone@dev.local` / `cumora-dev`) into any empty database, including a production one, with no env gate. That is a separate decision from this bug and I left it alone — but it is why this path runs on a real deployment at all, so it seemed worth naming.
