### PR TITLE
fix(ui): an expired mute must stop hiding unread, on every counter

### DIFF
--- a/server/src/__tests__/unread-total-mute.test.ts
+++ b/server/src/__tests__/unread-total-mute.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Guard: every unread total goes through isMuted(), never the raw flag.
+ *
+ * `muted` is a cached server value. A conversation muted "for 15 minutes"
+ * keeps `muted: true` in the local row until something reloads the list, so a
+ * raw read keeps silencing the count after the mute has lapsed.
+ * `isMuted()` exists for exactly that, and says so:
+ *
+ *   "if the user keeps the app open past the expiry (e.g. muted 'for 15 min'
+ *    and no traffic happens for 20), the local cached row would still claim
+ *    muted=true. Recompute against `now` so the silence wears off without
+ *    waiting for the next WS-triggered reload."
+ *
+ * Ten call sites honoured it. `ChatPane`'s empty stage did not, and it renders
+ * on the same screen as the Rail badge — so at 09:16, after a 15-minute mute
+ * taken at 09:00 with 4 unread, the Rail showed 4 and the empty stage showed
+ * none, side by side.
+ *
+ * A test of isMuted() cannot catch this: the defect is a caller that never
+ * asked. So this reads the source, like the electron guards do, and self-tests
+ * its own matcher.
+ *
+ * Run: node --import tsx --test server/src/__tests__/unread-total-mute.test.ts
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
+const SRC = join(REPO_ROOT, 'src')
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) walk(full, out)
+    else if (/\.tsx?$/.test(entry)) out.push(full)
+  }
+  return out
+}
+
+/** An unread aggregation that reads the raw flag instead of asking isMuted. */
+const RAW_MUTE_IN_UNREAD_SUM = /\bc\.muted\s*\?[^\n]*\bunread\b/
+
+test('no unread total reads the raw muted flag', () => {
+  const offenders = walk(SRC)
+    .filter((file) => RAW_MUTE_IN_UNREAD_SUM.test(readFileSync(file, 'utf8')))
+    .map((file) => file.slice(REPO_ROOT.length + 1))
+  assert.deepEqual(
+    offenders, [],
+    `these sum unread against the cached flag instead of isMuted(): ${offenders.join(', ')}`,
+  )
+})
+
+test('isMuted is still the shared helper, and is still used', () => {
+  // If the helper is renamed or the call sites migrate elsewhere, the check
+  // above quietly becomes vacuous. Anchor on both.
+  const store = readFileSync(join(SRC, 'stores', 'conversations.ts'), 'utf8')
+  assert.match(store, /export function isMuted\(/)
+  const callers = walk(SRC).filter((f) => /\bisMuted\(/.test(readFileSync(f, 'utf8')))
+  assert.ok(callers.length >= 6, `expected isMuted to be widely used, found ${callers.length} files`)
+})
+
+// ── the matcher must be able to fail ───────────────────────────────────────
+
+test('the guard rejects the expression that shipped', () => {
+  assert.equal(
+    RAW_MUTE_IN_UNREAD_SUM.test('list.reduce((n, c) => n + (c.muted ? 0 : (c.unread ?? 0)), 0)'),
+    true,
+  )
+})
+
+test('the guard accepts the corrected expression', () => {
+  assert.equal(
+    RAW_MUTE_IN_UNREAD_SUM.test('list.reduce((n, c) => n + (isMuted(c) ? 0 : (c.unread ?? 0)), 0)'),
+    false,
+  )
+})
+
+test('the guard leaves unrelated uses of the flag alone', () => {
+  // Reading `c.muted` to render a mute icon is fine — only the unread sum is
+  // wrong, because only it has an expiry to honour.
+  assert.equal(RAW_MUTE_IN_UNREAD_SUM.test('const showBell = c.muted ? "off" : "on"'), false)
+})

--- a/src/desktop/ChatPane.tsx
+++ b/src/desktop/ChatPane.tsx
@@ -3,7 +3,7 @@ import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso'
 import { useApp } from '@/stores/app'
 import { EMPTY_DRAFT, type ComposerDraft } from '@/stores/composerDrafts'
 import { useMe } from '@/stores/auth'
-import { useConversations } from '@/stores/conversations'
+import { isMuted, useConversations } from '@/stores/conversations'
 import { useParticipants } from '@/stores/participants'
 import { useMessages, sendUserMessage, messagesFor, VIRTUOSO_FIRST_INDEX_BASE } from '@/stores/messages'
 import type { MessagesState } from '@/stores/messages'
@@ -1401,8 +1401,13 @@ function EmptyConversationState() {
   // italic counter pattern in WhispersView's sidebar header.
   const list = useConversations((s) => s.list)
   const total = list.length
+  // isMuted, not the raw flag: a "muted for 15 min" row keeps `muted: true`
+  // locally until something reloads the list, so the raw read keeps silencing
+  // the count after the mute has lapsed. Every other unread total already goes
+  // through the helper — Rail, MobileTabBar, ConversationsPane, App — and this
+  // one sits on the same screen as the Rail badge, disagreeing with it.
   const unread = useMemo(
-    () => list.reduce((n, c) => n + (c.muted ? 0 : (c.unread ?? 0)), 0),
+    () => list.reduce((n, c) => n + (isMuted(c) ? 0 : (c.unread ?? 0)), 0),
     [list],
   )
 


### PR DESCRIPTION
Two unread counters on one screen disagree once a timed mute lapses.

`muted` is a cached server value, and `isMuted()` exists precisely because it goes stale:

```ts
/** … if the user keeps the app open past the expiry (e.g. muted "for 15 min"
 *  and no traffic happens for 20), the local cached row would still claim
 *  muted=true. Recompute against `now` so the silence wears off without
 *  waiting for the next WS-triggered reload. */
export function isMuted(c: Pick<Conversation, 'muted' | 'mutedUntil'>): boolean {
```

Ten call sites go through it. One does not — `ChatPane`'s empty stage:

```ts
const unread = useMemo(
  () => list.reduce((n, c) => n + (c.muted ? 0 : (c.unread ?? 0)), 0),
  [list],
)
```

`ConversationsPane.tsx:952` computes the *same* quantity the right way, which is what makes this a divergence rather than a preference:

```ts
const unreadTotal = list.reduce((s, c) => s + (isMuted(c) ? 0 : (c.unread ?? 0)), 0)
```

### What you see

Mute `#general` at 09:00 for 15 minutes while it holds 4 unread, deselect the conversation so the empty stage shows, and let every room stay quiet — nothing triggers a list reload, so the cached row still reads `muted: true, mutedUntil: 09:15`.

At 09:16, on one screen: the Rail badge (`isMuted` → false) shows **4**; the empty stage (`c.muted` → true) counts **0** and drops the "N unread" line entirely.

Nothing is lost — opening the conversation still shows the messages — but the two live counters for the same number sit side by side contradicting each other, and the one that is wrong is the one that says there is nothing to read.

### Verification

A test of `isMuted()` cannot catch this: the defect is a caller that never asked. So the guard reads the source, the way `electron-native-image.test.ts` and `electron-tray-unread-dot.test.ts` do, and names the offender:

```
not ok 1 - no unread total reads the raw muted flag
    these sum unread against the cached flag instead of isMuted(): src/desktop/ChatPane.tsx
```

It self-tests its matcher three ways, because a source-scraping check's failure mode is becoming a silent no-op:

- it must **reject** the expression that shipped,
- **accept** the corrected one,
- and **leave an unrelated read alone** — rendering a mute icon from `c.muted` is fine; only a sum with an expiry to honour is not.

A second case anchors on the helper still existing and still being widely used, so the first cannot go vacuous if `isMuted` is renamed or the call sites move.

Frontend `tsc --noEmit`, `biome lint .`, unit suite 1107 pass / 0 fail.
