### PR TITLE
fix(onboard ui): prevent engine picker content from collapsing

### DIFF
--- a/src/desktop/MeView.tsx
+++ b/src/desktop/MeView.tsx
@@ -1189,20 +1189,24 @@ function ComputersTab() {
             </div>
             {/* biome-ignore lint/security/noDangerouslySetInnerHtml: static copy from the locale bundle, not user input */}
             <div className="text-[11.5px] text-ink-500 mb-2.5 italic font-display" dangerouslySetInnerHTML={{ __html: t('me.engineRequired') }} />
-            <div className="flex items-center gap-2.5 mb-2.5">
-              <span className="text-[12px] text-ink-500">{t('me.engineLabel')}</span>
-              <div className="inline-flex rounded-[9px] p-0.5" style={{ background: 'var(--ink-100)' }}>
-                {RUNNABLE_ENGINES.map((id) => (
-                  <button key={id} type="button" onClick={() => setEngine(id)}
-                    className="px-3 py-1 rounded-[7px] text-[12px] font-semibold transition-colors duration-150"
-                    style={engine === id
-                      ? { background: 'var(--paper)', color: 'var(--ink-900)', boxShadow: '0 1px 2px rgba(0,0,0,0.08)' }
-                      : { color: 'var(--ink-500)' }}>
-                    {engineLabel(id)}
-                  </button>
-                ))}
+            <div className="mb-2.5">
+              <div className="flex items-center gap-2.5 min-w-0">
+                <span className="text-[12px] text-ink-500 shrink-0">{t('me.engineLabel')}</span>
+                <div className="flex-1 min-w-0 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                  <div className="inline-flex min-w-max rounded-[9px] p-0.5" style={{ background: 'var(--ink-100)' }}>
+                    {RUNNABLE_ENGINES.map((id) => (
+                      <button key={id} type="button" onClick={() => setEngine(id)}
+                        className="shrink-0 whitespace-nowrap px-3 py-1 rounded-[7px] text-[12px] font-semibold transition-colors duration-150"
+                        style={engine === id
+                          ? { background: 'var(--paper)', color: 'var(--ink-900)', boxShadow: '0 1px 2px rgba(0,0,0,0.08)' }
+                          : { color: 'var(--ink-500)' }}>
+                        {engineLabel(id)}
+                      </button>
+                    ))}
+                  </div>
+                </div>
               </div>
-              <span className="text-[11px] text-ink-400">{t('me.engineDefaultHint')}</span>
+              <div className="mt-1.5 text-[11px] leading-relaxed text-ink-400">{t('me.engineDefaultHint')}</div>
             </div>
             <label className="flex items-start gap-2 mb-2.5 cursor-pointer select-none">
               <input type="checkbox" checked={asService} onChange={(e) => setAsService(e.target.checked)} className="mt-[3px]" />

--- a/src/desktop/Onboarding.tsx
+++ b/src/desktop/Onboarding.tsx
@@ -85,20 +85,24 @@ export function Onboarding() {
                 <div className="text-[11.5px] text-ink-500 mb-2.5 italic font-display">
                   {t('onboard.tokenHint')}
                 </div>
-                <div className="flex items-center gap-2.5 mb-2.5">
-                  <span className="text-[12px] text-ink-500">{t('onboard.engine')}</span>
-                  <div className="inline-flex rounded-[9px] p-0.5" style={{ background: 'var(--ink-100)' }}>
-                    {RUNNABLE_ENGINES.map((id) => (
-                      <button key={id} type="button" onClick={() => setEngine(id)}
-                        className="px-3 py-1 rounded-[7px] text-[12px] font-semibold transition-colors duration-150"
-                        style={engine === id
-                          ? { background: 'var(--paper)', color: 'var(--ink-900)', boxShadow: '0 1px 2px rgba(0,0,0,0.08)' }
-                          : { color: 'var(--ink-500)' }}>
-                        {engineLabel(id)}
-                      </button>
-                    ))}
+                <div className="mb-2.5">
+                  <div className="flex items-center gap-2.5 min-w-0">
+                    <span className="text-[12px] text-ink-500 shrink-0">{t('onboard.engine')}</span>
+                    <div className="flex-1 min-w-0 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                      <div className="inline-flex min-w-max rounded-[9px] p-0.5" style={{ background: 'var(--ink-100)' }}>
+                        {RUNNABLE_ENGINES.map((id) => (
+                          <button key={id} type="button" onClick={() => setEngine(id)}
+                            className="shrink-0 whitespace-nowrap px-3 py-1 rounded-[7px] text-[12px] font-semibold transition-colors duration-150"
+                            style={engine === id
+                              ? { background: 'var(--paper)', color: 'var(--ink-900)', boxShadow: '0 1px 2px rgba(0,0,0,0.08)' }
+                              : { color: 'var(--ink-500)' }}>
+                            {engineLabel(id)}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
                   </div>
-                  <span className="text-[11px] text-ink-400">{t('onboard.engineHint')}</span>
+                  <div className="mt-1.5 text-[11px] leading-relaxed text-ink-400">{t('onboard.engineHint')}</div>
                 </div>
                 <label className="flex items-start gap-2 mb-2.5 cursor-pointer select-none">
                   <input type="checkbox" checked={asService} onChange={(e) => setAsService(e.target.checked)} className="mt-[3px]" />


### PR DESCRIPTION
## Summary
Closes #223 
Fix the engine picker layout on the computer pairing screens.

The engine hint previously shared a single flex row with all engine options. When the available width was insufficient, the hint collapsed to approximately one Chinese character per line, while engine names such as `Claude Code` and `Grok Build` wrapped onto multiple lines.

## Changes

- Move the engine hint below the engine picker.
- Allow the engine picker to scroll horizontally when its content exceeds the available width.
- Keep engine buttons from shrinking or wrapping.
- Hide the visible scrollbar while preserving horizontal scrolling.
- Apply the same layout fix to:
  - the onboarding screen;
  - the **Me → Computers** pairing section.

## Before

- The help text could collapse into a narrow vertical column.
- Engine names containing spaces could wrap onto multiple lines.
- The layout created excessive vertical whitespace.

## After

- The help text uses the full available row width.
- Engine names remain on a single line.
- Overflowing engine options remain accessible through horizontal scrolling.
- The onboarding and computer settings screens behave consistently.

## Testing

- Ran `npm run typecheck`.
- Ran `git diff --check`.
- Manually verified the onboarding screen in Simplified Chinese.
- Verified that engine options remain horizontally scrollable with the scrollbar hidden.

## Screenshots

| Before | After |
| --- | --- |
| <img width="1358" height="770" alt="image" src="https://github.com/user-attachments/assets/53bb9fcf-9507-4b5a-afc7-9fec0091f3b3" />| <img width="1358" height="770" alt="image" src="https://github.com/user-attachments/assets/70871353-23d9-4c5a-a827-27fa812e8b06" /> |