### PR TITLE
fix(db): wrap versioned schema migrations and ledger records in transactions

### DIFF
--- a/server/src/__integration__/schema-migrations.test.ts
+++ b/server/src/__integration__/schema-migrations.test.ts
@@ -1,7 +1,12 @@
 import { after, before, test } from 'node:test'
 import assert from 'node:assert/strict'
 import { pool } from '../db/pool.js'
-import { ensureSchema, REQUIRED_SCHEMA_INDEXES } from '../db/migrate.js'
+import {
+  applyPendingMigration,
+  ensureSchema,
+  REQUIRED_SCHEMA_INDEXES,
+  type VersionedMigration,
+} from '../db/migrate.js'
 import { SCHEMA_MIGRATIONS } from '../db/migrations/manifest.js'
 import { verifySchemaCompatibility } from '../db/schema-version.js'
 import { ensureSchemaOnce, teardownAll } from './_helpers.js'
@@ -68,3 +73,38 @@ test('promotion-required indexes are valid, ready, and live', async () => {
     assert.equal(row.indislive, true, `${name} must be live`)
   }
 })
+
+test('a failed versioned migration rolls back DDL changes and leaves no ledger entry on PostgreSQL', async () => {
+  const client = await pool.connect()
+  try {
+    const dummyMigration: VersionedMigration = {
+      version: 9999,
+      name: '9999-fail-atomicity',
+      checksum: 'f'.repeat(64),
+      sourceChecksum: 'f'.repeat(64),
+      transactional: true,
+      up: async (txClient) => {
+        await txClient.query('CREATE TABLE IF NOT EXISTS migration_atomicity_test_table (id INT)')
+        throw new Error('simulated DDL explosion')
+      },
+    }
+
+    await assert.rejects(
+      () => applyPendingMigration(client, dummyMigration),
+      /simulated DDL explosion/,
+    )
+
+    const { rows: tableRows } = await pool.query(
+      `SELECT 1 FROM information_schema.tables WHERE table_name = 'migration_atomicity_test_table'`,
+    )
+    assert.equal(tableRows.length, 0, 'rolled-back table must not exist in database')
+
+    const { rows: ledgerRows } = await pool.query(
+      `SELECT 1 FROM schema_migrations WHERE version = 9999`,
+    )
+    assert.equal(ledgerRows.length, 0, 'rolled-back ledger row must not exist')
+  } finally {
+    client.release()
+  }
+})
+

