### PR TITLE
fix(electron): the loopback must not report a sign-in it dropped

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -459,15 +459,27 @@ function armAuthHandoff() {
 function consumeAuthNonce(nonce) {
   const armed = armedAuthNonce
   const expiry = armedAuthExpiry
-  armedAuthNonce = null
-  armedAuthExpiry = 0
-  if (!armed || Date.now() > expiry) return false
-  if (typeof nonce !== 'string' || nonce.length !== armed.length) return false
-  try {
-    return crypto.timingSafeEqual(Buffer.from(nonce), Buffer.from(armed))
-  } catch {
+  // Clear only on a MATCH (or a genuine expiry). Clearing first meant any
+  // inbound value disarmed the pending sign-in: click sign-in twice, finish the
+  // first tab, and its now-stale nonce took the second one's arming with it —
+  // so the obvious recovery, going back and finishing the other tab, failed too.
+  if (!armed || Date.now() > expiry) {
+    armedAuthNonce = null
+    armedAuthExpiry = 0
     return false
   }
+  if (typeof nonce !== 'string' || nonce.length !== armed.length) return false
+  let ok = false
+  try {
+    ok = crypto.timingSafeEqual(Buffer.from(nonce), Buffer.from(armed))
+  } catch {
+    ok = false
+  }
+  if (ok) {
+    armedAuthNonce = null
+    armedAuthExpiry = 0
+  }
+  return ok
 }
 
 /** Pull token + companyId + nonce out of a `cumora://auth#token=…` URL. The OS
@@ -495,7 +507,7 @@ function parseAuthDeepLink(rawUrl) {
 function dispatchAuthToken(token, companyId, nonce) {
   if (!consumeAuthNonce(nonce)) {
     console.warn('[auth] dropped inbound token: no matching armed nonce (possible drive-by deep link)')
-    return
+    return false
   }
   if (mainWindow && !mainWindow.isDestroyed()) {
     if (mainWindow.isMinimized()) mainWindow.restore()
@@ -505,6 +517,7 @@ function dispatchAuthToken(token, companyId, nonce) {
   } else {
     pendingAuthToken = { token, companyId }
   }
+  return true
 }
 let pendingAuthToken = null
 
@@ -545,8 +558,15 @@ function startAuthLoopback() {
           }
           const companyId = typeof parsed.companyId === 'string' ? parsed.companyId : null
           const nonce = typeof parsed.nonce === 'string' ? parsed.nonce : null
-          dispatchAuthToken(parsed.token, companyId, nonce)
-          res.statusCode = 204; res.end()
+          // Answer what actually happened. A 204 for a token the app dropped
+          // made the browser page report "Signed in — Cumora has your session"
+          // while nothing had been handed over; the page keys on `r.ok` and its
+          // catch branch is the one that tells the user to open Cumora itself.
+          if (dispatchAuthToken(parsed.token, companyId, nonce)) {
+            res.statusCode = 204; res.end()
+          } else {
+            res.statusCode = 409; res.end('no armed sign-in')
+          }
         } catch {
           res.statusCode = 400; res.end('bad json')
         }

--- a/server/src/__tests__/electron-auth-handoff.test.ts
+++ b/server/src/__tests__/electron-auth-handoff.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Guard: the loopback must not report a sign-in it dropped.
+ *
+ * The desktop arms a nonce, opens the system browser, and the return page POSTs
+ * `{token, companyId, nonce}` back to the loopback. `dispatchAuthToken` drops a
+ * token whose nonce does not match — correctly, that is the drive-by-deep-link
+ * defence — but it returned `void`, and the handler answered 204 either way.
+ *
+ * The page keys on `r.ok`:
+ *
+ *   if (!r.ok) throw new Error('handoff rejected: ' + r.status);
+ *   h1.textContent = 'Signed in';
+ *   label.innerHTML = '<span class="ok">✓</span> Signed in';
+ *   hint.textContent = 'You can close this tab.';
+ *
+ * So the browser told the user they were signed in, with a checkmark, while the
+ * app had received nothing. Its catch branch — the one that says to open Cumora
+ * itself — was unreachable for this case.
+ *
+ * Reaching it is ordinary: `armAuthHandoff` "supersedes any previous unused
+ * nonce", and AuthScreen re-arms on window focus. Click sign-in, click back
+ * into Cumora, click sign-in again, then finish the FIRST tab.
+ *
+ * Second half: `consumeAuthNonce` cleared the armed nonce before validating, so
+ * that stale first tab also disarmed the second one — the obvious recovery,
+ * going back and finishing the other tab, failed too.
+ *
+ * electron/ has no runtime harness, so this reads the source the way
+ * electron-tray-unread-dot.test.ts does, and self-tests its matchers.
+ *
+ * Run: node --import tsx --test server/src/__tests__/electron-auth-handoff.test.ts
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
+const MAIN_CJS = readFileSync(join(REPO_ROOT, 'electron', 'main.cjs'), 'utf8')
+
+function bodyOf(source: string, decl: string): string | null {
+  const at = source.indexOf(decl)
+  if (at < 0) return null
+  const end = source.indexOf('\n}', at)
+  return end < 0 ? null : source.slice(at, end)
+}
+
+/** Does the handler decide its status from the dispatch result? */
+function answersTheRealStatus(handler: string): boolean {
+  return /if \(dispatchAuthToken\(/.test(handler) && /statusCode = 4\d\d/.test(handler)
+}
+
+/** Does the nonce survive a value that does not match it? */
+function clearsOnlyOnMatch(fn: string): boolean {
+  const firstGuard = fn.search(/if \(!armed/)
+  const firstClear = fn.indexOf('armedAuthNonce = null')
+  if (firstGuard < 0 || firstClear < 0) return false
+  return firstClear > firstGuard
+}
+
+test('the loopback answers what actually happened', () => {
+  const handler = bodyOf(MAIN_CJS, "if (typeof parsed?.token !== 'string'")
+  assert.ok(handler, 'the /auth/token handler moved — update this guard alongside the refactor')
+  assert.ok(
+    answersTheRealStatus(handler),
+    'the handler answers 204 without checking whether the token was accepted',
+  )
+})
+
+test('dispatchAuthToken reports acceptance on both paths', () => {
+  const fn = bodyOf(MAIN_CJS, 'function dispatchAuthToken(')
+  assert.ok(fn, 'dispatchAuthToken moved — update this guard alongside the refactor')
+  assert.match(fn, /return false/, 'the drop path must say so')
+  assert.match(fn, /return true/, 'the accept path must say so')
+})
+
+test('a mismatching nonce does not disarm the pending sign-in', () => {
+  const fn = bodyOf(MAIN_CJS, 'function consumeAuthNonce(')
+  assert.ok(fn, 'consumeAuthNonce moved — update this guard alongside the refactor')
+  assert.ok(
+    clearsOnlyOnMatch(fn),
+    'the armed nonce is cleared before it is validated, so any inbound value disarms it',
+  )
+})
+
+test('the timing-safe compare is still how the nonce is checked', () => {
+  // The change above must not have loosened the comparison it guards.
+  const fn = bodyOf(MAIN_CJS, 'function consumeAuthNonce(') ?? ''
+  assert.match(fn, /crypto\.timingSafeEqual\(/)
+  assert.match(fn, /nonce\.length !== armed\.length/)
+})
+
+// ── the matchers must be able to fail ──────────────────────────────────────
+
+test('the status guard rejects the unconditional 204', () => {
+  assert.equal(
+    answersTheRealStatus('dispatchAuthToken(parsed.token, companyId, nonce)\nres.statusCode = 204; res.end()'),
+    false,
+  )
+})
+
+test('the status guard accepts a branched answer', () => {
+  assert.equal(
+    answersTheRealStatus('if (dispatchAuthToken(a, b, c)) { res.statusCode = 204 } else { res.statusCode = 409 }'),
+    true,
+  )
+})
+
+test('the nonce guard rejects clearing before validating', () => {
+  assert.equal(
+    clearsOnlyOnMatch('const armed = armedAuthNonce\narmedAuthNonce = null\nif (!armed) return false'),
+    false,
+  )
+})
+
+test('the nonce guard accepts clearing inside the guard', () => {
+  assert.equal(
+    clearsOnlyOnMatch('const armed = armedAuthNonce\nif (!armed) { armedAuthNonce = null; return false }'),
+    true,
+  )
+})


### PR DESCRIPTION
The browser says "Signed in ✓" while the desktop app received nothing.

The return page hands the token to the loopback and reports success straight from the HTTP status:

```js
fetch('/auth/token', { method: 'POST', … }).then((r) => {
  if (!r.ok) throw new Error('handoff rejected: ' + r.status);
  h1.textContent = 'Signed in';
  sub.textContent = 'Cumora has your session.';
  label.innerHTML = '<span class="ok">✓</span> Signed in';
  btn.disabled = true;
  hint.textContent = 'You can close this tab.';
}).catch(() => { /* …offer the OS route… */ })
```

`dispatchAuthToken` drops a token whose nonce does not match — that is the drive-by-deep-link defence, and it is right — but it returned `void`:

```js
function dispatchAuthToken(token, companyId, nonce) {
  if (!consumeAuthNonce(nonce)) {
    console.warn('[auth] dropped inbound token: no matching armed nonce (possible drive-by deep link)')
    return                                     // ← caller cannot tell
  }
```

and the handler answered 204 either way:

```js
dispatchAuthToken(parsed.token, companyId, nonce)
res.statusCode = 204; res.end()                // ← unconditional
```

So the drop is silent in the one place the user is looking. The page's `catch` branch — the one that tells them to open Cumora themselves — is unreachable for exactly the case it was written for.

### No attacker needed

`armAuthHandoff`'s own comment says it "supersedes any previous unused nonce", and `AuthScreen` re-arms on window `focus`. So:

1. Click "Sign in with Google". The browser tab opens **behind** the app.
2. Click back into the Cumora window — the focus handler re-arms, buttons go live again.
3. Click sign-in again. A second nonce supersedes the first.
4. Finish the consent in the tab that is already open — the first one, carrying the now-stale nonce.

Token dropped, page says signed in, user closes the tab.

### The recovery failed too

`consumeAuthNonce` cleared the armed nonce **before** validating it:

```js
const armed = armedAuthNonce
const expiry = armedAuthExpiry
armedAuthNonce = null          // ← unconditional
armedAuthExpiry = 0
if (!armed || Date.now() > expiry) return false
```

So the stale tab's POST disarmed the *live* nonce on its way out. Going back and finishing the second tab — the obvious thing to try — then failed as well, with the same false success.

Now it clears only on a match, or on a genuine expiry. The timing-safe compare and the length pre-check are untouched, and a test pins them so this cannot quietly loosen the comparison it guards.

### The change

- `dispatchAuthToken` returns whether it accepted.
- The handler answers **409** when it did not, so the page falls into its existing `catch` and shows "Ready when you are" with the "Open Cumora" route.
- `consumeAuthNonce` consumes on match.

The `cumora://` deep-link handler ignores the new return value deliberately — there is nobody to answer there.

### Verification

`electron/` has no runtime harness (`main.cjs` requires `electron`), so this is a source-level guard in the shape of `electron-tray-unread-dot.test.ts`. Eight cases; **three go red against the shipped file**:

```
not ok 1 - the loopback answers what actually happened
not ok 2 - dispatchAuthToken reports acceptance on both paths
not ok 3 - a mismatching nonce does not disarm the pending sign-in
# pass 5  # fail 3
```

Both matchers self-test in both directions — reject the shipped shape, accept the fixed one — because a source-scraping check's failure mode is becoming a silent no-op. The anchors fail loudly if the functions move rather than passing vacuously.

One case is purely a guard on the change itself: `crypto.timingSafeEqual` and the length check must still be how the nonce is compared.

`biome lint .` clean; unit suite 1110 pass / 0 fail.

I could not exercise a real OAuth round trip here, so the flow above is argued from the control flow and the page's own script rather than observed end to end.
