### PR TITLE
fix(electron): the window must reopen at the size it was left

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -5,6 +5,7 @@ const fs = require('node:fs')
 const http = require('node:http')
 const crypto = require('node:crypto')
 const { pathToFileURL } = require('node:url')
+const { initialWindowSize } = require('./window-size.cjs')
 const autoUpdater = require('./autoUpdater.cjs')
 
 const isDev = !app.isPackaged
@@ -1084,16 +1085,18 @@ function attachDisplayListeners() {
 }
 
 function createWindow() {
-  const saved = readWindowState() ?? DEFAULT_WINDOW_STATE
+  const savedState = readWindowState()
+  const saved = savedState ?? DEFAULT_WINDOW_STATE
   const rect = visibleRect(saved)
-  // Cap initial size to fit comfortably inside the primary display's
-  // work area — 90% of work area, with the configured default as the
-  // upper ceiling. Without this, the 1480×920 default would exceed
-  // smaller laptop displays and macOS would clamp on launch, making
-  // every first-run feel "fullscreen".
-  const wa = screen.getPrimaryDisplay().workArea
-  const initW = Math.min(saved.width ?? DEFAULT_WINDOW_STATE.width, Math.round(wa.width * 0.9))
-  const initH = Math.min(saved.height ?? DEFAULT_WINDOW_STATE.height, Math.round(wa.height * 0.9))
+  // The 90% cap is for FIRST RUN — it stops the 1480×920 default exceeding a
+  // small laptop, which macOS would clamp on launch so the app felt like it
+  // opened fullscreen. A size the user chose is not capped, only fitted, and
+  // fitted against the display it is actually landing on rather than the
+  // primary one. See window-size.cjs for what the old expression cost.
+  const wa = (rect ? screen.getDisplayMatching(rect) : screen.getPrimaryDisplay()).workArea
+  const { width: initW, height: initH } = initialWindowSize(
+    saved, DEFAULT_WINDOW_STATE, wa, Boolean(savedState),
+  )
   mainWindow = new BrowserWindow({
     width: initW,
     height: initH,

--- a/electron/window-size.cjs
+++ b/electron/window-size.cjs
@@ -1,0 +1,44 @@
+/**
+ * How large the main window opens.
+ *
+ * Two different questions were being answered by one expression:
+ *
+ *   FIRST RUN — the 1480×920 default has to fit a small laptop, or macOS
+ *   clamps it on launch and the app feels like it opened fullscreen. Capping
+ *   at 90% of the work area is the fix, and is what the comment describes.
+ *
+ *   RESTORING — the saved size is the size the user chose. Shaving 10% off it
+ *   on every launch is not a cap, it is a slow shrink, and because
+ *   `persistState` writes the new bounds back on the first resize event, the
+ *   size they picked is overwritten and gone.
+ *
+ * The old code applied the 90% cap to both, against the PRIMARY display's work
+ * area regardless of which display the window was being restored onto. On a
+ * laptop plus a large external, a window sized 2300×1300 on the external came
+ * back at the laptop's 90% — roughly a third of its area — and that third was
+ * then saved over the original.
+ *
+ * So: cap the default, fit the saved size. "Fit" still bounds it to the work
+ * area of the display it is actually landing on, because a monitor that was
+ * unplugged since last quit should not produce a window larger than what is
+ * left — it just no longer takes a 10% bite out of a size that already fits.
+ *
+ * Pure and electron-free so the arithmetic can be tested, the same split as
+ * cli-path.cjs.
+ */
+
+/**
+ * @param {{width?: number, height?: number}} saved     last-quit size, or the defaults on first run
+ * @param {{width: number, height: number}} defaults    DEFAULT_WINDOW_STATE
+ * @param {{width: number, height: number}} workArea    work area of the display the window will open on
+ * @param {boolean} restoring                           true when `saved` came from disk
+ */
+function initialWindowSize(saved, defaults, workArea, restoring) {
+  const cap = restoring ? 1 : 0.9
+  return {
+    width: Math.min(saved?.width ?? defaults.width, Math.round(workArea.width * cap)),
+    height: Math.min(saved?.height ?? defaults.height, Math.round(workArea.height * cap)),
+  }
+}
+
+module.exports = { initialWindowSize }

--- a/server/src/__tests__/electron-window-size.test.ts
+++ b/server/src/__tests__/electron-window-size.test.ts
@@ -1,0 +1,103 @@
+/**
+ * The window opens at the size the user left it.
+ *
+ * One expression answered two different questions:
+ *
+ *   const wa = screen.getPrimaryDisplay().workArea
+ *   const initW = Math.min(saved.width ?? DEFAULT_WINDOW_STATE.width, Math.round(wa.width * 0.9))
+ *
+ * The 90% cap is described, correctly, as protecting FIRST RUN: the 1480×920
+ * default would exceed a small laptop and macOS would clamp it, so the app felt
+ * like it opened fullscreen. But it was applied to the SAVED size too, so every
+ * launch shaved 10% off the size the user chose — and `persistState` writes the
+ * new bounds back on the first resize event, so the original was overwritten.
+ *
+ * Multi-monitor made it worse: the cap read the PRIMARY display's work area
+ * regardless of which display the window was restored onto. A window sized
+ * 2300×1300 on an external came back at the laptop's 90%, roughly a third of
+ * its area, and that third was then saved over the original.
+ *
+ * Run: node --import tsx --test server/src/__tests__/electron-window-size.test.ts
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const { initialWindowSize } = require('../../../electron/window-size.cjs') as {
+  initialWindowSize: (
+    saved: { width?: number; height?: number } | null,
+    defaults: { width: number; height: number },
+    workArea: { width: number; height: number },
+    restoring: boolean,
+  ) => { width: number; height: number }
+}
+
+const DEFAULTS = { width: 1480, height: 920 }
+/** MacBook Air 13", after the menu bar. */
+const LAPTOP = { width: 1470, height: 931 }
+const EXTERNAL = { width: 2560, height: 1440 }
+
+// ── restoring: the user's size, not 90% of it ──────────────────────────────
+
+test('a size that fits is restored exactly', () => {
+  const saved = { width: 1460, height: 925 }
+  assert.deepEqual(initialWindowSize(saved, DEFAULTS, LAPTOP, true), saved)
+})
+
+test('a large size on the external display survives', () => {
+  // The old code capped this against the LAPTOP's work area even though the
+  // window was being restored onto the external, and persistState then wrote
+  // the shrunken size back.
+  const saved = { width: 2300, height: 1300 }
+  assert.deepEqual(initialWindowSize(saved, DEFAULTS, EXTERNAL, true), saved)
+})
+
+test('restoring is idempotent — the size does not creep down', () => {
+  // Relaunch three times; the size the user chose must not decay.
+  let size = { width: 1460, height: 925 }
+  for (let i = 0; i < 3; i++) size = initialWindowSize(size, DEFAULTS, LAPTOP, true)
+  assert.deepEqual(size, { width: 1460, height: 925 })
+})
+
+test('a saved size larger than the display it lands on is fitted, not shrunk further', () => {
+  // The external was unplugged. Bound it to what is left — but to the whole
+  // work area, not 90% of it.
+  assert.deepEqual(
+    initialWindowSize({ width: 2300, height: 1300 }, DEFAULTS, LAPTOP, true),
+    { width: 1470, height: 931 },
+  )
+})
+
+// ── first run: the cap the comment describes ───────────────────────────────
+
+test('first run is capped to 90% so it does not feel fullscreen', () => {
+  assert.deepEqual(
+    initialWindowSize(DEFAULTS, DEFAULTS, LAPTOP, false),
+    { width: 1323, height: 838 },
+  )
+})
+
+test('first run on a large display gets the configured default, not 90% of the screen', () => {
+  // The default is the ceiling; the cap only ever lowers it.
+  assert.deepEqual(initialWindowSize(DEFAULTS, DEFAULTS, EXTERNAL, false), DEFAULTS)
+})
+
+test('a saved record missing its size falls back to the default', () => {
+  assert.deepEqual(
+    initialWindowSize({}, DEFAULTS, EXTERNAL, true),
+    DEFAULTS,
+  )
+  assert.deepEqual(initialWindowSize(null, DEFAULTS, EXTERNAL, true), DEFAULTS)
+})
+
+// ── the regression, stated as the difference ───────────────────────────────
+
+test('restoring and first-run no longer produce the same number', () => {
+  // This equality IS the bug: the old code could not tell the two apart.
+  const saved = { width: 1460, height: 925 }
+  const restored = initialWindowSize(saved, DEFAULTS, LAPTOP, true)
+  const firstRun = initialWindowSize(DEFAULTS, DEFAULTS, LAPTOP, false)
+  assert.notDeepEqual(restored, firstRun)
+  assert.ok(restored.width > firstRun.width)
+})


### PR DESCRIPTION
The desktop window opens smaller than you left it, every launch — and the size you chose is overwritten, not just ignored.

One expression answers two different questions:

```js
const wa = screen.getPrimaryDisplay().workArea
const initW = Math.min(saved.width ?? DEFAULT_WINDOW_STATE.width, Math.round(wa.width * 0.9))
const initH = Math.min(saved.height ?? DEFAULT_WINDOW_STATE.height, Math.round(wa.height * 0.9))
```

The comment above it describes the 90% cap accurately, and only for first run:

> Without this, the 1480×920 default would exceed smaller laptop displays and macOS would clamp on launch, making every first-run feel "fullscreen".

But `saved.width ?? DEFAULT` means the cap lands on a restored size too, and the module's own contract says that is exactly what must not happen:

> Saved on every resize/move/close and restored on launch — so users get the size + position they had last

### What it costs

**A slow shrink.** MacBook Air 13", work area 1470×931. Size the window to fill it, ~1460×925, and quit. Next launch: `Math.round(1470 × 0.9) = 1323`, so it opens at 1323×838. Drag it back; next launch shrinks it again.

**And the size is gone.** `persistState` writes `getNormalBounds()` back on the first `resize` event, so the clamped size replaces the saved one. This is not "ignored on launch" — the original is overwritten.

**Multi-monitor is worse.** The cap reads the **primary** display's work area whichever display the window is restored onto, while `visibleRect` happily restores x/y onto an external (it only requires 80px of overlap with some display). A window sized 2300×1300 on a 2560×1440 external comes back at the laptop's 1323×838 — about a third of its area — on the big screen, and that third is then saved over the original.

### The change

Cap the default, fit the saved size, and fit it against the display the window is actually landing on:

```js
const wa = (rect ? screen.getDisplayMatching(rect) : screen.getPrimaryDisplay()).workArea
const { width: initW, height: initH } = initialWindowSize(saved, DEFAULT_WINDOW_STATE, wa, Boolean(savedState))
```

"Fit" still bounds a saved size to the work area available, so a monitor unplugged since last quit cannot produce a window larger than what is left — it just no longer takes a 10% bite out of a size that already fits.

Distinguishing the two cases needs to know whether `saved` came from disk, so `readWindowState()`'s null is kept rather than collapsed into the default immediately.

### Verification

The arithmetic moves into `electron/window-size.cjs`, electron-free so it can actually be run — the same split `cli-path.cjs` already uses, tested the same way through `createRequire`.

Eight cases. **Five go red against the shipped rule**:

```
not ok 1 - a size that fits is restored exactly
not ok 2 - a large size on the external display survives
not ok 3 - restoring is idempotent — the size does not creep down
not ok 4 - a saved size larger than the display it lands on is fitted, not shrunk further
not ok 8 - restoring and first-run no longer produce the same number
# pass 3  # fail 5
```

Case 8 states the defect as an equality: the old code could not tell the two situations apart, so it produced the same number for both. Case 3 relaunches three times and asserts the size does not decay, which is the part a single-launch test would miss.

The two first-run cases pass either way and are the guard: the 90% cap must still apply on a small display, and the configured default must still be the ceiling on a large one — this must not turn into "open at 90% of whatever screen you have".

`biome lint .` clean; unit suite 1110 pass / 0 fail.

I could not exercise this against a real second monitor — the reasoning above is from `getPrimaryDisplay()` vs `getDisplayMatching()` and `visibleRect`'s overlap rule, and the arithmetic is what the tests pin. Worth a sanity check on a two-display machine before merging.
