### PR TITLE
release: v0.15.0

### DIFF
--- a/agent-cli/package.json
+++ b/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cumora",
-  "version": "0.14.2",
+  "version": "0.15.0",
   "description": "Run Cumora agents on your own machine with Claude Code, Codex, Antigravity, and other BYOA engines.",
   "license": "MIT",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cumora",
-  "version": "0.14.2",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cumora",
-      "version": "0.14.2",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1045.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cumora",
   "private": true,
-  "version": "0.14.2",
+  "version": "0.15.0",
   "type": "module",
   "main": "electron/main.cjs",
   "bin": {


### PR DESCRIPTION
Cuts v0.15.0. Sixteen contributor PRs landed today, the first release since v0.14.2.

**Correctness / data integrity**
- #185 — a message body cut mid-emoji produced a lone surrogate that Postgres rejected as invalid JSON, rolling back the *entire* message transaction. The realtime outbox now strips lone surrogates on serialize.
- #184 — a fresh install crash-looped on first boot: `seed.ts` inserted conversations without the `company_id` that migration 0002 made NOT NULL.
- #207 — the FUSE workspace endpoints and the CLI's `agent_log` / `agent_tasks` / `agent_climate` writes recorded a NULL tenant, so agent state escaped company scoping.
- #196 — an agent-supplied memory/skill id went into a `LIKE` pattern unescaped, so `_` and `%` matched anything; `memory list` also truncated ids to 10 chars while they are 16 wide, so list → pin/delete could never round-trip.
- #199 — an agent's reply never fired a push, so a phone stayed silent for exactly the messages you'd most want to hear about.

**Calendar**
- #208 — a recurring event more than `MAX_CATCHUP_MS` behind is now fast-forwarded to the next real occurrence in one step instead of firing its way through every missed slot.
- #183 — the desktop and mobile views had their own recurrence stepper that drifted on month-ends and leap years; both now share the server's indexed math (fixes #182).

**BYOA**
- #194 — Anthropic's own base URL was being classified as a custom provider, suppressing the fast-model path.
- #203 — `agent computer --stop` killed a running `--doctor`; the one-shot flag list is now the single source of truth.
- #193 — the Claude settings tests read the developer's own shell environment.

**Desktop / UI**
- #195 — the tray unread dot never updated on Windows or Linux (the call sat after a darwin-only early return).
- #204 — the window no longer reopens at the wrong size, and restores on the display it was left on.
- #205 — the loopback reported success for a sign-in it had actually dropped.
- #202 — an expired mute kept hiding unread counts.
- #197 — a roster event from another workspace could join the active one.
- #188 — CJK punctuation adjacent to a URL was swallowed into the link.

Verified on merged `main` before tagging: lint, `typecheck`, `server:typecheck`, all three guards (big-brain, llm-tracked, engine-registry), and 1179/1179 unit tests.

https://claude.ai/code/session_0126NkM9crkemuV6Ho4LWv59
