### PR TITLE
fix(byoa): Anthropic's own base URL is not a custom provider

### DIFF
--- a/server/src/__tests__/claude-first-party-endpoint.test.ts
+++ b/server/src/__tests__/claude-first-party-endpoint.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Anthropic's own base URL is not a custom provider.
+ *
+ * Three places asked "is ANTHROPIC_BASE_URL set?" and treated yes as "a custom
+ * endpoint owns the model namespace":
+ *
+ *   engine.ts        omit `--model haiku` from the triage spawn
+ *   model-catalog.ts drop the opus/sonnet/haiku presets and defaultFastModel
+ *   registry.ts      via prefersLocalDefault, drop the deploy-level model pin
+ *
+ * But Claude Code exports ANTHROPIC_BASE_URL into every process it spawns,
+ * pointing at Anthropic's own endpoint. So a first-party account with no
+ * settings.json at all took the custom-provider branch on cumora's flagship
+ * engine, purely because the daemon was started from a Claude Code session —
+ * or from any shell that exports the variable.
+ *
+ * Measured before the fix, with CLAUDE_CONFIG_DIR pointing at an empty dir:
+ *
+ *   without the variable   models=opus,sonnet,haiku  defaultFastModel=haiku
+ *   ANTHROPIC_BASE_URL=https://api.anthropic.com
+ *                          models=(none)             defaultFastModel=null
+ *
+ * The model picker empties and triage silently leaves Haiku for the account's
+ * default big model — on the highest-frequency call an agent makes.
+ *
+ * Run: node --import tsx --test server/src/__tests__/claude-first-party-endpoint.test.ts
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+process.env.CUMORA_RUNTIME_CLIENT = 'http'
+process.env.OPENAI_API_KEY ??= 'test-key'
+
+const { isCustomAnthropicEndpoint } = await import('../agents/computer/claude-user-settings.js')
+const { discoverEngineModelCatalog } = await import('../agents/computer/model-catalog.js')
+
+// ── the predicate ──────────────────────────────────────────────────────────
+
+test("Anthropic's own endpoint is not custom, however it is written", () => {
+  for (const url of [
+    'https://api.anthropic.com',
+    'https://api.anthropic.com/',
+    'https://api.anthropic.com/v1',
+    '  https://API.Anthropic.COM/v1/  ',
+  ]) {
+    assert.equal(isCustomAnthropicEndpoint(url), false, url)
+  }
+})
+
+test('an absent or blank value is not custom', () => {
+  for (const url of [undefined, null, '', '   ']) {
+    assert.equal(isCustomAnthropicEndpoint(url), false, JSON.stringify(url))
+  }
+})
+
+test('anything else is custom', () => {
+  for (const url of [
+    'https://provider.example.test',
+    'http://localhost:8080',
+    'https://anthropic.com.evil.test',      // suffix trick must not read as first-party
+    'https://not-api.anthropic.com.co',
+  ]) {
+    assert.equal(isCustomAnthropicEndpoint(url), true, url)
+  }
+})
+
+test('an unparseable value is treated as custom', () => {
+  // We cannot vouch for it as first-party, and the conservative answer is to
+  // stop claiming Anthropic's aliases exist behind it.
+  assert.equal(isCustomAnthropicEndpoint('not a url'), true)
+  assert.equal(isCustomAnthropicEndpoint('api.anthropic.com'), true) // no scheme → not parseable
+})
+
+// ── what that means for the catalog the editor renders ─────────────────────
+
+const EMPTY_CONFIG = { CLAUDE_CONFIG_DIR: '/nonexistent-claude-config-for-tests' }
+
+test('a first-party account keeps its presets when the variable is set', async () => {
+  const catalog = await discoverEngineModelCatalog('claude', '/usr/local/bin/claude', true, {
+    ...EMPTY_CONFIG,
+    ANTHROPIC_BASE_URL: 'https://api.anthropic.com',
+  })
+  assert.deepEqual(catalog.models.map((m) => m.id), ['opus', 'sonnet', 'haiku'])
+  assert.equal(catalog.defaultFastModel, 'haiku')
+  assert.notEqual(catalog.prefersLocalDefault, true)
+})
+
+test('and is identical to having no variable at all', async () => {
+  const withVar = await discoverEngineModelCatalog('claude', '/usr/local/bin/claude', true, {
+    ...EMPTY_CONFIG, ANTHROPIC_BASE_URL: 'https://api.anthropic.com',
+  })
+  const without = await discoverEngineModelCatalog('claude', '/usr/local/bin/claude', true, {
+    ...EMPTY_CONFIG,
+  })
+  assert.deepEqual(withVar.models, without.models)
+  assert.equal(withVar.defaultFastModel, without.defaultFastModel)
+})
+
+test('a real custom endpoint still owns its namespace', async () => {
+  // The behaviour this branch exists for must be untouched: claiming Anthropic's
+  // aliases exist on someone else's endpoint is the thing it prevents.
+  const catalog = await discoverEngineModelCatalog('claude', '/usr/local/bin/claude', true, {
+    ...EMPTY_CONFIG,
+    ANTHROPIC_BASE_URL: 'https://provider.example.test',
+  })
+  assert.deepEqual(catalog.models, [])
+  assert.equal(catalog.defaultFastModel, null)
+  assert.equal(catalog.prefersLocalDefault, true)
+})