--- a/server/src/__tests__/migration-transaction-atomicity.test.ts
+++ b/server/src/__tests__/migration-transaction-atomicity.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Database migration transaction atomicity.
+ *
+ * Migration DDL and ledger record must be atomic. If a migration is interrupted
+ * or fails midway, PostgreSQL must roll back all partial schema changes and
+ * the schema_migrations ledger must have no record, allowing clean recovery
+ * on rerun.
+ *
+ * Run: node --import tsx --test server/src/__tests__/migration-transaction-atomicity.test.ts
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import type { PoolClient } from 'pg'
+
+process.env.CUMORA_RUNTIME_CLIENT = 'http'
+process.env.OPENAI_API_KEY ??= 'test-key'
+
+const { applyPendingMigration } = await import('../db/migrate.js')
+type VersionedMigration = import('../db/migrate.js').VersionedMigration
+
+function fakeClient(opts: { failRollback?: boolean } = {}) {
+  const calls: { sql: string; params?: unknown[] }[] = []
+  const client = {
+    calls,
+    query: async (sql: string, params?: unknown[]) => {
+      calls.push({ sql: sql.trim(), params })
+      if (sql.trim() === 'ROLLBACK' && opts.failRollback) {
+        throw new Error('rollback network error')
+      }
+      return { rows: [] }
+    },
+    release: () => {},
+  } as unknown as PoolClient
+  return { client, calls }
+}
+
+test('transactional migration executes within BEGIN and COMMIT', async () => {
+  const { client, calls } = fakeClient()
+  let upCalled = false
+
+  const migration: VersionedMigration = {
+    version: 2,
+    name: '0002-test',
+    checksum: 'a'.repeat(64),
+    sourceChecksum: 'a'.repeat(64),
+    transactional: true,
+    up: async () => {
+      upCalled = true
+      calls.push({ sql: 'CREATE TABLE test_table (id INT)' })
+    },
+  }
+
+  await applyPendingMigration(client, migration)
+
+  assert.ok(upCalled, 'migration.up should be called')
+  assert.equal(calls[0].sql, 'BEGIN')
+  assert.equal(calls[1].sql, 'CREATE TABLE test_table (id INT)')
+  assert.match(calls[2].sql, /^INSERT INTO schema_migrations/i)
+  assert.equal(calls[3].sql, 'COMMIT')
+})
+
+test('transactional migration defaults to true when transactional is omitted for version >= 2', async () => {
+  const { client, calls } = fakeClient()
+
+  const migration: VersionedMigration = {
+    version: 5,
+    name: '0005-test-default',
+    checksum: 'b'.repeat(64),
+    sourceChecksum: 'b'.repeat(64),
+    up: async () => {
+      calls.push({ sql: 'ALTER TABLE test ADD COLUMN foo TEXT' })
+    },
+  }
+
+  await applyPendingMigration(client, migration)
+
+  assert.equal(calls[0].sql, 'BEGIN')
+  assert.equal(calls[1].sql, 'ALTER TABLE test ADD COLUMN foo TEXT')
+  assert.match(calls[2].sql, /^INSERT INTO schema_migrations/i)
+  assert.equal(calls[3].sql, 'COMMIT')
+})
+
+test('failing migration issues ROLLBACK and never records ledger entry', async () => {
+  const { client, calls } = fakeClient()
+
+  const migration: VersionedMigration = {
+    version: 3,
+    name: '0003-failing',
+    checksum: 'c'.repeat(64),
+    sourceChecksum: 'c'.repeat(64),
+    transactional: true,
+    up: async () => {
+      calls.push({ sql: 'ALTER TABLE bad ADD COLUMN bar INT' })
+      throw new Error('relation bad does not exist')
+    },
+  }
+
+  await assert.rejects(
+    () => applyPendingMigration(client, migration),
+    /relation bad does not exist/,
+  )
+
+  const statements = calls.map((c) => c.sql)
+  assert.equal(statements[0], 'BEGIN')
+  assert.equal(statements[1], 'ALTER TABLE bad ADD COLUMN bar INT')
+  assert.equal(statements[2], 'ROLLBACK')
+  assert.ok(!statements.includes('COMMIT'), 'COMMIT must never be called on failure')
+  assert.ok(
+    !statements.some((s) => s.startsWith('INSERT INTO schema_migrations')),
+    'schema_migrations record must never be written on failure',
+  )
+})
+
+test('non-transactional migration (transactional: false) runs without BEGIN/COMMIT', async () => {
+  const { client, calls } = fakeClient()
+
+  const migration: VersionedMigration = {
+    version: 1,
+    name: '0001-baseline',
+    checksum: 'd'.repeat(64),
+    sourceChecksum: 'd'.repeat(64),
+    transactional: false,
+    up: async () => {
+      calls.push({ sql: 'CREATE INDEX CONCURRENTLY idx_foo ON foo(id)' })
+    },
+  }
+
+  await applyPendingMigration(client, migration)
+
+  const statements = calls.map((c) => c.sql)
+  assert.ok(!statements.includes('BEGIN'), 'BEGIN must not be called')
+  assert.ok(!statements.includes('COMMIT'), 'COMMIT must not be called')
+  assert.equal(statements[0], 'CREATE INDEX CONCURRENTLY idx_foo ON foo(id)')
+  assert.match(statements[1], /^INSERT INTO schema_migrations/i)
+})
+
+test('rollback failure still preserves original migration error', async () => {
+  const { client } = fakeClient({ failRollback: true })
+
+  const migration: VersionedMigration = {
+    version: 4,
+    name: '0004-rollback-failure',
+    checksum: 'e'.repeat(64),
+    sourceChecksum: 'e'.repeat(64),
+    transactional: true,
+    up: async () => {
+      throw new Error('primary migration error')
+    },
+  }
+
+  await assert.rejects(
+    () => applyPendingMigration(client, migration),
+    /primary migration error/,
+  )
+})

--- a/server/src/db/migrate.ts
+++ b/server/src/db/migrate.ts
@@ -2048,8 +2048,9 @@ export function computedBaselineMigrationChecksum(): string {
   return createHash('sha256').update(DDL).digest('hex')
 }
 
