### PR TITLE
fix(ui): a roster event from another workspace must not join this one

### DIFF
--- a/server/src/__tests__/ws-tenant-events.test.ts
+++ b/server/src/__tests__/ws-tenant-events.test.ts
@@ -1,0 +1,88 @@
+/**
+ * A websocket frame from the other workspace must not join this workspace's
+ * roster.
+ *
+ * The socket is per-USER and deliberately carries every workspace the user
+ * belongs to — the server resolves recipients through company membership, so
+ * one connection serves them all. For someone in two workspaces, that means
+ * frames from the one they are NOT looking at arrive on the same socket.
+ *
+ * Two of the three roster handlers are self-limiting: `participants.status` and
+ * `participants.avatar` both do `if (!cur) return {}`, so a foreign id is a
+ * no-op. `participants.added` INSERTS, and had no company check at all — the
+ * client type did not even declare `companyId`, although the server has always
+ * tagged the event (`ParticipantAddedEvent extends TenantTagged`, published
+ * with `companyId` at onboardCompany.ts:398).
+ *
+ * The roster is what board-card assignee pickers, calendar assignees and
+ * mention lists are drawn from, so a foreign agent landing in `byId` is
+ * selectable — and `POST /boards/:id/cards` stores `assignee_id` without
+ * checking that the participant exists in that workspace.
+ *
+ * `commitIfEpochCurrent` (see workspace-context-epoch.test.ts) already guards
+ * the HTTP path against the same shape: a response from the previous workspace
+ * committing into the current one. This is the websocket half of that rule.
+ *
+ * Run: node --import tsx --test server/src/__tests__/ws-tenant-events.test.ts
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { isForActiveWorkspace } from '../../../src/lib/tenant-events'
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
+
+test('a frame from another workspace is not for the active one', () => {
+  assert.equal(isForActiveWorkspace('co-b', 'co-a'), false)
+})
+
+test('a frame from the active workspace is', () => {
+  assert.equal(isForActiveWorkspace('co-a', 'co-a'), true)
+})
+
+test('an untagged frame is treated as current', () => {
+  // Older servers may publish without the tag. Dropping those would break the
+  // roster entirely, which is worse than the contamination being fixed.
+  for (const missing of [undefined, null, '']) {
+    assert.equal(isForActiveWorkspace(missing, 'co-a'), true, JSON.stringify(missing))
+  }
+})
+
+test('a tagged frame is dropped while no workspace is active', () => {
+  // Before the first workspace resolves, activeCompanyId is null. Inserting a
+  // roster entry then would attribute it to whichever workspace loads next.
+  assert.equal(isForActiveWorkspace('co-b', null), false)
+  assert.equal(isForActiveWorkspace('co-b', undefined), false)
+})
+
+test('matching is exact, not a prefix', () => {
+  // Workspace ids are user-chosen slugs, so 'acme' and 'acme-eu' coexist.
+  assert.equal(isForActiveWorkspace('acme-eu', 'acme'), false)
+  assert.equal(isForActiveWorkspace('acme', 'acme-eu'), false)
+})
+
+// ── and the handler that needs it actually asks ────────────────────────────
+
+test('the participants.added handler is the one gated', () => {
+  // A pure predicate cannot catch a handler that simply stops calling it, and
+  // this handler is the only one that inserts. Assert the shape of the source,
+  // the way the electron guards do.
+  const store = readFileSync(join(REPO_ROOT, 'src', 'stores', 'participants.ts'), 'utf8')
+  const branch = store.slice(store.indexOf("e.type === 'participants.added'"))
+  assert.ok(branch, "the participants.added branch moved — update this guard alongside the refactor")
+  const guardAt = branch.indexOf('isForActiveWorkspace(')
+  const insertAt = branch.indexOf('useParticipants.setState(')
+  assert.ok(guardAt >= 0, 'participants.added no longer checks the frame\'s workspace')
+  assert.ok(insertAt >= 0, 'the upsert moved — update this guard alongside the refactor')
+  assert.ok(guardAt < insertAt, 'the workspace check must run before the upsert, not after')
+})
+
+test('the sibling handlers still guard themselves', () => {
+  // They are safe because they bail on an unknown id. If that changes, they
+  // need the same company check and this test is where that shows up.
+  const store = readFileSync(join(REPO_ROOT, 'src', 'stores', 'participants.ts'), 'utf8')
+  const avatar = store.slice(store.indexOf("e.type === 'participants.avatar'"))
+  assert.match(avatar.slice(0, 600), /if \(!cur\) return \{\}/)
+})

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1520,7 +1520,7 @@ export type WsEvent =
   | { type: 'participants.status'; participantId: string; status: Status; statusUpdatedAt?: string }
   | { type: 'participants.avatar'; participantId: string; avatarUrl: string }
   | { type: 'computers.status'; computerId: string; status: ComputerStatus }
-  | { type: 'participants.added'; conversationId?: string; participant: {
+  | { type: 'participants.added'; companyId?: string; conversationId?: string; participant: {
       id: string; kind: 'human' | 'agent'; name: string; role: string | null;
       initial: string; avatarBg: string; avatarUrl: string | null;
       status: Status; statusUpdatedAt: string | null;

--- a/src/lib/tenant-events.ts
+++ b/src/lib/tenant-events.ts
@@ -1,0 +1,29 @@
+/**
+ * Is a tenant-tagged websocket frame for the workspace the user is looking at?
+ *
+ * The socket is per-USER, not per-workspace, and that is deliberate: the server
+ * resolves recipients through company membership so one connection serves every
+ * workspace the user belongs to. For a person in two workspaces that means
+ * frames from the one they are NOT looking at arrive on the same socket.
+ *
+ * Most handlers are self-limiting — `participants.status` and
+ * `participants.avatar` both bail with `if (!cur) return {}` when the id is not
+ * already in the local roster, so a foreign frame is a no-op. A handler that
+ * INSERTS has no such backstop, and the roster is what board-card assignees,
+ * calendar assignees and mention pickers are drawn from.
+ *
+ * `commitIfEpochCurrent` already guards the HTTP path against exactly this
+ * shape — a response from the previous workspace landing in the current one.
+ * This is the websocket half of the same rule.
+ *
+ * An untagged frame is treated as current: older servers may publish without
+ * the tag, and dropping those would be a worse failure than the one being
+ * fixed.
+ */
+export function isForActiveWorkspace(
+  eventCompanyId: string | null | undefined,
+  activeCompanyId: string | null | undefined,
+): boolean {
+  if (!eventCompanyId) return true
+  return eventCompanyId === activeCompanyId
+}

