### PR TITLE
release: v0.16.2

### DIFF
--- a/agent-cli/package.json
+++ b/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cumora",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Run Cumora agents on your own machine with Claude Code, Codex, Antigravity, and other BYOA engines.",
   "license": "MIT",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cumora",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cumora",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1045.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cumora",
   "private": true,
-  "version": "0.16.1",
+  "version": "0.16.2",
   "type": "module",
   "main": "electron/main.cjs",
   "bin": {


### PR DESCRIPTION
Version bump to 0.16.2.

Rolls up #228, which unblocks the production deploy: migration 0002 has failed closed against live data since 2026-09-03, and this gives it an opt-in, archived repair path (`repair_0002=archive-detach` on the Deploy workflow, default `off`).

Tagging it so the image production rolls to corresponds to a named release rather than a bare SHA.

https://claude.ai/code/session_0126NkM9crkemuV6Ho4LWv59