### PR TITLE
release: v0.16.1

### DIFF
--- a/agent-cli/package.json
+++ b/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cumora",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Run Cumora agents on your own machine with Claude Code, Codex, Antigravity, and other BYOA engines.",
   "license": "MIT",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cumora",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cumora",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1045.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cumora",
   "private": true,
-  "version": "0.16.0",
+  "version": "0.16.1",
   "type": "module",
   "main": "electron/main.cjs",
   "bin": {


### PR DESCRIPTION
Version bump to 0.16.1.

Rolls up #220 — multi-recipient inbound email delivery and ghost-thread cleanup, including migration `0006_email_messages_company_smtp_id` — which merged just after the v0.16.0 tag was cut.

Verified locally on the merge base: lint, typecheck, server:typecheck, all three guards, 1220/1220 unit tests passing.

https://claude.ai/code/session_0126NkM9crkemuV6Ho4LWv59