### PR TITLE
fix(ui): typing a model id in full must pin that model

### DIFF
--- a/server/src/__tests__/combobox-highlight.test.ts
+++ b/server/src/__tests__/combobox-highlight.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Typing a model id in full and pressing Enter must pin that model.
+ *
+ * The BYOA model picker's first row is the placeholder
+ *
+ *   { value: '', label: 'Follow engine default', hint: <catalog default id> }
+ *
+ * and <Combobox>'s filter matches `hint` as well as `label`. For an agent with
+ * no pin (`value === ''`), typing the default model id left both rows in the
+ * list, the highlight stayed on the placeholder because it held the current
+ * value, and Enter committed '' — so the agent was saved UNPINNED while the
+ * trigger showed the typed id as its hint.
+ *
+ * Pinning is what stops a model upgrade in the local CLI from silently changing
+ * an agent's behaviour, so the failure surfaces much later and looks like the
+ * agent changed on its own.
+ *
+ * Run: node --import tsx --test server/src/__tests__/combobox-highlight.test.ts
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { initialActiveIndex } from '../../../src/lib/combobox-highlight.js'
+
+/** The BYOA model options, in the order AgentEditor builds them. */
+const MODEL_ROWS = [
+  { value: '', label: 'Follow engine default' },
+  { value: 'gpt-5.6-sol', label: 'GPT-5.6 Sol' },
+  { value: 'gpt-5.4-mini', label: 'GPT-5.4 mini' },
+]
+
+// ── the case that lost the pin ─────────────────────────────────────────────
+
+test('typing the default model id in full highlights that model, not the placeholder', () => {
+  // Both rows survive the filter: the placeholder matches through its hint,
+  // which IS this id. The unpinned agent's value is ''.
+  const filtered = [MODEL_ROWS[0], MODEL_ROWS[1]]
+  assert.equal(initialActiveIndex(filtered, '', 'gpt-5.6-sol'), 1)
+})
+
+test('the same holds when the typed id is not the catalog default', () => {
+  const filtered = [MODEL_ROWS[2]]
+  assert.equal(initialActiveIndex(filtered, '', 'gpt-5.4-mini'), 0)
+})
+
+test('an exact label match counts too', () => {
+  // The user can type what they see rather than the id.
+  const filtered = [MODEL_ROWS[0], MODEL_ROWS[1]]
+  assert.equal(initialActiveIndex(filtered, '', 'GPT-5.6 Sol'), 1)
+})
+
+test('matching is case-insensitive, like the filter above it', () => {
+  const filtered = [MODEL_ROWS[0], MODEL_ROWS[1]]
+  assert.equal(initialActiveIndex(filtered, '', 'GPT-5.6-SOL'), 1)
+  assert.equal(initialActiveIndex(filtered, '', '  gpt-5.6-sol  '), 1)
+})
+
+// ── and the behaviour that was already right ───────────────────────────────
+
+test('with no query the highlight still follows the current value', () => {
+  assert.equal(initialActiveIndex(MODEL_ROWS, 'gpt-5.4-mini', ''), 2)
+  assert.equal(initialActiveIndex(MODEL_ROWS, '', ''), 0)
+})
+
+test('a partial query is left alone', () => {
+  // Nothing is named exactly, so the old rule applies: the current value, which
+  // here is the pinned model. Changing this would be a different decision.
+  assert.equal(initialActiveIndex(MODEL_ROWS, 'gpt-5.4-mini', 'gpt'), 2)
+})
+
+test('a current value that filtered out falls back to the top', () => {
+  assert.equal(initialActiveIndex([MODEL_ROWS[1]], 'gpt-5.4-mini', 'sol'), 0)
+})
+
+test('an empty list is not an index', () => {
+  assert.equal(initialActiveIndex([], 'gpt-5.6-sol', 'gpt-5.6-sol'), 0)
+})
+
+test('the placeholder is still reachable by naming it', () => {
+  // Pinning must not become impossible to undo from the keyboard.
+  assert.equal(initialActiveIndex(MODEL_ROWS, 'gpt-5.6-sol', 'Follow engine default'), 0)
+})

--- a/src/components/Combobox.tsx
+++ b/src/components/Combobox.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useId, useMemo, useRef, useState } from 'react'
+import { initialActiveIndex } from '@/lib/combobox-highlight'
 import { useT } from '@/lib/i18n'
 import { cn } from '@/lib/utils'
 
