### PR TITLE
fix(byoa): --stop must not kill a running --doctor

### DIFF
--- a/server/src/__tests__/agents-computer-stop-daemon-match.test.ts
+++ b/server/src/__tests__/agents-computer-stop-daemon-match.test.ts
@@ -15,7 +15,10 @@
  */
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { isStoppableDaemonCommand } from '../agents/computer/daemon.js'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { isStoppableDaemonCommand, ONE_SHOT_FLAGS } from '../agents/computer/daemon.js'
 
 // ── real long-running daemons: must be killed ────────────────────────────────
 
@@ -62,16 +65,58 @@ test('the supervised daemon IS stoppable even with env noise in the command line
 // ── one-shot CLIs: must be spared ────────────────────────────────────────────
 
 test('every one-shot flag is spared', () => {
-  for (const flag of [
-    '--stop', '--status', '--restart', '--logs', '--version',
-    '--install-service', '--uninstall-service', '--pair',
-  ]) {
+  for (const flag of ONE_SHOT_FLAGS) {
     assert.equal(
-      isStoppableDaemonCommand(`node /usr/local/bin/cumora agent computer ${flag}`),
+      isStoppableDaemonCommand(`node /usr/local/bin/cumora agent computer --${flag}`),
       false,
       flag,
     )
   }
+})
+
+test('every mode the parser treats as one-shot is in that list', () => {
+  // The old version of the test above restated the matcher's own eight flags,
+  // so a mode missing from BOTH could never be caught — which is how --doctor
+  // spent minutes of engine probes being killed by a concurrent --stop.
+  // Derive the expectation from parseArgs instead, so the next one-shot flag
+  // added there fails here until --stop knows to spare it.
+  const source = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), '..', 'agents', 'computer', 'daemon.ts'),
+    'utf8',
+  )
+  // Anchor inside the body: parseArgs' return type is a multi-line object
+  // literal, so slicing from the declaration would stop at the type, not the code.
+  const from = source.indexOf('const out: ReturnType<typeof parseArgs>')
+  const body = from < 0 ? '' : source.slice(from, source.indexOf('return out', from))
+  assert.ok(
+    body.includes("argv[i] === '--status'"),
+    'parseArgs moved — update this guard alongside the refactor',
+  )
+
+  // Long flags the parser recognises, minus the ones that configure a daemon
+  // rather than replacing it.
+  // The only two that CONFIGURE a daemon rather than replacing it.
+  const CONFIGURES_A_DAEMON = new Set(['server', 'engine'])
+  const parsed = [...body.matchAll(/argv\[i\] === '--([a-z-]+)'/g)].map((m) => m[1])
+  const oneShot = parsed.filter((flag) => !CONFIGURES_A_DAEMON.has(flag))
+
+  const known = new Set<string>(ONE_SHOT_FLAGS)
+  const missing = oneShot.filter((flag) => !known.has(flag))
+  assert.deepEqual(missing, [], `--stop would kill these one-shot invocations: ${missing.join(', ')}`)
+})
+
+test('the bare `doctor` subcommand is spared too', () => {
+  // parseArgs accepts `doctor` as well as `--doctor`, and that form has no `--`
+  // to anchor on.
+  assert.equal(isStoppableDaemonCommand('npx cumora@latest agent computer doctor'), false)
+})
+
+test('a path containing the word doctor is still a daemon', () => {
+  // The bare-word rule must stay as tight as the `--` one.
+  assert.equal(
+    isStoppableDaemonCommand('node /opt/doctor-tools/cumora agent computer --server https://api.cumora.ai'),
+    true,
+  )
 })
 
 test('--pair with a value is spared', () => {

--- a/server/src/agents/computer/daemon.ts
+++ b/server/src/agents/computer/daemon.ts
@@ -3906,8 +3906,18 @@ export async function restartService(hooks: RestartServiceHooks = {}): Promise<v
 /** One-shot CLI invocations: these do a thing and exit, so they are never the
  *  long-running daemon we mean to stop. Anchored to the `--` so the words can't
  *  match incidentally elsewhere in the command line. */
-const ONE_SHOT_FLAG_RE =
-  /--(stop|status|restart|logs|version|install-service|uninstall-service|pair)\b/
+export const ONE_SHOT_FLAGS = [
+  'stop', 'status', 'restart', 'logs', 'version', 'install-service',
+  'uninstall-service', 'pair', 'doctor', 'help',
+] as const
+const ONE_SHOT_FLAG_RE = new RegExp(`--(?:${ONE_SHOT_FLAGS.join('|')})\\b`)
+
+/** `--doctor` and `--help` also answer to bare `doctor` / `help` (parseArgs
+ *  accepts both spellings), and those forms carry no `--` to anchor on. Anchor
+ *  them to the command instead of matching the bare word, so a path like
+ *  /opt/doctor-tools/ still reads as a daemon — the same rule the `--`
+ *  anchoring exists for. */
+const ONE_SHOT_SUBCOMMAND_RE = /\bagent computer (?:doctor|help)\b/
 
 /** Is this `ps`-reported command line a long-running BYOA daemon that `--stop`
  *  should kill? True only for `agent computer` with no one-shot flag.
@@ -3919,7 +3929,8 @@ const ONE_SHOT_FLAG_RE =
  *  candidate set. Killing the wrapper's child is what actually stops the daemon,
  *  and the wrapper exits with it. */
 export function isStoppableDaemonCommand(cmd: string): boolean {
-  return /agent computer/.test(cmd) && !ONE_SHOT_FLAG_RE.test(cmd)
+  if (!/agent computer/.test(cmd)) return false
+  return !ONE_SHOT_FLAG_RE.test(cmd) && !ONE_SHOT_SUBCOMMAND_RE.test(cmd)
 }
 
 async function commandLineForPid(pid: number): Promise<string> {


### PR DESCRIPTION
`agent computer --stop` kills a `--doctor` that is still running.

`isStoppableDaemonCommand` spares one-shot invocations by matching a flag list:

```ts
const ONE_SHOT_FLAG_RE =
  /--(stop|status|restart|logs|version|install-service|uninstall-service|pair)\b/

export function isStoppableDaemonCommand(cmd: string): boolean {
  return /agent computer/.test(cmd) && !ONE_SHOT_FLAG_RE.test(cmd)
}
```

`--doctor` is not on it, though it is a one-shot by every other measure — `parseArgs` gives it its own flag, `doRun` dispatches it with an immediate `return`, and `helpText()` lists it under diagnostics next to `--status` and `--version`.

So `killRunningDaemons` pgreps `agent computer`, finds the doctor's pid, and SIGTERM → SIGKILLs it.

### Why this one and not the others

`--doctor` is the longest-running one-shot there is. `runEngineDoctor` probes every installed engine with a 60-second per-tier timeout, so a machine with three engines sits there for minutes — and the person running `--doctor` is, by definition, someone whose agents are misbehaving, which is also the person likely to try `--stop` in the next terminal. The doctor dies mid-probe with no output; `--stop` counts it and prints `stopped 2 running daemon process(es)`.

The same code path is reached without anyone typing `--stop`: `--restart` and `--pair` both call `killRunningDaemons` (via `installService` / `reloadService`).

### The existing test could not have caught it

```ts
test('every one-shot flag is spared', () => {
  for (const flag of [
    '--stop', '--status', '--restart', '--logs', '--version',
    '--install-service', '--uninstall-service', '--pair',
  ]) {
```

That is the matcher's own eight flags, restated. A mode missing from **both** the regex and the list is invisible to it — the test confirms the implementation rather than the contract.

It now derives the expectation from `parseArgs`, and reverting the flag list makes it say what is wrong:

```
not ok 7 - every mode the parser treats as one-shot is in that list
    --stop would kill these one-shot invocations: help, doctor
```

It found `--help` on its own, which is the point of deriving it — I had added `help` while fixing `doctor`, and the guard would have caught it either way. The next one-shot flag added to `parseArgs` now fails here until `--stop` is taught to spare it.

The parser slice is anchored inside the function body (`const out: ReturnType<typeof parseArgs>` → `return out`) because `parseArgs`' return type is a multi-line object literal — slicing from the declaration stops at the type, not the code — and the guard asserts loudly if that anchor ever moves.

### Bare spellings

`parseArgs` accepts `doctor` and `help` without the `--`. Those carry no `--` to anchor on, so they are matched as `\bagent computer (?:doctor|help)\b` — anchored to the command, not as bare words. A daemon launched from `/opt/doctor-tools/cumora` must still be stoppable, which is the same rule the `--` anchoring exists for, and a test pins it.

### Verification

12 cases, all green with the fix. With the flag list reverted (the export kept, so the failures are behavioural rather than an import error):

```
not ok 7 - every mode the parser treats as one-shot is in that list
not ok 8 - the bare `doctor` subcommand is spared too
# pass 10  # fail 2
```

The existing positive cases — npx-launched, `_npx` shim, `npm exec`, bare foreground, launchd env noise — are untouched and still pass, so nothing that should be killed became spared.

`tsc --noEmit`, `biome lint .`, all three source guards clean. Unit suite 1105 pass / 0 fail.
