### PR TITLE
fix(realtime): a body cut mid-emoji must not roll back the message

### DIFF
--- a/server/src/__integration__/realtime-outbox.test.ts
+++ b/server/src/__integration__/realtime-outbox.test.ts
@@ -2,7 +2,7 @@ import { createServer, type Server } from 'node:http'
 import { after, before, beforeEach, test } from 'node:test'
 import assert from 'node:assert/strict'
 import { pool } from '../db/pool.js'
-import { drainRealtimeOutbox } from '../realtime-outbox.js'
+import { drainRealtimeOutbox, enqueueBroadcast } from '../realtime-outbox.js'
 import type { BroadcastEvent } from '../redis.js'
 import {
   buildApiTestApp, ensureSchemaOnce, resetAllTables,
@@ -153,4 +153,76 @@ test('[integration] document and calendar creates replay without duplicate rows 
     `SELECT COUNT(*)::int AS count FROM realtime_outbox`,
   )
   assert.equal(events.rows[0]?.count, 2)
+})
+
+// ── a body cut mid-emoji must not roll the transaction back ─────────────────
+//
+// The quote path truncates by UTF-16 code unit (`qr[0].body.slice(0, 240)`), so
+// a message with a non-BMP character straddling that index yields a lone
+// surrogate. JSON.stringify emits it as the ASCII escape `\ud83d`, which reaches
+// Postgres intact and is refused by the jsonb cast:
+//
+//   ERROR:  invalid input syntax for type json
+//   DETAIL: Unicode low surrogate must follow a high surrogate.
+//
+// Because the enqueue is inside the caller's transaction, that took the message
+// with it. `messages.body` is TEXT and accepts the same bytes, so only the
+// outbox half died — which is what made one emoji-bearing message permanently
+// un-quotable rather than merely ugly.
+
+/** Exactly what the quote path produces: 239 ASCII chars then an emoji, cut at 240. */
+const CUT_MID_EMOJI = `${'a'.repeat(239)}\u{1F600}`.slice(0, 240)
+
+test('[integration] a payload truncated mid-emoji still enqueues', async () => {
+  assert.equal(CUT_MID_EMOJI.charCodeAt(239), 0xd83d, 'fixture no longer ends in a lone surrogate')
+
+  const id = await enqueueBroadcast(pool, 'message:new', {
+    type: 'message.new',
+    conversationId: 'c-outbox',
+    quoted: { body: CUT_MID_EMOJI },
+  } as unknown as BroadcastEvent)
+
+  const { rows } = await pool.query<{ body: string }>(
+    `SELECT payload->'quoted'->>'body' AS body FROM realtime_outbox WHERE id = $1`,
+    [id],
+  )
+  assert.equal(rows.length, 1, 'the row was not written')
+  // The broken half is dropped, not the message: 239 readable characters survive.
+  assert.equal(rows[0].body, 'a'.repeat(239))
+})
+
+test('[integration] a lone surrogate anywhere in the tree is scrubbed, not just at the top', async () => {
+  // Payload fields grow over time; scrubbing lives at the single cast so a new
+  // nested field cannot reintroduce this.
+  const id = await enqueueBroadcast(pool, 'message:new', {
+    type: 'message.new',
+    conversationId: 'c-outbox',
+    quoted: { body: '\ud83d', authorName: 'tail \ud83d' },
+    tags: ['\ud83d', 'ok'],
+  } as unknown as BroadcastEvent)
+
+  const { rows } = await pool.query<{ payload: Record<string, unknown> }>(
+    `SELECT payload FROM realtime_outbox WHERE id = $1`, [id],
+  )
+  const payload = rows[0].payload as {
+    quoted: { body: string; authorName: string }; tags: string[]
+  }
+  assert.equal(payload.quoted.body, '')
+  assert.equal(payload.quoted.authorName, 'tail ')
+  assert.deepEqual(payload.tags, ['', 'ok'])
+})
+
+test('[integration] a well-formed emoji is untouched', async () => {
+  // The scrub must only remove UNPAIRED halves — a real emoji has to survive
+  // intact or every message carrying one arrives mangled.
+  const id = await enqueueBroadcast(pool, 'message:new', {
+    type: 'message.new',
+    conversationId: 'c-outbox',
+    quoted: { body: 'ship it \u{1F680} done' },
+  } as unknown as BroadcastEvent)
+  const { rows } = await pool.query<{ body: string }>(
+    `SELECT payload->'quoted'->>'body' AS body FROM realtime_outbox WHERE id = $1`,
+    [id],
+  )
+  assert.equal(rows[0].body, 'ship it \u{1F680} done')
 })

--- a/server/src/realtime-outbox.ts
+++ b/server/src/realtime-outbox.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import type { PoolClient, QueryResult, QueryResultRow } from 'pg'
 import { pool } from './db/pool.js'