@@ -77,12 +78,13 @@ export function Combobox<T extends string = string>({
     : ''
   const resultCount = filtered.length + (customValue ? 1 : 0)
 
-  // Keep the highlight on the current value when the menu (re)opens, else top.
+  // Keep the highlight on the current value when the menu (re)opens, else top —
+  // except when the query names one option exactly, which wins. See
+  // combobox-highlight.ts for the case that made the exception necessary.
   useEffect(() => {
     if (!open) return
-    const idx = filtered.findIndex((o) => o.value === value)
-    setActiveIndex(idx >= 0 ? idx : 0)
-  }, [open, filtered, value, customValue])
+    setActiveIndex(initialActiveIndex(filtered, value, query))
+  }, [open, filtered, value, query, customValue])
 
   // Close on outside click.
   useEffect(() => {

--- a/src/lib/combobox-highlight.ts
+++ b/src/lib/combobox-highlight.ts
@@ -1,0 +1,43 @@
+/**
+ * Which row a <Combobox> highlights when its menu opens or its filter changes.
+ *
+ * Pure and React-free so the rule can be pinned without rendering — the same
+ * reason recurrence.ts and prompt-surface.ts are split out.
+ *
+ * The rule used to be "whatever row holds the current value, else the first",
+ * which reads well until a row's `hint` collides with another row's `value`.
+ * The BYOA model picker does exactly that: its first row is
+ *
+ *   { value: '', label: 'Follow engine default', hint: <the default model id> }
+ *
+ * and the filter matches on `hint` as well as `label`. So for an agent with no
+ * pin (value === ''), typing the default model id in full left BOTH rows in the
+ * list, the highlight stayed on the placeholder because it holds the current
+ * value, and Enter committed '' — "follow engine default" — when the user had
+ * just typed the id they wanted pinned. Pinning exists precisely so a model
+ * upgrade in the underlying CLI cannot silently change an agent's behaviour, so
+ * the failure is quiet and lands later.
+ *
+ * A query that names one option exactly now wins over the current value. With
+ * no query, or with a partial one, nothing changes.
+ */
+export interface HighlightableOption {
+  value: string
+  label: string
+}
+
+export function initialActiveIndex(
+  filtered: readonly HighlightableOption[],
+  currentValue: string,
+  query: string,
+): number {
+  const needle = query.trim().toLowerCase()
+  if (needle) {
+    const exact = filtered.findIndex(
+      (option) => option.value.toLowerCase() === needle || option.label.toLowerCase() === needle,
+    )
+    if (exact >= 0) return exact
+  }
+  const current = filtered.findIndex((option) => option.value === currentValue)
+  return current >= 0 ? current : 0
+}


### PR DESCRIPTION
Typing a model id in full and pressing Enter saves the agent **unpinned**.

The BYOA model picker builds its first row as a placeholder whose hint is the catalog's default model id (`src/components/AgentEditor.tsx:100-105`):

```ts
{ value: '', label: t('agent.followEngineDefault'), hint: modelCatalog?.defaultModel ?? undefined }
```

and `<Combobox>` filters on `hint` as well as `label`:

```ts
return options.filter((o) =>
  o.label.toLowerCase().includes(needle) || (o.hint?.toLowerCase().includes(needle) ?? false),
)
```

So for an agent with no pin — `value === ''` — typing the default id leaves **both** rows in the list, and the highlight effect picks the row holding the current value:

```ts
const idx = filtered.findIndex((o) => o.value === value)   // value is '' → index 0, the placeholder
setActiveIndex(idx >= 0 ? idx : 0)
```

Enter commits `filtered[0]`, so `onValueChange('')` fires and the agent is saved with no pin, while the trigger shows "Follow engine default" with the typed id sitting next to it as its hint. It looks like it worked.

### Why it matters later

Pinning exists to stop the local CLI's default from moving underneath an agent — `listAgentsForComputer`'s own comment puts it plainly: *"a model upgrade in the underlying CLI … silently changes agent behavior on every user's machine unless we pin here."* An operator who pinned deliberately and got nothing finds out when the CLI updates and the agent starts behaving differently, which does not look like a picker bug by then.

The bug is specific to an unpinned agent. With an existing pin, `findIndex` lands on the real row and Enter commits correctly.

### The change

A query that names one option **exactly** — by value or label, case-insensitively — wins over the current value. With no query, or a partial one, nothing changes: the highlight still follows the current value, then falls back to the top.

The rule moves into `src/lib/combobox-highlight.ts`, pure and React-free, so it can be pinned without rendering — the same split as `recurrence.ts` and `prompt-surface.ts`, and the same cross-directory test import `frontend-calendar-recurrence.test.ts` established.

### Verification

- Nine cases. **Four go red against the original rule** and green with this one:
  ```
  not ok 1 - typing the default model id in full highlights that model, not the placeholder
  not ok 3 - an exact label match counts too
  not ok 4 - matching is case-insensitive, like the filter above it
  not ok 9 - the placeholder is still reachable by naming it
  ```
- The other five pin what must not change: no query still follows the current value, a partial query is left alone, a current value that filtered out falls back to the top, and an empty list yields 0.
- Case 9 is the one I'd want a reviewer to check hardest — **un-pinning must stay possible from the keyboard**, so typing "Follow engine default" with a model pinned still selects the placeholder.
- Frontend and server `tsc --noEmit`, `biome lint .`, all three source guards clean. Unit suite green.

`<Combobox>` has two other call sites — the admin tenant picker (`ObservabilityPage.tsx:1551`) and the small-brain picker next to this one. For the tenant picker the effect is that typing a tenant's exact name now highlights it, which is the same improvement.