-interface VersionedMigration extends MigrationMetadata {
+export interface VersionedMigration extends MigrationMetadata {
   sourceChecksum: string
+  transactional?: boolean
   up(client: import('pg').PoolClient): Promise<void>
 }
 
@@ -2369,24 +2370,59 @@ const VERSIONED_MIGRATIONS: readonly VersionedMigration[] = [
   {
     ...SCHEMA_MIGRATIONS[0],
     sourceChecksum: computedBaselineMigrationChecksum(),
+    transactional: false,
     up: applyLegacyBaseline,
   },
   {
     ...SCHEMA_MIGRATIONS[1],
     sourceChecksum: normalizedConversationMembersChecksum(),
+    transactional: true,
     up: applyNormalizedConversationMembers,
   },
   {
     ...SCHEMA_MIGRATIONS[2],
     sourceChecksum: workspaceCleanupJobsChecksum(),
+    transactional: true,
     up: applyWorkspaceCleanupJobs,
   },
   {
     ...SCHEMA_MIGRATIONS[3],
     sourceChecksum: agentRuntimeAssignmentChecksum(),
+    transactional: true,
     up: applyAgentRuntimeAssignment,
   },
 ]
+
+export async function applyPendingMigration(
+  client: import('pg').PoolClient,
+  migration: VersionedMigration,
+): Promise<void> {
+  const started = Date.now()
+  console.log(`[db] applying migration ${migration.version} ${migration.name}`)
+  if (migration.transactional !== false) {
+    await client.query('BEGIN')
+    try {
+      await migration.up(client)
+      await client.query(
+        `INSERT INTO schema_migrations (version, name, checksum, execution_ms)
+         VALUES ($1, $2, $3, $4)`,
+        [migration.version, migration.name, migration.checksum, Date.now() - started],
+      )
+      await client.query('COMMIT')
+    } catch (err) {
+      await client.query('ROLLBACK').catch(() => { /* swallow rollback err */ })
+      throw err
+    }
+  } else {
+    await migration.up(client)
+    await client.query(
+      `INSERT INTO schema_migrations (version, name, checksum, execution_ms)
+       VALUES ($1, $2, $3, $4)`,
+      [migration.version, migration.name, migration.checksum, Date.now() - started],
+    )
+  }
+  console.log(`[db] applied migration ${migration.version} in ${Date.now() - started}ms`)
+}
 
 function validateMigrationDefinitions(): void {
   if (VERSIONED_MIGRATIONS.length !== SCHEMA_MIGRATIONS.length) {
@@ -2445,15 +2481,7 @@ export async function ensureSchema(): Promise<void> {
         const migration = VERSIONED_MIGRATIONS.find((candidate) => candidate.version === metadata.version)
         if (!migration) throw new Error(`migration ${metadata.version} has metadata but no implementation`)
 
-        const started = Date.now()
-        console.log(`[db] applying migration ${migration.version} ${migration.name}`)
-        await migration.up(client)
-        await client.query(
-          `INSERT INTO schema_migrations (version, name, checksum, execution_ms)
-           VALUES ($1, $2, $3, $4)`,
-          [migration.version, migration.name, migration.checksum, Date.now() - started],
-        )
-        console.log(`[db] applied migration ${migration.version} in ${Date.now() - started}ms`)
+        await applyPendingMigration(client, migration)
       }
 
       const finalHistory = validateMigrationHistory(await readHistory())


### PR DESCRIPTION
### Summary

Fixes #186.

In `server/src/db/migrate.ts`, `ensureSchema()` previously executed each migration step in autocommit mode, followed by an independent insertion into `schema_migrations`:
1. `await migration.up(client)` ran DDL queries in autocommit.
2. `await client.query('INSERT INTO schema_migrations ...')` recorded the applied version.

If a migration was interrupted midway (e.g. Kubernetes pod eviction, node reboot, or a statement error), partial DDL was left committed in the database, while `schema_migrations` recorded nothing. On restart, the migrator would attempt to re-run the migration from statement 1 and crash with `relation already exists` or `column already exists`, permanently wedging the database.

### Changes

1. **Transactional Migration Wrapper (`server/src/db/migrate.ts`)**:
   - Extended `VersionedMigration` with optional `transactional?: boolean`.
   - Baseline migration 1 retains `transactional: false` because it relies on `CREATE INDEX CONCURRENTLY` (which PostgreSQL forbids inside a transaction block).
   - Versioned migrations (versions >= 2) execute within an atomic PostgreSQL transaction:
     ```ts
     await client.query('BEGIN')
     try {
       await migration.up(client)
       await client.query('INSERT INTO schema_migrations ...', [...])
       await client.query('COMMIT')
     } catch (err) {
       await client.query('ROLLBACK').catch(() => { /* swallow */ })
       throw err
     }
     ```
   - Extracted `applyPendingMigration` helper so the migration execution contract is modular and unit-testable.

2. **Unit Tests (`server/src/__tests__/migration-transaction-atomicity.test.ts`)**:
   - Tests `BEGIN` -> `migration.up` -> `INSERT INTO schema_migrations` -> `COMMIT` call sequence.
   - Verifies that any failure issues `ROLLBACK`, never commits, and never inserts a ledger record.
   - Verifies that `transactional: false` migrations bypass `BEGIN`/`COMMIT` for concurrent index creation.

3. **Integration Test (`server/src/__integration__/schema-migrations.test.ts`)**:
   - Verifies live PostgreSQL rollback: a simulated failing migration rolls back all table creations and leaves zero rows in `schema_migrations`.

### Verification
- `npm run lint` - 0 errors, 0 warnings
- `npm run typecheck` - passed
- `npm run server:typecheck` - passed
- `npm run guard:big-brain` - passed
- `npm run guard:llm-tracked` - passed
- `npm run guard:engine-registry` - passed
- `node --import tsx --test server/src/__tests__/migration-transaction-atomicity.test.ts` - passed (5/5)
- `OPENAI_API_KEY=mock-key INTEGRATION_DATABASE_URL=... node --import tsx --test server/src/__integration__/schema-migrations.test.ts` - passed (5/5)