### PR TITLE
test(byoa): the Claude settings tests must not read the developer's shell

### DIFF
--- a/server/src/__tests__/agents-computer-engine.test.ts
+++ b/server/src/__tests__/agents-computer-engine.test.ts
@@ -10,6 +10,7 @@ import { delimiter, dirname, join } from 'node:path'
 import { afterEach, test } from 'node:test'
 import { setTimeout as delay } from 'node:timers/promises'
 import { type EngineHopReport, type EngineRunResult, getAdapter, headlessSpawnOptions, resolveSpawn, runnableEngineIds, secureEngineCapabilityReason } from '../agents/computer/engine.js'
+import { CLAUDE_CORE_ENV_KEYS } from '../agents/computer/claude-user-settings.js'
 
 const IS_WIN = process.platform === 'win32'
 const ORIGINAL_PATH = process.env.PATH
@@ -21,8 +22,18 @@ const tempDirs: string[] = []
 const liveSessions: Array<{ stop(): void | Promise<void> }> = []
 
 function secureClaudeEnv(root: string, overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  const base: NodeJS.ProcessEnv = { ...process.env }
+  // withClaudeUserSettingsEnv only imports a key from settings.json when the
+  // process environment does NOT already define it — an explicit value wins, by
+  // design. Spreading process.env therefore let the developer's own shell
+  // decide the outcome: anyone running Claude Code has ANTHROPIC_BASE_URL set,
+  // so the settings-import assertions below failed on their machine and nowhere
+  // else. Drop the bootstrap keys so these tests measure the import, not the
+  // shell. Sourced from the module under test so a fifth key cannot drift.
+  for (const key of CLAUDE_CORE_ENV_KEYS) delete base[key]
+  delete base.CLAUDE_CONFIG_DIR
   return {
-    ...process.env,
+    ...base,
     CUMORA_AGENT_IPC_DIR: join(root, 'private-ipc'),
     CUMORA_AGENT_MCP_SHIM: join(root, 'trusted', 'cumora-mcp'),
     ...overrides,


### PR DESCRIPTION
`npm test` fails on the machine of anyone who runs Claude Code — which is cumora's flagship BYOA engine.

```
not ok 7 - Claude secure mode is fail-closed and strips tool credentials
    Expected values to be strictly deep-equal:
    + actual - expected
      {
        apiKey: 'explicit-daemon-api-key',
        authToken: 'settings-auth-token',
    +   baseUrl: 'https://api.anthropic.com'
    -   baseUrl: 'https://provider.example.test'
      }
```

Green in CI, red locally, with nothing in the diff to explain it. I spent a while assuming `main` was broken before finding the cause.

### Cause

`secureClaudeEnv` spreads the ambient environment:

```ts
function secureClaudeEnv(root: string, overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
  return { ...process.env, CUMORA_AGENT_IPC_DIR: …, CUMORA_AGENT_MCP_SHIM: …, ...overrides }
}
```

and `withClaudeUserSettingsEnv` imports a key from `settings.json` **only when the environment does not already define it**:

```ts
for (const key of CLAUDE_CORE_ENV_KEYS) {
  if (merged[key] === undefined && coreEnv[key] !== undefined) merged[key] = coreEnv[key]
}
```

That precedence is correct and deliberate — an explicit daemon-level value should beat a user's settings file. But it means the tests asserting the *settings import* were really asserting "…and the developer's shell happens not to set these four names". Claude Code sets `ANTHROPIC_BASE_URL` in its environment, so on a contributor's machine the shell wins and the assertion fails.

Confirmed by elimination: `env -u ANTHROPIC_BASE_URL node --import tsx --test …` → 21 pass, 0 fail, on unmodified `main`. **No product bug here** — the adapter does exactly what its comment says.

### The change

Drop the bootstrap keys, and `CLAUDE_CONFIG_DIR`, before applying the per-test overrides. `CLAUDE_CORE_ENV_KEYS` is imported from the module under test rather than restated, so adding a fifth key cannot leave the helper behind.

### Verification

Green three ways, so the fix is not just moving the sensitivity around:

| environment | before | after |
|---|---|---|
| `ANTHROPIC_BASE_URL` set (a Claude Code machine) | **1 fail** | 21 pass |
| unset (CI today) | 21 pass | 21 pass |
| `ANTHROPIC_AUTH_TOKEN` + `ANTHROPIC_API_KEY` + a bogus `CLAUDE_CONFIG_DIR` | untested | 21 pass |

Full unit suite: 1102 pass, 0 fail, run with `ANTHROPIC_BASE_URL` still set in the shell. `tsc --noEmit`, `biome lint .`, all three source guards clean.

The third row is the point — the old helper only failed on `ANTHROPIC_BASE_URL` today because that is the one Claude Code exports, but `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` are equally common in a shell and would have taken the same path through the same `if`.
