### PR TITLE
release: v0.16.0

### DIFF
--- a/agent-cli/package.json
+++ b/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cumora",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Run Cumora agents on your own machine with Claude Code, Codex, Antigravity, and other BYOA engines.",
   "license": "MIT",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cumora",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cumora",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1045.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cumora",
   "private": true,
-  "version": "0.15.0",
+  "version": "0.16.0",
   "type": "module",
   "main": "electron/main.cjs",
   "bin": {


### PR DESCRIPTION
Cuts v0.16.0. Six more contributor PRs landed today, on top of the sixteen in v0.15.0.

**Email delivery — two halves of the same bug**
- #216 — the email-gate worker turned an upstream 5xx or network error into `setReject(…)`, which Cloudflare maps to an SMTP **550 permanent bounce**. A single blip while the server was restarting lost the mail for good, with an NDR to the sender. Transient failures now throw, so the sending MTA queues and retries; `setReject` is kept strictly for 404 and 4xx. This closes a `KNOWN GAP` the code had documented in-place, with the tests that comment asked for.

**Storage and tenant hygiene**
- #222 — deleting a document or a workspace left its embedded images orphaned in object storage forever. Keys are now collected inside the deletion transaction, with two-phase protection so an image still referenced by a surviving document is spared until the last referencing document goes.
- #187 — the workspace purge now sweeps `agent_events`, `agent_runs` and `agent_triages` by owner as well as by tenant. These are the tables carrying per-run history and cost, so a row that slips through resurfaces on a billing report rather than in a UI. Follows #207 in v0.15.0.

**Client**
- #215 — an ambiguous create failure pinned its idempotency key forever, so the *next* "+ New Board" replayed the old request and selected the old board. Keys now expire after 60s and are evicted on non-retryable 4xx, while 5xx keeps the key so a genuine retry still de-duplicates.

**BYOA**
- #177 — `POST /computers/pair` enumerated pairable engines by hand and omitted antigravity, so pairing a machine with `--engine antigravity` silently fell back to `claude` and seeded starter agents onto an engine that wasn't installed. Now uses the authoritative `PAIRABLE_ENGINES` set, which fixes it for every future engine too. Also adds antigravity model-catalog discovery via `agy models`.

**UI**
- #224 — the engine picker collapsed to roughly one character per line at narrow widths (#223).

Verified on merged `main` before tagging: lint, `typecheck`, `server:typecheck`, all three guards, and 1219/1219 unit tests.

Note: production is still blocked on migration `0002`, so this release reaches npm and the desktop app but not `api.cumora.ai` until that data condition is cleared.

https://claude.ai/code/session_0126NkM9crkemuV6Ho4LWv59
