### PR TITLE
fix(email-gate): throw on upstream 5xx and network errors for SMTP 4xx tempfail

### DIFF
--- a/workers/email-gate/src/index.test.ts
+++ b/workers/email-gate/src/index.test.ts
@@ -12,7 +12,7 @@
  */
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import {
+import worker, {
   recipientAccepted,
   readArrayHeader,
   toBase64,
@@ -133,3 +133,99 @@ test('attachment byte limits are sensibly ordered', () => {
   assert.ok(MAX_ATTACHMENT_BYTES < MAX_TOTAL_ATTACHMENT_BYTES)
   assert.ok(MAX_TOTAL_ATTACHMENT_BYTES * 1.34 < 25 * 1024 * 1024)
 })
+
+/* ==================== email() handler error handling ======================= */
+
+function createFakeMessage() {
+  const rejected: string[] = []
+  const rawStream = new Response(
+    'From: alice@example.com\r\nTo: agent@cumora.ai\r\nSubject: Test\r\nMessage-ID: <msg-1@example.com>\r\n\r\nHello',
+  ).body!
+  const message = {
+    to: 'agent@cumora.ai',
+    from: 'alice@example.com',
+    raw: rawStream,
+    setReject: (reason: string) => { rejected.push(reason) },
+  } as unknown as Parameters<typeof worker.email>[0]
+  return { message, rejected }
+}
+
+const fakeEnv = {
+  EMAIL_ROOT_DOMAINS: 'cumora.ai',
+  EMAIL_INBOUND_HMAC_SECRET: 'test-secret-value-12345',
+  CUMORA_INBOUND_URL: 'http://upstream.local/inbound',
+} as unknown as Parameters<typeof worker.email>[1]
+
+const fakeCtx = {
+  waitUntil: (promise: Promise<unknown>) => { void promise.catch(() => {}) },
+  passThroughOnException: () => {},
+} as unknown as Parameters<typeof worker.email>[2]
+
+test('email handler throws on upstream network error (triggering SMTP tempfail)', async () => {
+  const { message, rejected } = createFakeMessage()
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = async () => {
+    throw new Error('connection reset by peer')
+  }
+  try {
+    await assert.rejects(
+      () => worker.email(message, fakeEnv, fakeCtx),
+      /Upstream unreachable: connection reset by peer/,
+    )
+    assert.deepEqual(rejected, [], 'setReject must NOT be called on transient network error')
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test('email handler throws on upstream 5xx error (triggering SMTP tempfail)', async () => {
+  const { message, rejected } = createFakeMessage()
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = async () => new Response('Internal Server Error', { status: 502 })
+  try {
+    await assert.rejects(
+      () => worker.email(message, fakeEnv, fakeCtx),
+      /Upstream temporary failure \(502\)/,
+    )
+    assert.deepEqual(rejected, [], 'setReject must NOT be called on 5xx error')
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test('email handler rejects with 550 bounce on 404 no recipient', async () => {
+  const { message, rejected } = createFakeMessage()
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = async () => new Response('Not Found', { status: 404 })
+  try {
+    await worker.email(message, fakeEnv, fakeCtx)
+    assert.deepEqual(rejected, ['No such recipient'])
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test('email handler rejects with 550 bounce on 4xx client errors', async () => {
+  const { message, rejected } = createFakeMessage()
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = async () => new Response('Bad Request', { status: 400 })
+  try {
+    await worker.email(message, fakeEnv, fakeCtx)
+    assert.deepEqual(rejected, ['Upstream 400'])
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test('email handler accepts email on 200 response without setReject', async () => {
+  const { message, rejected } = createFakeMessage()
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = async () => new Response('OK', { status: 200 })
+  try {
+    await worker.email(message, fakeEnv, fakeCtx)
+    assert.deepEqual(rejected, [])
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+

--- a/workers/email-gate/src/index.ts
+++ b/workers/email-gate/src/index.ts
@@ -226,27 +226,27 @@ export default {
         body,
       })
     } catch (e) {
-      message.setReject('Upstream unreachable')
       console.error('[email-gate] POST failed:', e instanceof Error ? e.message : String(e))
-      return
+      // Transient network or connection error — throw to signal a temporary failure
+      // (SMTP 4xx tempfail) in Cloudflare Email Routing so the sending MTA retries delivery later.
+      throw new Error(`Upstream unreachable: ${e instanceof Error ? e.message : String(e)}`)
     }
     if (res.status === 404) {
-      // Server says no agent matches this recipient — bounce.
+      // Server says no agent matches this recipient — permanent rejection (SMTP 550 bounce).
       message.setReject('No such recipient')
       return
     }
+    if (res.status >= 500) {
+      // 5xx upstream failure (server restarting, deploy in progress, database blip).
+      // Cloudflare Email Routing signals a temporary SMTP failure (4xx tempfail) when the
+      // handler throws, allowing sending MTAs (Gmail, Outlook, etc.) to retry delivery later.
+      const errorText = await res.text().catch(() => '')
+      console.error(`[email-gate] upstream ${res.status}: ${errorText.slice(0, 400)}`)
+      throw new Error(`Upstream temporary failure (${res.status}): ${errorText.slice(0, 200)}`)
+    }
     if (!res.ok) {
-      // 4xx other than 404, or 5xx.
-      //
-      // KNOWN GAP: this *should* tempfail on 5xx so the sender's MTA retries,
-      // but setReject() is a PERMANENT rejection — a single upstream blip
-      // loses the mail for good. Cloudflare issues a temporary failure when
-      // the handler throws, so the fix is to throw here on 5xx and keep
-      // setReject for 4xx. Not changed yet because it flips real delivery
-      // behaviour and wants its own test + rollout.
-      //
-      // Reading the body keeps the response from leaking; ctx.waitUntil so
-      // we don't block the email return.
+      // 4xx other than 404 (e.g. 400 bad request, 401 unauthorized HMAC, 413 payload too large).
+      // Permanent client rejection — retrying will not change the outcome.
       ctx.waitUntil(res.text().then((t) => console.error(`[email-gate] upstream ${res.status}: ${t.slice(0, 400)}`)))
       message.setReject(`Upstream ${res.status}`)
       return


### PR DESCRIPTION
### Summary

Fixes #200.

In `workers/email-gate/src/index.ts`, when upstream `cumora-server` was restarting (e.g. during deployments), temporarily overloaded, or unreachable:
1. `fetch(env.CUMORA_INBOUND_URL)` either rejected with a network error or responded with a `5xx` status.
2. The worker called `message.setReject('Upstream unreachable')` or `message.setReject('Upstream 502')`.

In Cloudflare Workers Email Routing, `message.setReject(...)` maps to an SMTP `550 5.7.1` permanent rejection (hard bounce / NDR). Sending MTAs (such as Gmail, Exchange, Outlook) immediately drop the email and send an NDR bounce to the sender, without attempting retry.

### Changes

1. **SMTP 4xx Tempfail on Transient Failures (`workers/email-gate/src/index.ts`)**:
   - In Cloudflare Email Routing, an uncaught rejection in the `email()` handler signals a temporary failure (SMTP 4xx tempfail).
   - Upstream network errors and `5xx` responses now throw an `Error`, causing sending MTAs to queue and retry delivery when the server comes back up.
   - Preserves `message.setReject(...)` strictly for true permanent errors: `404` (no agent recipient resolved) and `4xx` client/payload errors.

2. **Unit Tests (`workers/email-gate/src/index.test.ts`)**:
   - Tests upstream network error throws and does not call `setReject`.
   - Tests upstream `502` throws and does not call `setReject`.
   - Tests `404` calls `setReject('No such recipient')`.
   - Tests `400` calls `setReject('Upstream 400')`.
   - Tests `200` accepts delivery without `setReject`.

### Verification
- `npm run lint` - 0 errors, 0 warnings
- `npm run typecheck` - passed
- `npm run server:typecheck` - passed
- `npm run guard:big-brain` - passed
- `npm run guard:llm-tracked` - passed
- `npm run guard:engine-registry` - passed
- `node --import tsx --test workers/email-gate/src/index.test.ts` - passed (21/21)