--- a/server/src/agents/computer/claude-user-settings.ts
+++ b/server/src/agents/computer/claude-user-settings.ts
@@ -22,6 +22,31 @@ export const CLAUDE_CORE_ENV_KEYS = [
   'ANTHROPIC_SMALL_FAST_MODEL',
 ] as const
 
+/** Anthropic's own API origins. A base URL naming one of these is not a custom
+ *  provider — it is the default, written out.
+ *
+ *  This matters because Claude Code exports ANTHROPIC_BASE_URL into every
+ *  process it spawns, pointing at Anthropic's own endpoint. Treating "the
+ *  variable is set" as "a custom provider owns the model namespace" therefore
+ *  fires for an ordinary first-party account whenever the daemon is started
+ *  from a Claude Code session, or from any shell that exports it. */
+const ANTHROPIC_FIRST_PARTY_HOSTS: ReadonlySet<string> = new Set(['api.anthropic.com'])
+
+/** Does this base URL point somewhere other than Anthropic itself?
+ *
+ *  Unset is not custom. An unparseable value IS treated as custom: we cannot
+ *  vouch for it as first-party, and the conservative answer is to stop claiming
+ *  Anthropic's model aliases exist behind it. */
+export function isCustomAnthropicEndpoint(baseUrl: string | null | undefined): boolean {
+  const raw = baseUrl?.trim()
+  if (!raw) return false
+  try {
+    return !ANTHROPIC_FIRST_PARTY_HOSTS.has(new URL(raw).hostname.toLowerCase())
+  } catch {
+    return true
+  }
+}
+
 type ClaudeCoreEnvKey = typeof CLAUDE_CORE_ENV_KEYS[number]
 
 export interface ClaudeUserSettings {
@@ -80,7 +105,7 @@ export function readClaudeUserSettings(env: NodeJS.ProcessEnv = process.env): Cl
       // A custom endpoint owns its model namespace. When no explicit Agent pin
       // exists, the server must not replace that namespace with its Anthropic
       // deployment default even if the local config omits a named model.
-      prefersLocalDefault: !!coreEnv.ANTHROPIC_BASE_URL,
+      prefersLocalDefault: isCustomAnthropicEndpoint(coreEnv.ANTHROPIC_BASE_URL),
     }
   } catch {
     return EMPTY_SETTINGS

--- a/server/src/agents/computer/engine.ts
+++ b/server/src/agents/computer/engine.ts
@@ -30,7 +30,7 @@ import { homedir, tmpdir } from 'node:os'
 import { basename, dirname, join, delimiter as PATH_DELIMITER } from 'node:path'
 import { StringDecoder } from 'node:string_decoder'
 import { stripLoneSurrogates } from '../text-safety.js'
-import { withClaudeUserSettingsEnv } from './claude-user-settings.js'
+import { isCustomAnthropicEndpoint, withClaudeUserSettingsEnv } from './claude-user-settings.js'
 import { isCliVersionAtLeast, probeEngineVersion, probeLocalEngineVersion } from './cli-version.js'
 import { discoverEngineModelCatalog, type EngineModelCatalog } from './model-catalog.js'
 
@@ -1419,13 +1419,16 @@ function claudeCoreEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
 /** Pick the small brain inside the local provider namespace. An explicit
  * per-agent/computer pin wins; next use the provider's configured fast model.
  * If a custom endpoint names no fast model, omit --model and let that endpoint
- * choose instead of injecting Anthropic's `haiku` alias. */
+ * choose instead of injecting Anthropic's `haiku` alias. Anthropic's OWN base
+ * URL is not a custom endpoint — Claude Code exports it into every child
+ * process, so keying on "the variable is set" dropped Haiku for first-party
+ * accounts. */
 function claudeFastModelArgs(env: NodeJS.ProcessEnv, requested?: string | null): string[] {
   const model = requested?.trim()
     || env.CUMORA_TRIAGE_MODEL?.trim()
     || env.ANTHROPIC_SMALL_FAST_MODEL?.trim()
   if (model) return ['--model', model]
-  return env.ANTHROPIC_BASE_URL?.trim() ? [] : ['--model', 'haiku']
+  return isCustomAnthropicEndpoint(env.ANTHROPIC_BASE_URL) ? [] : ['--model', 'haiku']
 }
 
 function claudeTurnEnv(env: NodeJS.ProcessEnv, fastModel?: string | null): NodeJS.ProcessEnv {

--- a/server/src/agents/computer/model-catalog.ts
+++ b/server/src/agents/computer/model-catalog.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process'
 import type { EngineId } from './engine.js'
-import { readClaudeUserSettings, withClaudeUserSettingsEnv } from './claude-user-settings.js'
+import { isCustomAnthropicEndpoint, readClaudeUserSettings, withClaudeUserSettingsEnv } from './claude-user-settings.js'
 import { versionCommandInvocation } from './cli-version.js'
 
 export type ModelCatalogSource = 'protocol' | 'cli' | 'presets'
@@ -331,7 +331,7 @@ export async function discoverEngineModelCatalog(
     const settings = readClaudeUserSettings(env)
     const coreEnv = withClaudeUserSettingsEnv(env)
     const defaultFastModel = clean(coreEnv.ANTHROPIC_SMALL_FAST_MODEL, 160)
-    const prefersLocalDefault = !!clean(coreEnv.ANTHROPIC_BASE_URL, 4096)
+    const prefersLocalDefault = isCustomAnthropicEndpoint(clean(coreEnv.ANTHROPIC_BASE_URL, 4096))
     const configured = [settings.defaultModel, defaultFastModel]
       .filter((model): model is string => !!model)
       .map((model) => ({ id: model, label: model }))


### PR DESCRIPTION
A first-party Anthropic account loses its model picker and its Haiku triage default, if the daemon happens to be started from a shell that exports `ANTHROPIC_BASE_URL` — which Claude Code does, into every process it spawns.

Three places ask "is `ANTHROPIC_BASE_URL` set?" and read yes as "a custom endpoint owns the model namespace":

```ts
// engine.ts — claudeFastModelArgs
return env.ANTHROPIC_BASE_URL?.trim() ? [] : ['--model', 'haiku']

// model-catalog.ts
const prefersLocalDefault = !!clean(coreEnv.ANTHROPIC_BASE_URL, 4096)
…
models: mergeModels(configured, prefersLocalDefault ? [] : preset.models),
defaultFastModel: defaultFastModel ?? (prefersLocalDefault ? null : preset.defaultFastModel),

// registry.ts:675 — the deploy-level pin, gated on the same flag
if (r.engine === 'claude' && localCatalog?.prefersLocalDefault) { … }
```

The value it keys on is `https://api.anthropic.com`. That is the default, spelled out — not a custom provider.

Note also that `coreEnv` here is `withClaudeUserSettingsEnv(env)`, the **merged** environment, and the merge is deliberately env-wins. So the ambient variable decides this even for a user whose `settings.json` says nothing. `readClaudeUserSettings` already returns a `prefersLocalDefault` computed from the settings file alone, and it is never read — the catalog recomputes it from the merged env instead.

### Measured

`CLAUDE_CONFIG_DIR` pointing at an empty directory, so nothing comes from a settings file:

```
no variable                             models=opus,sonnet,haiku   defaultFastModel=haiku
ANTHROPIC_BASE_URL=https://api.anthropic.com
                                        models=(none)              defaultFastModel=null   prefersLocalDefault=true
```

Opus, Sonnet and Haiku vanish from the Agent editor for that computer, and `defaultFastModel` goes null.

The triage half I read rather than ran — my fake-CLI harness did not capture the argv cleanly and I would rather say so than dress it up — but the function is four lines with no branch left over: with no explicit pin and the variable set, `claudeFastModelArgs` returns `[]`, so the spawn carries no `--model` and inbox triage runs on the account's default model instead of Haiku. That is the highest-frequency LLM call an agent makes, once per wake.

### The change

Decide on the endpoint, not on the variable's presence:

```ts
export function isCustomAnthropicEndpoint(baseUrl: string | null | undefined): boolean {
  const raw = baseUrl?.trim()
  if (!raw) return false
  try {
    return !ANTHROPIC_FIRST_PARTY_HOSTS.has(new URL(raw).hostname.toLowerCase())
  } catch {
    return true
  }
}
```

Parsing rather than string-matching matters for the negative case: `https://anthropic.com.evil.test` is custom, because the check is on the parsed hostname. And it holds however the URL is written — trailing slash, `/v1`, mixed case.

An unparseable value stays **custom**. We cannot vouch for it as first-party, and the conservative answer is to stop claiming Anthropic's aliases exist behind it.

I used option (b) from the two available — exclude Anthropic's own origins — rather than (a) "trust only the settings file", because an operator who sets `ANTHROPIC_BASE_URL` in the daemon's own environment to point at their proxy *is* on a custom provider, and (a) would stop recognising them.

### Verification

- **Measured before and after** against the real `discoverEngineModelCatalog`, across first-party, `/v1/` + mixed case, a genuine custom endpoint, and an unparseable value.
- Seven regression tests. Reverting **only the catalog call site** (keeping the predicate, so the tests fail for the right reason) turns exactly the two behavioural cases red:
  ```
  not ok 5 - a first-party account keeps its presets when the variable is set
  not ok 6 - and is identical to having no variable at all
  # pass 5  # fail 2
  ```
- The last test is the guard in the other direction — **a real custom endpoint still empties the presets** — and it passes both with and without the fix, so this cannot quietly undo the behaviour the branch exists for.
- Unit suite: **1109 pass, 0 fail**. Server and frontend `tsc --noEmit`, `biome lint .`, all three source guards clean.
- Existing tests are unaffected: every one of them uses `https://provider.example.test`, which this change still classifies as custom.

### Related

#193 makes the Claude settings tests hermetic against the same ambient variable. They are independent — that one stops the *tests* reading the developer's shell, this one stops the *product* doing it — but they were found together, and either alone leaves half of it.