+import { stripLoneSurrogates } from './agents/text-safety.js'
 import { publish, type BroadcastEvent } from './redis.js'
 
 /**
@@ -60,9 +61,34 @@ export async function enqueueBroadcast(
   await db.query(
     `INSERT INTO realtime_outbox (id, channel, payload)
      VALUES ($1, $2, $3::jsonb)`,
-    [id, channel, JSON.stringify(payload)],
+    [id, channel, serializePayload(payload)],
   )
   return id
+}
+
+/** Serialize an outbox payload so Postgres will accept it as `jsonb`.
+ *
+ *  A body truncated mid-emoji — `qr[0].body.slice(0, 240)` on the quote path —
+ *  ends in a lone UTF-16 surrogate. JSON.stringify turns that into the literal
+ *  ASCII escape `\ud83d`, which survives transport intact and is then rejected:
+ *
+ *    ERROR:  invalid input syntax for type json
+ *    DETAIL: Unicode low surrogate must follow a high surrogate.
+ *
+ *  That matters here and not before because the enqueue is INSIDE the caller's
+ *  transaction. The same payload used to go to redis.publish AFTER COMMIT, where
+ *  a lone surrogate was a cosmetic glyph; behind a `::jsonb` cast it rolls the
+ *  message back and 500s, so a quote-reply to one emoji-bearing message fails
+ *  forever. `messages.body` is TEXT and accepts the same bytes, which is why
+ *  only the outbox half dies.
+ *
+ *  Scrubbing here rather than at each call site is deliberate: every field of
+ *  every future event goes through this one cast. The replacer visits every
+ *  string in the tree, so nesting and arrays need no traversal of our own. */
+function serializePayload(payload: unknown): string {
+  return JSON.stringify(payload, (_key, value) =>
+    typeof value === 'string' ? stripLoneSurrogates(value) : value,
+  )
 }
 
 /** Run a mutation and all of its realtime invalidations in one transaction. */


### PR DESCRIPTION
Quoting a message that contains an emoji can destroy the reply and 500.

The quote path truncates by UTF-16 code unit:

```ts
body: qr[0].body.slice(0, 240),      // server/src/api/router.ts:4133
```

If the 240th code unit is half of a non-BMP character, the result ends in a lone surrogate. `JSON.stringify` renders that as the literal ASCII escape `\ud83d`, which survives node-postgres' parameter encoding byte-for-byte — and Postgres refuses it:

```
ERROR:  invalid input syntax for type json
DETAIL: Unicode low surrogate must follow a high surrogate.
```

`enqueueBroadcast` runs **inside the caller's transaction**, so this doesn't just drop a notification. The `ROLLBACK` at `router.ts:4189` discards the sender's `messages` row, the `conversation_counters` bump and the `conversations.updated_at` touch, and the request 500s. Every retry fails the same way, so **one emoji-bearing message becomes permanently un-quotable** — for humans through the API and for agents through `cumora send --quote` (`server/src/agents/cli.ts:2176`, same `slice(0, 240)`).

### Reproduced

Postgres 16, through `enqueueBroadcast` itself, with exactly the string `router.ts:4133` produces:

```
quoted body ends with charCode 0xd83d
ENQUEUE FAILED  code=22P02
  message: invalid input syntax for type json
  detail : Unicode low surrogate must follow a high surrogate.
```

And the asymmetry that makes it a lost write rather than a cosmetic one:

```sql
SELECT '{"body":"hi \ud83d"}'::jsonb;   -- ERROR: invalid input syntax for type json
SELECT length('hi \ud83d');             -- 9
```

`messages.body` is TEXT and takes the same bytes happily. Only the outbox half dies, and it takes the transaction with it.

### Why this is new in 0.14

`git diff v0.13.2..main -- server/src/api/router.ts` shows the same payload used to go out as

```diff
-      await publish(CH_MESSAGE_NEW, {
+      await enqueueBroadcast(client, CH_MESSAGE_NEW, {
```

`redis.publish` happened **after** COMMIT and took any string, so a lone surrogate was a glyph that rendered as `�` somewhere. Behind a `::jsonb` cast inside the transaction it became a rollback. This is precisely the ambiguity `docs/decisions/0001-transactional-realtime-outbox.md` set out to remove — the commit is meant to be the only success boundary — so it seemed worth fixing at that boundary rather than at the caller.

### The fix

Scrub at the cast, not at the 24 `enqueueBroadcast` call sites across 8 files, so fields added to future events are covered without anyone remembering to.

The helper already exists and its own doc comment names this exact cause:

```ts
/** Strip UNPAIRED UTF-16 surrogates. A string sliced mid-emoji (e.g.
 *  `body.slice(0, N)` cutting a surrogate pair) leaves a lone high/low surrogate. …
```

It was written for the model boundary (`cli.ts`, `computer/engine.ts`) and had simply never been pointed at this one. A `JSON.stringify` replacer visits every string in the tree, so nesting and arrays need no traversal of our own — worth noting because scrubbing the *serialized* text would not work: by then the surrogate is already the ASCII escape.

### Verification

- **Reproduced and fixed against a real Postgres 16**, through the product code path rather than a mock.
- Three regression tests in `realtime-outbox.test.ts`. **Two fail without the fix**, with the production error:
  ```
  not ok 4 - [integration] a payload truncated mid-emoji still enqueues
    error: 'invalid input syntax for type json'
  not ok 5 - [integration] a lone surrogate anywhere in the tree is scrubbed, not just at the top
    error: 'invalid input syntax for type json'
  ```
- The third pins the opposite direction — **a well-formed emoji must survive intact** — and passes both with and without the fix, so over-scrubbing would be caught too.
- The mid-emoji test also asserts the readable half is kept: 239 characters survive, only the broken byte pair goes.
- Unit suite: zero new failures against `main`. `tsc --noEmit`, `biome lint .`, all three source guards clean.

### Not changed

The quote card is still cut at 240 code units, so a truncated body can now end one character short of a glyph instead of showing a broken one. Fixing the truncation to be grapheme-aware is a display question, separate from the lost write, and I left it alone.