--- a/src/stores/participants.ts
+++ b/src/stores/participants.ts
@@ -1,4 +1,6 @@
 import { create } from 'zustand'
+import { isForActiveWorkspace } from '@/lib/tenant-events'
+import { useAuth } from '@/stores/auth'
 import { api, ws, type ApiParticipant } from '@/api/client'
 import type { Participant, Status } from '@/types'
 import { invalidateAvatar, clearAvatarCache } from '@/lib/avatarCache'
@@ -164,6 +166,13 @@ export function bootParticipants() {
         return { byId: { ...s.byId, [e.participantId]: { ...cur, avatarUrl: e.avatarUrl } } }
       })
     } else if (e.type === 'participants.added') {
+      // The socket carries every workspace this user belongs to, so a member of
+      // two workspaces receives the other one's roster events while looking at
+      // this one. The sibling handlers above are self-limiting — they patch an
+      // existing row and bail when the id is unknown — but this one INSERTS, so
+      // a foreign participant would land in the active workspace's roster and
+      // from there into assignee pickers and mention lists.
+      if (!isForActiveWorkspace(e.companyId, useAuth.getState().activeCompanyId)) return
       // A new human (or agent) joined the workspace. Upsert into byId so
       // the system-row referencing them resolves immediately (otherwise
       // SystemRow returns null on unknown participantId and the inviter


### PR DESCRIPTION
An agent created in workspace B shows up in workspace A's roster, for anyone who belongs to both.

The websocket is per-**user**, not per-workspace, and that is deliberate — `server/src/ws.ts` says so:

> Set of company_ids this user is a member of. Refreshed on connect; the WS bridge uses it to filter Redis events tagged with `companyId`.

That filter is an authorization gate: it decides whether the user may receive the frame at all. For a member of two workspaces the answer is yes for both, so both arrive on the one socket the client has open.

Two of the three roster handlers survive that by accident:

```ts
// participants.status
const cur = s.byId[id]
if (!cur) return {}

// participants.avatar
const cur = s.byId[e.participantId]
if (!cur) return {}
```

A foreign id is not in `byId`, so those are no-ops. `participants.added` **inserts**, and had no company check at all — the client event type did not even declare `companyId`:

```ts
| { type: 'participants.added'; conversationId?: string; participant: { … } }
```

although the server has always tagged it (`ParticipantAddedEvent extends TenantTagged`, published with `companyId` from `onboardCompany.ts:398`). The field was on the wire and invisible to the client.

### What that costs

The roster is what the Agents view, board-card assignee dropdowns, calendar assignee pickers and mention lists are drawn from. So workspace B's new agent is *selectable* in workspace A — and `POST /boards/:id/cards` stores `assignee_id` without checking the participant belongs to that workspace. The card ends up assigned to an id workspace A cannot resolve, and its chip renders blank as soon as the 60-second refresher drops the entry again.

### The shape of the fix

The repo already guards the HTTP path against exactly this — `commitIfEpochCurrent`, pinned by `workspace-context-epoch.test.ts`:

> a late request from the previous workspace cannot overwrite the current workspace

This is the websocket half of the same rule, written the same way: a pure predicate the store asks, so it can be pinned without a browser.

An **untagged** frame is treated as current. An older server may publish without the tag, and dropping those would empty the roster — a worse failure than the one being fixed. A frame tagged for a workspace while none is active is dropped, because inserting then would attribute it to whichever workspace loads next.

Only `participants.added` is gated. The sibling handlers already refuse unknown ids, and a test asserts they still do — if that changes, they need the same check and this is where it shows up.

### Verification

- Seven cases. Against the shipped store, the wiring assertion goes red:
  ```
  not ok 6 - the participants.added handler is the one gated
  # pass 6  # fail 1
  ```
- That case reads the source rather than the predicate, deliberately: **a pure function cannot catch a handler that stops calling it**, and it also asserts the check runs *before* the upsert rather than after.
- Exact matching is pinned too — workspace ids are user-chosen slugs, so `acme` and `acme-eu` must not match each other.
- Frontend and server `tsc --noEmit`, `biome lint .`, all three source guards clean. Unit suite 1109 pass / 0 fail.

### Not changed

`POST /boards/:id/cards` accepting an `assignee_id` from another workspace is the server-side half of the same story. That is a validation question with its own blast radius — every assignee-bearing route — so I left it alone rather than widening this into it.
