### PR TITLE
fix(byoa): inherit Claude reasoning preferences in secure turns

### DIFF
--- a/docs/BYOA.md
+++ b/docs/BYOA.md
@@ -274,8 +274,9 @@ fail-closed host boundary:
   environment variable not needed by the fixed Cumora MCP bridge. Because
   restricted mode ignores user settings, the daemon imports only
   `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL`, and
-  `ANTHROPIC_SMALL_FAST_MODEL` from Claude's user settings into the trusted
-  Claude core; those names remain denied to model-spawned subprocesses and the
+  `ANTHROPIC_SMALL_FAST_MODEL` plus the three `ANTHROPIC_DEFAULT_*_MODEL`
+  aliases from Claude's user settings into the trusted
+  Claude core; those names remain denied to model-spawned subprocesses and
   Cumora never serializes the values into argv, its logs, Agent files, or server
   reports. Claude Code
   2.1.248 or newer is required. Linux/WSL2 also requires `bubblewrap` and
@@ -306,11 +307,49 @@ This opt-in also re-enables `CUMORA_*_ARGS` whole-argv overrides and Codex's
 persistent app-server path. Without it, opaque engine arguments are ignored
 because the daemon cannot prove that they preserve the sandbox.
 
+### Claude reasoning and response preferences
+
+Secure Claude agent turns inherit a validated subset of the operator's
+`~/.claude/settings.json` (or absolute `CLAUDE_CONFIG_DIR`):
+
+| Setting | Behavior |
+| --- | --- |
+| `effortLevel` | Inherit `low`, `medium`, `high`, or `xhigh`. |
+| `modelSettings.*.effortLevel` | Inherit per-model effort; Claude resolves canonical names and aliases and gives these entries precedence over the global setting. |
+| `alwaysThinkingEnabled` | Preserve both `true` and `false`; unset keeps Claude's native default. |
+| `language` | Inherit the response language preference. |
+| `env.CLAUDE_CODE_EFFORT_LEVEL` | Explicit effort override, including `max` and `auto`. |
+| `env.MAX_THINKING_TOKENS` | Preserve the operator's budget, including an explicit `0`. |
+| `env.CLAUDE_CODE_MAX_OUTPUT_TOKENS` | Preserve a positive output-token limit. |
+| `env.CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING`, `env.CLAUDE_CODE_DISABLE_THINKING` | Preserve explicit `0`/`1` model or gateway compatibility switches. |
+
+Daemon environment values override corresponding settings-file environment
+entries. Claude applies its native precedence between environment, global,
+and per-model preferences. Cumora no longer supplies `MAX_THINKING_TOKENS=0`
+for agent turns; triage and doctor calls retain their separate thinking-off
+policy and do not import turn-only preferences. Per-Agent model selections
+still win over local model defaults. The three `ANTHROPIC_DEFAULT_OPUS_MODEL`,
+`ANTHROPIC_DEFAULT_SONNET_MODEL`, and `ANTHROPIC_DEFAULT_HAIKU_MODEL` environment
+settings are inherited so provider-specific aliases retain their meaning.
+
+Preferences are loaded at engine-process creation, including session resume;
+restart the daemon to apply edits to existing persistent sessions. In
+unsandboxed compatibility mode Claude continues loading its own settings.
+Hooks, plugins, MCP servers, permissions, arbitrary environment values,
+output styles, and workflow modes are not imported by this preference bridge.
+
+An inherited effort is a preference, not a guarantee of thinking tokens:
+Claude can cap effort for a model or organization, and Opus 5 with thinking
+disabled may send `high` even when `xhigh` is saved. To request deeper
+reasoning, enable thinking as well as setting effort. See
+[Claude model configuration](https://code.claude.com/docs/en/model-config#adjust-effort-level)
+and [ADR 0007](decisions/0007-claude-turn-preferences.md).
+
 ### Running against a custom provider
 
 Custom providers (CC Switch and friends) often store their endpoint,
 authentication value, and default model in `~/.claude/settings.json`. Secure
-Claude imports only that provider bootstrap subset, reports the configured
+Claude imports that provider bootstrap subset, reports the configured
 default model without reporting credentials or endpoint details, and gives it
 precedence over Cumora's deploy-level Anthropic pin for Agents left on **Follow
 engine default**. Explicit per-Agent model choices still win.
@@ -324,7 +363,8 @@ different policy or an older daemon has not reported its local default:
 | `local` | pass **no** model at all — the CLI runs on whatever it is already configured for, and the small/fast pin is dropped too |
 | any model id | use that model instead of the pinned one |
 
-The configured `ANTHROPIC_SMALL_FAST_MODEL` is also used for local triage. When
+The configured `ANTHROPIC_DEFAULT_HAIKU_MODEL` (falling back to the legacy
+`ANTHROPIC_SMALL_FAST_MODEL`) is also used for local triage. When
 a custom endpoint does not name a fast model, Cumora passes no triage model and
 lets the provider choose instead of injecting the first-party `haiku` alias.
 `CUMORA_TRIAGE_MODEL` remains an explicit override, and `cumora agent computer
@@ -393,7 +433,8 @@ the operator's existing login, but model-spawned commands cannot read that
 login or inherit provider credentials in secure mode. Each agent gets its own
 writable home; its credential-free IPC namespace and executable bridge stay
 outside that home. Claude restricted mode ignores user/project settings;
-Cumora restores only its allowlisted provider bootstrap to the trusted core.
+Cumora restores only its allowlisted provider bootstrap and validated model
+preferences to the trusted core.
 Codex `exec --ignore-user-config --ignore-rules`
 does the same and marks the project untrusted. Secure engine startup also drops
 empty, relative, and agent-home entries from `PATH`, so a model-planted

--- a/docs/COORDINATION.md
+++ b/docs/COORDINATION.md
@@ -71,6 +71,9 @@ the pin, every user's behavior drifts whenever Anthropic ships a model.
 Override per-agent by setting `participants.model` for a specific id. Secure
 Claude provider bootstrap and the reason credentials stay outside model tools
 are recorded in [ADR 0005](decisions/0005-secure-claude-provider-bootstrap.md).
+Agent turns now inherit validated Claude effort/thinking preferences instead
+of forcing thinking off. Triage retains its separate cheap-call policy; see
+[ADR 0007](decisions/0007-claude-turn-preferences.md) for precedence and scope.
 
 ### 2. Per-computer big-brain concurrency cap (daemon)
 `CUMORA_BYOA_MAX_CONCURRENT_BIG_BRAIN` (default **6**; drop to 2-4 on very

--- a/docs/decisions/0007-claude-turn-preferences.md
+++ b/docs/decisions/0007-claude-turn-preferences.md
@@ -1,0 +1,60 @@
+# ADR 0007: Inherit Claude model preferences inside the restricted boundary
+
+- Status: Accepted
+- Date: 2026-09-05
+- Amends: [ADR 0005](0005-secure-claude-provider-bootstrap.md), its bootstrap-only allowlist
+
+## Context
+
+The provider bootstrap fix restored authentication and model routing but did
+not restore `effortLevel`. Restricted Claude ignores user settings, and Cumora
+also defaulted every agent turn to `MAX_THINKING_TOKENS=0`. This silently
+discarded the operator's reasoning preferences even for substantial agent work.
+New Claude versions also save effort in `modelSettings`, so inheriting only the
+global field would miss settings written by the native effort picker.
+
+## Decision
+
+- Import validated `effortLevel`, per-model effort entries,
+  `alwaysThinkingEnabled`, and `language` into Cumora's inline turn settings.
+  Rebuild nested model entries from allowed fields; never merge arbitrary
+  user settings into permissions, hooks, tools, or the sandbox.
+- Import a fixed turn-only environment allowlist for effort, thinking budget,
+  output limit, and thinking/adaptive compatibility switches. Explicit daemon
+  environment values win. Every imported environment name remains denied to
+  model-spawned subprocesses. Provider credentials remain outside argv.
+- Stop forcing thinking off for agent turns. Preserve an explicit disabled
+  setting, and otherwise let Claude choose its native default and apply its
+  model-specific and managed-policy rules. Inherit preferences, not an
+  assertion that the provider will honor a particular reasoning level.
+- Preserve Opus/Sonnet/Haiku provider model aliases in the core environment.
+  The current Haiku alias is also used for catalog/triage fast-model defaults,
+  with the legacy small-fast setting as fallback; Agent pins still win.
+- Keep triage and doctor thinking off and separate from turn preferences.
+  Read preferences when a process is spawned, for both one-shot and persistent
+  sessions; an existing persistent session requires a daemon restart to pick
+  up local edits.
+
+## Consequences
+
+Explicit high-effort or thinking preferences can increase turn latency and
+cost; that is the operator's choice. Missing preferences no longer imply an
+unadvertised Cumora thinking-off policy. `xhigh` plus thinking disabled can
+still become `high` for Opus 5 under Claude's native compatibility handling.
+The public server model catalog never receives these personal turn preferences.
+
+## Alternatives considered
+
+- **Load the complete settings file:** rejected; restores executable settings
+  and tool authority excluded by restricted mode.
+- **Hard-code `--effort xhigh` or turn thinking on:** rejected; overrides
+  per-model, environment, and explicitly disabled preferences.
+- **Forward output styles, fast mode, or ultracode:** deferred; styles can load
+  user-authored role prompts, and speed/workflow modes change billing or
+  orchestration beyond reasoning preference inheritance.
+
+## References
+
+- [Claude effort and thinking](https://code.claude.com/docs/en/model-config#adjust-effort-level)
+- [Claude settings reference](https://code.claude.com/docs/en/settings-reference)
+- [Claude environment variables](https://code.claude.com/docs/en/env-vars)

--- a/server/src/__tests__/agents-computer-engine.test.ts
+++ b/server/src/__tests__/agents-computer-engine.test.ts
@@ -10,7 +10,7 @@ import { delimiter, dirname, join } from 'node:path'
 import { afterEach, test } from 'node:test'
 import { setTimeout as delay } from 'node:timers/promises'
 import { type EngineHopReport, type EngineRunResult, getAdapter, headlessSpawnOptions, resolveSpawn, runnableEngineIds, secureEngineCapabilityReason } from '../agents/computer/engine.js'
-import { CLAUDE_CORE_ENV_KEYS } from '../agents/computer/claude-user-settings.js'
+import { CLAUDE_CORE_ENV_KEYS, CLAUDE_TURN_ENV_KEYS } from '../agents/computer/claude-user-settings.js'
 
 const IS_WIN = process.platform === 'win32'
 const ORIGINAL_PATH = process.env.PATH
@@ -31,7 +31,8 @@ function secureClaudeEnv(root: string, overrides: NodeJS.ProcessEnv = {}): NodeJ
   // else. Drop the bootstrap keys so these tests measure the import, not the
   // shell. Sourced from the module under test so a fifth key cannot drift.
   for (const key of CLAUDE_CORE_ENV_KEYS) delete base[key]
-  delete base.CLAUDE_CONFIG_DIR
+  for (const key of CLAUDE_TURN_ENV_KEYS) delete base[key]
+  base.CLAUDE_CONFIG_DIR = join(root, 'missing-claude-config')
   return {
     ...base,
     CUMORA_AGENT_IPC_DIR: join(root, 'private-ipc'),
@@ -290,7 +291,8 @@ test('Claude secure triage stays inside the custom provider model namespace', { 
     env: {
       ANTHROPIC_AUTH_TOKEN: 'fixture-token',
       ANTHROPIC_BASE_URL: 'https://provider.example.test',
-      ANTHROPIC_SMALL_FAST_MODEL: 'provider/fast-model',
+      ANTHROPIC_SMALL_FAST_MODEL: 'provider/legacy-fast-model',
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: 'provider/fast-model',
     },
   }), 'utf8')
   const env = secureClaudeEnv(root, {
@@ -318,6 +320,94 @@ test('Claude secure triage stays inside the custom provider model namespace', { 
   const unnamedArgv = JSON.parse(unnamed.text) as { argv: string[] }
   assert.equal(unnamedArgv.argv.includes('--model'), false)
   assert.equal(unnamedArgv.argv.includes('haiku'), false)
+})
+
+test('Claude turn preferences reach one-shot and persistent children without widening tools or triage', { skip: IS_WIN }, async () => {
+  const root = await mkdtemp(join(tmpdir(), 'cumora-claude-preferences-'))
+  tempDirs.push(root)
+  const binDir = join(root, 'bin')
+  const configDir = join(root, 'config')
+  const home = join(root, 'home')
+  await Promise.all([mkdir(binDir), mkdir(configDir), mkdir(home)])
+  await writeFakeCli(binDir, 'claude', `
+const argv = process.argv.slice(2)
+const capture = () => JSON.stringify({ argv, env: Object.fromEntries(
+  ${JSON.stringify([...CLAUDE_CORE_ENV_KEYS, ...CLAUDE_TURN_ENV_KEYS])}.filter(k => process.env[k] !== undefined).map(k => [k, process.env[k]])
+) })
+if (argv.includes('--input-format')) {
+  require('node:readline').createInterface({ input: process.stdin }).on('line', () => {
+    process.stderr.write(capture() + '\\n')
+    process.stdout.write(JSON.stringify({type:'result', subtype:'success', result:'OK', session_id:'fixture'}) + '\\n')
+  })
+} else if (argv.includes('--output-format') && argv[argv.indexOf('--output-format') + 1] === 'json') {
+  process.stdout.write(JSON.stringify({result: capture()}))
+} else {
+  process.stderr.write(capture() + '\\n')
+  process.stdout.write(JSON.stringify({type:'result', subtype:'success', result:'OK'}) + '\\n')
+}
+`)
+  useFakeCliPath(binDir)
+  const preferences = {
+    effortLevel: 'xhigh', modelSettings: { 'claude-opus-5': { effortLevel: 'medium' } },
+    alwaysThinkingEnabled: true, language: 'Chinese',
+  }
+  for (const thinking of [undefined, false, true]) {
+    await writeFile(join(configDir, 'settings.json'), JSON.stringify({
+      ...preferences, alwaysThinkingEnabled: thinking,
+      hooks: { SessionStart: [{ hooks: [{ type: 'command', command: 'untrusted-command' }] }] },
+      permissions: { allow: ['Bash'], defaultMode: 'bypassPermissions' },
+      sandbox: { enabled: false },
+      env: { ANTHROPIC_DEFAULT_OPUS_MODEL: 'provider/main', ANTHROPIC_DEFAULT_HAIKU_MODEL: 'provider/small', CLAUDE_CODE_MAX_OUTPUT_TOKENS: '8192' },
+    }))
+    const env = secureClaudeEnv(root, { CLAUDE_CONFIG_DIR: configDir })
+    for (const persistent of [false, true]) {
+      const logs: string[] = []
+      const args = { home, env, model: 'opus', fastModel: 'agent/small', onLog: (line: string) => logs.push(line) }
+      if (persistent) {
+        const session = getAdapter('claude').startSession?.(args)
+        assert.ok(session)
+        liveSessions.push(session)
+        assert.equal((await session.send('wake')).exitCode, 0)
+        await session.stop()
+      } else {
+        assert.equal((await getAdapter('claude').run({ ...args, prompt: 'wake', signal: new AbortController().signal })).exitCode, 0)
+      }
+      const captured = JSON.parse(logs[0]) as { argv: string[]; env: NodeJS.ProcessEnv }
+      const settings = JSON.parse(captured.argv[captured.argv.indexOf('--settings') + 1])
+      assert.equal(settings.effortLevel, 'xhigh')
+      assert.deepEqual(settings.modelSettings, preferences.modelSettings)
+      assert.equal(settings.alwaysThinkingEnabled, thinking)
+      assert.equal(settings.language, 'Chinese')
+      assert.equal(captured.env.MAX_THINKING_TOKENS, undefined)
+      assert.equal(captured.env.ANTHROPIC_DEFAULT_OPUS_MODEL, 'provider/main')
+      assert.equal(captured.env.ANTHROPIC_DEFAULT_HAIKU_MODEL, 'agent/small')
+      assert.equal(captured.env.ANTHROPIC_SMALL_FAST_MODEL, 'agent/small')
+      assert.equal(captured.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS, '8192')
+      assert.equal(settings.hooks, undefined)
+      assert.equal(settings.sandbox.enabled, true)
+      assert.equal(settings.permissions.defaultMode, 'dontAsk')
+      assert.ok(settings.sandbox.credentials.envVars.some((x: {name: string; mode: string}) => x.name === 'CLAUDE_CODE_MAX_OUTPUT_TOKENS' && x.mode === 'deny'))
+      assert.doesNotMatch(JSON.stringify(captured.argv), /untrusted-command|provider\/main/)
+    }
+  }
+  await writeFile(join(configDir, 'settings.json'), JSON.stringify({
+    effortLevel: 'xhigh', alwaysThinkingEnabled: true,
+    env: { MAX_THINKING_TOKENS: '4096', CLAUDE_CODE_EFFORT_LEVEL: 'max', CLAUDE_CODE_MAX_OUTPUT_TOKENS: '8192' },
+  }))
+  const env = secureClaudeEnv(root, { CLAUDE_CONFIG_DIR: configDir, MAX_THINKING_TOKENS: '0', CLAUDE_CODE_EFFORT_LEVEL: 'low' })
+  const logs: string[] = []
+  await getAdapter('claude').run({ home, env, prompt: 'wake', onLog: l => logs.push(l), signal: new AbortController().signal })
+  const captured = JSON.parse(logs[0])
+  assert.equal(captured.env.MAX_THINKING_TOKENS, '0')
+  assert.equal(captured.env.CLAUDE_CODE_EFFORT_LEVEL, 'low')
+  const triage = await getAdapter('claude').classify({
+    cwd: home, env: secureClaudeEnv(root, { CLAUDE_CONFIG_DIR: configDir }), prompt: 'classify', signal: new AbortController().signal,
+  })
+  const cheap = JSON.parse(triage.text)
+  assert.equal(cheap.env.MAX_THINKING_TOKENS, '0')
+  assert.equal(cheap.env.CLAUDE_CODE_EFFORT_LEVEL, undefined)
+  assert.equal(cheap.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS, undefined)
+  assert.equal(cheap.argv.includes('--settings'), false)
 })
 
 test('persistent Claude startup failure keeps stderr for first send', async () => {

--- a/server/src/__tests__/agents-computer-model-catalog.test.ts
+++ b/server/src/__tests__/agents-computer-model-catalog.test.ts
@@ -54,6 +54,8 @@ test('Claude custom-provider settings expose only core bootstrap values and mode
   try {
     const settings = readClaudeUserSettings(env)
     assert.deepEqual(settings, {
+      turnEnv: {},
+      turnSettings: {},
       coreEnv: {
         ANTHROPIC_AUTH_TOKEN: 'settings-token',
         ANTHROPIC_BASE_URL: 'https://provider.example.test',
@@ -79,6 +81,14 @@ test('Claude custom-provider settings expose only core bootstrap values and mode
       'provider/haiku-small',
     ])
     assert.doesNotMatch(JSON.stringify(catalog), /settings-token|provider\.example\.test/)
+
+    const modern = await discoverEngineModelCatalog('claude', '/fixture/claude', true, {
+      ...env, ANTHROPIC_DEFAULT_HAIKU_MODEL: 'provider/current-haiku',
+    })
+    assert.equal(modern.defaultFastModel, 'provider/current-haiku')
+    assert.equal(modern.models.some(model => model.id === 'provider/current-haiku'), true)
+    assert.equal('turnSettings' in modern, false)
+    assert.equal('turnEnv' in modern, false)
   } finally {
     clearModelCatalogCache()
     await rm(root, { recursive: true, force: true })
@@ -88,6 +98,8 @@ test('Claude custom-provider settings expose only core bootstrap values and mode
 test('Claude settings ignore a relative config-root override instead of reading from cwd', () => {
   assert.deepEqual(readClaudeUserSettings({ CLAUDE_CONFIG_DIR: 'relative/config' }), {
     coreEnv: {},
+    turnEnv: {},
+    turnSettings: {},
     defaultModel: null,
     defaultFastModel: null,
     prefersLocalDefault: false,

--- a/server/src/__tests__/claude-turn-preferences.test.ts
+++ b/server/src/__tests__/claude-turn-preferences.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { readClaudeUserSettings } from '../agents/computer/claude-user-settings.js'
+
+test('Claude preference import validates nested settings and never forwards arbitrary configuration', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'cumora-turn-preferences-'))
+  try {
+    const file = join(root, 'settings.json')
+    await writeFile(file, JSON.stringify({
+      effortLevel: 'xhigh', alwaysThinkingEnabled: false, language: 'Chinese',
+      modelSettings: {
+        'claude-opus-5': { effortLevel: 'high', hooks: { bad: true } },
+        'claude-sonnet-5': { effortLevel: 'max' },
+        'invalid': 'xhigh',
+      },
+      hooks: { bad: true }, outputStyle: 'untrusted-style', fastMode: true,
+      env: {
+        CLAUDE_CODE_EFFORT_LEVEL: 'max', MAX_THINKING_TOKENS: '4096',
+        CLAUDE_CODE_MAX_OUTPUT_TOKENS: '16384', CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING: '1',
+        CLAUDE_CODE_DISABLE_THINKING: '0', NODE_OPTIONS: '--require bad.js',
+        ANTHROPIC_DEFAULT_SONNET_MODEL: 'provider/sonnet', ANTHROPIC_DEFAULT_HAIKU_MODEL: 'provider/haiku',
+      },
+    }))
+    const read = () => readClaudeUserSettings({ CLAUDE_CONFIG_DIR: root })
+    assert.deepEqual(read().turnSettings, {
+      effortLevel: 'xhigh', alwaysThinkingEnabled: false, language: 'Chinese',
+      modelSettings: { 'claude-opus-5': { effortLevel: 'high' } },
+    })
+    assert.deepEqual(read().turnEnv, {
+      CLAUDE_CODE_EFFORT_LEVEL: 'max', MAX_THINKING_TOKENS: '4096',
+      CLAUDE_CODE_MAX_OUTPUT_TOKENS: '16384', CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING: '1',
+      CLAUDE_CODE_DISABLE_THINKING: '0',
+    })
+    assert.deepEqual(read().coreEnv, {
+      ANTHROPIC_DEFAULT_SONNET_MODEL: 'provider/sonnet', ANTHROPIC_DEFAULT_HAIKU_MODEL: 'provider/haiku',
+    })
+    await writeFile(file, JSON.stringify({
+      effortLevel: 'max', alwaysThinkingEnabled: 'true', language: [], modelSettings: [],
+      env: { CLAUDE_CODE_EFFORT_LEVEL: '--bad', MAX_THINKING_TOKENS: '-1', CLAUDE_CODE_MAX_OUTPUT_TOKENS: '0', CLAUDE_CODE_DISABLE_THINKING: {} },
+    }))
+    assert.deepEqual(read().turnSettings, {})
+    assert.deepEqual(read().turnEnv, {})
+    await writeFile(file, '{bad json')
+    assert.deepEqual(read().turnSettings, {})
+    assert.deepEqual(read().turnEnv, {})
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})

--- a/server/src/agents/computer/claude-user-settings.ts
+++ b/server/src/agents/computer/claude-user-settings.ts
@@ -1,10 +1,9 @@
 /**
  * Claude Code's `--restricted` mode intentionally ignores user settings. That
  * is the right boundary for tools, hooks and MCP servers, but custom providers
- * commonly keep the small provider/bootstrap surface the Claude core needs in
- * ~/.claude/settings.json. Import only that narrow bootstrap surface into the
- * engine process environment; the adapter's restricted settings separately
- * deny every imported value to model-spawned subprocesses.
+ * keep provider bootstrap and model preferences in ~/.claude/settings.json.
+ * Import only validated, non-executable fields. Environment values enter the
+ * trusted core; the adapter denies those names to model-spawned subprocesses.
  */
 import { readFileSync, statSync } from 'node:fs'
 import { homedir } from 'node:os'
@@ -20,7 +19,63 @@ export const CLAUDE_CORE_ENV_KEYS = [
   'ANTHROPIC_AUTH_TOKEN',
   'ANTHROPIC_BASE_URL',
   'ANTHROPIC_SMALL_FAST_MODEL',
+  'ANTHROPIC_DEFAULT_OPUS_MODEL',
+  'ANTHROPIC_DEFAULT_SONNET_MODEL',
+  'ANTHROPIC_DEFAULT_HAIKU_MODEL',
 ] as const
+
+/** Turn preferences must not raise the budget of triage or doctor calls. */
+export const CLAUDE_TURN_ENV_KEYS = [
+  'CLAUDE_CODE_EFFORT_LEVEL',
+  'MAX_THINKING_TOKENS',
+  'CLAUDE_CODE_MAX_OUTPUT_TOKENS',
+  'CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING',
+  'CLAUDE_CODE_DISABLE_THINKING',
+] as const
+
+type SavedEffort = 'low' | 'medium' | 'high' | 'xhigh'
+export interface ClaudeTurnSettings {
+  effortLevel?: SavedEffort
+  modelSettings?: Record<string, { effortLevel: SavedEffort }>
+  alwaysThinkingEnabled?: boolean
+  language?: string
+}
+
+function savedEffort(value: unknown): value is SavedEffort {
+  return typeof value === 'string' && ['low', 'medium', 'high', 'xhigh'].includes(value)
+}
+
+function turnSettings(record: Record<string, unknown>): ClaudeTurnSettings {
+  const result: ClaudeTurnSettings = {}
+  if (savedEffort(record.effortLevel)) result.effortLevel = record.effortLevel
+  if (typeof record.alwaysThinkingEnabled === 'boolean') result.alwaysThinkingEnabled = record.alwaysThinkingEnabled
+  const language = cleanString(record.language, 160)
+  if (language) result.language = language
+  if (record.modelSettings && typeof record.modelSettings === 'object' && !Array.isArray(record.modelSettings)) {
+    const entries = Object.entries(record.modelSettings).slice(0, 128).flatMap(([model, value]) => {
+      if (!model || model.length > 160 || /[\u0000-\u001f\u007f]/.test(model)
+        || !value || typeof value !== 'object' || Array.isArray(value)) return []
+      const effort = (value as Record<string, unknown>).effortLevel
+      return savedEffort(effort) ? [[model, { effortLevel: effort }] as const] : []
+    })
+    if (entries.length) result.modelSettings = Object.fromEntries(entries)
+  }
+  return result
+}
+
+function turnEnv(rawEnv: Record<string, unknown>): NodeJS.ProcessEnv {
+  const result: NodeJS.ProcessEnv = {}
+  for (const key of CLAUDE_TURN_ENV_KEYS) {
+    const value = rawEnv[key]
+    if (typeof value !== 'string') continue
+    if (key === 'CLAUDE_CODE_EFFORT_LEVEL') {
+      if (savedEffort(value) || value === 'max' || value === 'auto') result[key] = value
+    } else if (key === 'MAX_THINKING_TOKENS' || key === 'CLAUDE_CODE_MAX_OUTPUT_TOKENS') {
+      if (/^(0|[1-9]\d{0,8})$/.test(value) && (key === 'MAX_THINKING_TOKENS' || value !== '0')) result[key] = value
+    } else if (value === '0' || value === '1') result[key] = value
+  }
+  return result
+}
 
 /** Anthropic's own API origins. A base URL naming one of these is not a custom
  *  provider — it is the default, written out.
@@ -51,6 +106,8 @@ type ClaudeCoreEnvKey = typeof CLAUDE_CORE_ENV_KEYS[number]
 
 export interface ClaudeUserSettings {
   coreEnv: Partial<Record<ClaudeCoreEnvKey, string>>
+  turnEnv: NodeJS.ProcessEnv
+  turnSettings: ClaudeTurnSettings
   defaultModel: string | null
   defaultFastModel: string | null
   prefersLocalDefault: boolean
@@ -58,6 +115,8 @@ export interface ClaudeUserSettings {
 
 const EMPTY_SETTINGS: ClaudeUserSettings = {
   coreEnv: {},
+  turnEnv: {},
+  turnSettings: {},
   defaultModel: null,
   defaultFastModel: null,
   prefersLocalDefault: false,
@@ -79,7 +138,7 @@ function settingsPath(env: NodeJS.ProcessEnv): string | null {
   return join(dir, 'settings.json')
 }
 
-/** Read only the non-executable provider bootstrap subset of Claude's user
+/** Read only non-executable provider bootstrap and turn preferences from user
  * settings. Malformed, oversized or absent settings fail soft so first-party
  * OAuth/keychain users retain Claude's native behaviour. */
 export function readClaudeUserSettings(env: NodeJS.ProcessEnv = process.env): ClaudeUserSettings {
@@ -100,8 +159,11 @@ export function readClaudeUserSettings(env: NodeJS.ProcessEnv = process.env): Cl
     }
     return {
       coreEnv,
+      turnEnv: turnEnv(rawEnv),
+      turnSettings: turnSettings(record),
       defaultModel: cleanString(record.model, 160),
-      defaultFastModel: cleanString(rawEnv.ANTHROPIC_SMALL_FAST_MODEL, 160),
+      defaultFastModel: cleanString(rawEnv.ANTHROPIC_DEFAULT_HAIKU_MODEL, 160)
+        ?? cleanString(rawEnv.ANTHROPIC_SMALL_FAST_MODEL, 160),
       // A custom endpoint owns its model namespace. When no explicit Agent pin
       // exists, the server must not replace that namespace with its Anthropic
       // deployment default even if the local config omits a named model.

--- a/server/src/agents/computer/engine.ts
+++ b/server/src/agents/computer/engine.ts
@@ -30,7 +30,7 @@ import { homedir, tmpdir } from 'node:os'
 import { basename, dirname, join, delimiter as PATH_DELIMITER } from 'node:path'
 import { StringDecoder } from 'node:string_decoder'
 import { stripLoneSurrogates } from '../text-safety.js'
-import { isCustomAnthropicEndpoint, withClaudeUserSettingsEnv } from './claude-user-settings.js'
+import { isCustomAnthropicEndpoint, readClaudeUserSettings, withClaudeUserSettingsEnv } from './claude-user-settings.js'
 import { isCliVersionAtLeast, probeEngineVersion, probeLocalEngineVersion } from './cli-version.js'
 import { discoverEngineModelCatalog, type EngineModelCatalog } from './model-catalog.js'
 
@@ -1355,6 +1355,7 @@ function claudeSecureSettings(agentHome: string, env: NodeJS.ProcessEnv): string
   pathDirs.push(dirname(process.execPath))
   const allowRead = [...new Set([agentHome, ...pathDirs])]
   return JSON.stringify({
+    ...readClaudeUserSettings(env).turnSettings,
     permissions: {
       defaultMode: 'dontAsk',
       // Restricted mode confines file tools to the working directory. Keep the
@@ -1426,6 +1427,7 @@ function claudeCoreEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
 function claudeFastModelArgs(env: NodeJS.ProcessEnv, requested?: string | null): string[] {
   const model = requested?.trim()
     || env.CUMORA_TRIAGE_MODEL?.trim()
+    || env.ANTHROPIC_DEFAULT_HAIKU_MODEL?.trim()
     || env.ANTHROPIC_SMALL_FAST_MODEL?.trim()
   if (model) return ['--model', model]
   return isCustomAnthropicEndpoint(env.ANTHROPIC_BASE_URL) ? [] : ['--model', 'haiku']
@@ -1433,14 +1435,21 @@ function claudeFastModelArgs(env: NodeJS.ProcessEnv, requested?: string | null):
 
 function claudeTurnEnv(env: NodeJS.ProcessEnv, fastModel?: string | null): NodeJS.ProcessEnv {
   const core = claudeCoreEnv(env)
+  if (!allowUnsandboxedByoa(core)) {
+    for (const [key, value] of Object.entries(readClaudeUserSettings(env).turnEnv)) {
+      if (core[key] === undefined) core[key] = value
+    }
+  }
   const turnEnv: NodeJS.ProcessEnv = {
     ...core,
-    MAX_THINKING_TOKENS: core.MAX_THINKING_TOKENS ?? '0',
     CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: allowUnsandboxedByoa(core)
       ? core.CLAUDE_CODE_SUBPROCESS_ENV_SCRUB
       : '1',
   }
-  if (fastModel) turnEnv.ANTHROPIC_SMALL_FAST_MODEL = fastModel
+  if (fastModel) {
+    turnEnv.ANTHROPIC_DEFAULT_HAIKU_MODEL = fastModel
+    turnEnv.ANTHROPIC_SMALL_FAST_MODEL = fastModel
+  }
   return turnEnv
 }
 
@@ -1593,11 +1602,8 @@ class ClaudeAdapter implements EngineAdapter {
         ? ['-p', ...resume, ...model, '--output-format', 'stream-json', '--verbose', '--dangerously-skip-permissions']
         : ['-p', ...resume, ...model, '--output-format', 'stream-json', '--verbose', ...claudeSecureFlags(args.home, env)]
     const argv = wantsStdinPrompt ? base : (flags.length ? [...base, args.prompt] : ['-p', args.prompt, ...base.slice(1)])
-    // BYOA turns are short reactive cycles (read inbox, maybe reply). Extended
-    // thinking just adds latency + cost here, and in a group @all it makes the
-    // slowest agent finish last and bow out on the "don't duplicate" rule. Disable
-    // it by default (MAX_THINKING_TOKENS=0); a user can re-enable by exporting their
-    // own MAX_THINKING_TOKENS before launching the daemon.
+    // Agent turns can be substantial engineering/design work. Preserve the
+    // operator's reasoning preferences; only triage/doctor force thinking off.
     return spawnEngine(command, argv, { ...args, env }, { shell, stdinText: wantsStdinPrompt ? args.prompt : undefined })
   }
 

--- a/server/src/agents/computer/model-catalog.ts
+++ b/server/src/agents/computer/model-catalog.ts
@@ -330,7 +330,8 @@ export async function discoverEngineModelCatalog(
   if (id === 'claude') {
     const settings = readClaudeUserSettings(env)
     const coreEnv = withClaudeUserSettingsEnv(env)
-    const defaultFastModel = clean(coreEnv.ANTHROPIC_SMALL_FAST_MODEL, 160)
+    const defaultFastModel = clean(coreEnv.ANTHROPIC_DEFAULT_HAIKU_MODEL, 160)
+      ?? clean(coreEnv.ANTHROPIC_SMALL_FAST_MODEL, 160)
     const prefersLocalDefault = isCustomAnthropicEndpoint(clean(coreEnv.ANTHROPIC_BASE_URL, 4096))
     const configured = [settings.defaultModel, defaultFastModel]
       .filter((model): model is string => !!model)


### PR DESCRIPTION
## Problem

Secure Claude BYOA turns ignored the operator's saved effort and thinking preferences. An agent configured with `effortLevel: "xhigh"` still ran with Claude's default effort, and Cumora injected `MAX_THINKING_TOKENS=0` even for substantial engineering/design work.

## Change

- Inherit validated global/per-model effort, the thinking toggle, response language, and a fixed turn-only environment allowlist for effort, thinking budget, output limit, and thinking compatibility switches.
- Remove the unconditional thinking-off default for agent turns. Preserve explicit daemon environment overrides and explicit disabled preferences; let Claude apply its native model/managed-policy precedence.
- Preserve provider Opus/Sonnet/Haiku aliases, including Haiku catalog/triage defaults and explicit Agent fast-model precedence.
- Keep triage/doctor thinking off. Hooks, tools, MCP servers, sandbox permissions, and arbitrary settings remain excluded; imported environment values remain denied to model-spawned subprocesses.
- Document the contract and deferred settings in BYOA guidance and ADR 0007. Preferences apply when an engine process starts, including a resumed session.

## Validation

- PR CI passed all seven checks, including the complete unit and PostgreSQL/Redis integration suites: https://github.com/yetone/cumora/actions/runs/33970238204
- Lint, frontend/server typechecks, all three architecture guards, and agent CLI bundle build passed.
- Full local unit suite: 1180 passed, 4 skipped, 1 failed because the real-Postgres observability test could not connect to a local database. Local integration suite skipped without `INTEGRATION_DATABASE_URL`; PR CI supplies PostgreSQL and Redis for both suites.
- Regression coverage checks one-shot and persistent children, per-model settings, explicit false/unset thinking, environment precedence, malformed settings, provider aliases, credential isolation, and triage separation.
- Real Claude Code 2.1.260 against a loopback mock API (no external provider calls): `xhigh` + thinking enabled sent `xhigh`/adaptive; a per-model `medium` override sent `medium`; thinking disabled sent `high`/disabled; persistent mode sent `xhigh`/adaptive. This verifies native request behavior, including Claude's intentional Opus 5 effort cap with thinking disabled.
- Diff whitespace and sensitive-value checks passed.
