### PR TITLE
fix(electron): the tray unread dot never updates on Windows or Linux

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -704,6 +704,14 @@ function getDockUnreadIcon() {
 
 function setDockUnreadDot(visible) {
   dockUnreadDotVisible = !!visible
+  // Mirror to the tray FIRST. The dock is macOS-only, but the tray is the
+  // Windows/Linux surface for this same state — and the darwin early-return
+  // below used to sit in front of this call, so on Win/Linux the tray image
+  // was set once when the tray was created and never again. The dot could not
+  // appear there at all: `dock:set-unread-dot` is the only path that carries a
+  // change, and it returned before reaching this line.
+  // Cheap to call when there is no tray (no-op).
+  setTrayUnreadDot(dockUnreadDotVisible)
   if (process.platform !== 'darwin' || !app.dock) return
   try {
     app.dock.setBadge('')
@@ -711,9 +719,6 @@ function setDockUnreadDot(visible) {
     if (!img.isEmpty()) app.dock.setIcon(img)
   } catch { /* swallow — Dock is macOS-only and not critical path */ }
   scheduleRegularDockRepair()
-  // Mirror to the system tray so menu bar / system tray surfaces stay
-  // in sync with the dock. Cheap to call when there's no tray (no-op).
-  setTrayUnreadDot(dockUnreadDotVisible)
 }
 
 /* ============================ System tray ============================

--- a/server/src/__tests__/electron-tray-unread-dot.test.ts
+++ b/server/src/__tests__/electron-tray-unread-dot.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Guard: the tray unread dot must not sit behind the macOS early-return.
+ *
+ * `setDockUnreadDot` is the only path a change in unread state travels — the
+ * renderer sends `dock:set-unread-dot`, main calls this, and nothing else
+ * carries the value. The function mirrors the state to the system tray, which
+ * is the Windows/Linux surface for exactly the same indicator; the tray section
+ * says so itself: "Menu bar item on macOS, system tray on Win/Linux. Same
+ * unread-dot indicator the dock uses."
+ *
+ * The mirror call was placed AFTER `if (process.platform !== 'darwin') return`.
+ * So on Windows and Linux it was unreachable, and the only other call to
+ * `setTrayUnreadDot` is the one-shot restore inside tray creation. The tray
+ * image was therefore set once, at startup, from a state that is false then,
+ * and never updated again — the dot could never appear on those platforms.
+ *
+ * electron/ has no runtime test harness, so this is a source-level guard in the
+ * same shape as electron-native-image.test.ts: pin the ordering, and self-test
+ * the matcher so it cannot quietly become a no-op.
+ *
+ * Run: node --import tsx --test server/src/__tests__/electron-tray-unread-dot.test.ts
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
+const MAIN_CJS = join(REPO_ROOT, 'electron', 'main.cjs')
+
+/** The body of `setDockUnreadDot`, or null if the function moved or was renamed. */
+function dockUnreadDotBody(source: string): string | null {
+  const match = source.match(/function setDockUnreadDot\([^)]*\)\s*\{([\s\S]*?)\n\}/)
+  return match ? match[1] : null
+}
+
+/** Does the tray mirror run before the macOS-only bail-out? */
+function mirrorsTrayBeforeDarwinReturn(body: string): boolean {
+  const mirror = body.indexOf('setTrayUnreadDot(')
+  const bail = body.search(/if \(process\.platform !== 'darwin'[^)]*\) return/)
+  if (mirror < 0 || bail < 0) return false
+  return mirror < bail
+}
+
+test('the tray mirror runs before the macOS-only return', () => {
+  const body = dockUnreadDotBody(readFileSync(MAIN_CJS, 'utf8'))
+  assert.ok(body, 'setDockUnreadDot not found — update this guard alongside the refactor')
+  assert.ok(
+    mirrorsTrayBeforeDarwinReturn(body),
+    'setTrayUnreadDot is unreachable on Windows/Linux: it sits after the darwin early-return',
+  )
+})
+
+test('setDockUnreadDot is still the only path a change arrives on', () => {
+  // If a second updater appears, this guard stops being the whole story and
+  // whoever adds it should see that here rather than discover it on Windows.
+  const source = readFileSync(MAIN_CJS, 'utf8')
+  const calls = source.match(/(?<!function )setTrayUnreadDot\(/g) ?? []
+  assert.equal(
+    calls.length, 2,
+    `expected the mirror in setDockUnreadDot plus the one-shot restore in tray creation, found ${calls.length}`,
+  )
+  assert.match(source, /ipcMain\.on\('dock:set-unread-dot'/)
+})
+
+// ── the matcher must be able to fail ───────────────────────────────────────
+
+test('the guard rejects the ordering that shipped', () => {
+  const broken = [
+    "  dockUnreadDotVisible = !!visible",
+    "  if (process.platform !== 'darwin' || !app.dock) return",
+    "  scheduleRegularDockRepair()",
+    "  setTrayUnreadDot(dockUnreadDotVisible)",
+  ].join('\n')
+  assert.equal(mirrorsTrayBeforeDarwinReturn(broken), false)
+})
+
+test('the guard accepts the ordering that works', () => {
+  const fixed = [
+    "  dockUnreadDotVisible = !!visible",
+    "  setTrayUnreadDot(dockUnreadDotVisible)",
+    "  if (process.platform !== 'darwin' || !app.dock) return",
+  ].join('\n')
+  assert.equal(mirrorsTrayBeforeDarwinReturn(fixed), true)
+})
+
+test('the anchor fails loudly rather than silently passing', () => {
+  assert.equal(dockUnreadDotBody('function somethingElse() {\n  return 1\n}'), null)
+})


### PR DESCRIPTION
On Windows and Linux the system-tray unread dot can never appear.

`setDockUnreadDot` mirrors the state to the tray, and the tray section says exactly what that mirror is for:

> Menu bar item on macOS, system tray on Win/Linux. Same unread-dot indicator the dock uses (we reuse `dockUnreadDotVisible` as the authoritative state).

But the mirror sat below the macOS bail-out:

```js
function setDockUnreadDot(visible) {
  dockUnreadDotVisible = !!visible
  if (process.platform !== 'darwin' || !app.dock) return   // ← Win/Linux stop here
  try {
    app.dock.setBadge('')
    …
  } catch { /* swallow — Dock is macOS-only and not critical path */ }
  scheduleRegularDockRepair()
  // Mirror to the system tray so menu bar / system tray surfaces stay
  // in sync with the dock. Cheap to call when there's no tray (no-op).
  setTrayUnreadDot(dockUnreadDotVisible)                    // ← unreachable off macOS
}
```

`ipcMain.on('dock:set-unread-dot', …)` is the **only** path a change in unread state travels from the renderer, and it lands here. The only other call to `setTrayUnreadDot` is the one-shot restore inside tray creation:

```js
  // Restore unread state in case set-unread-dot was called before tray
  // existed (dock was, but tray wasn't — keep the two in lockstep).
  setTrayUnreadDot(dockUnreadDotVisible)
```

which runs while `dockUnreadDotVisible` is still `false`.

So on those platforms the tray image is set once, at startup, to the clean icon, and never updated again.

`dockUnreadDotVisible` was assigned above the return all along, so the *state* was always right — only the image never followed it. That is why nothing else looks wrong: the tray menu, click handling, and the dock on macOS all behave normally.

### The change

Mirror before the bail-out. One line moved, and the comment now records why its position is load-bearing.

### Verification

`electron/` has no runtime harness — `main.cjs` requires `electron` and cannot be imported by a node test — so the regression test is a source-level guard, in the same shape as `electron-native-image.test.ts`:

- It pins the ordering: `setTrayUnreadDot(` must appear before the `process.platform !== 'darwin'` return inside `setDockUnreadDot`.
- It asserts `setDockUnreadDot` is still the only updater, so a second path appearing later shows up here rather than on someone's Windows machine.
- It **self-tests the matcher both ways** — against the ordering that shipped (expects reject) and the fixed ordering (expects accept) — so the guard cannot quietly become a no-op, which is the failure mode a source-scraping check has.
- The anchor fails loudly: if `setDockUnreadDot` is renamed or moved, the body lookup returns null and the test says to update the guard rather than passing vacuously.

Run against the shipped ordering it goes red on exactly the one assertion:

```
not ok 1 - the tray mirror runs before the macOS-only return
# pass 4  # fail 1
```

Unit suite 1107 pass / 0 fail, `tsc --noEmit`, `biome lint .`, and all three source guards clean.

I could not exercise this on a real Windows or Linux desktop — I only have macOS here — so the platform behaviour is argued from the control flow rather than observed. The control flow is unambiguous, but that is worth stating plainly.
