### PR TITLE
fix(byoa): isolate sessions per engine and retry once fresh on stale resume (#209)

### DIFF
--- a/server/src/__tests__/agents-computer-session-isolation.test.ts
+++ b/server/src/__tests__/agents-computer-session-isolation.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Tests for Issue #209:
+ * BYOA engine hot-switch reuses Codex session IDs in Claude, causing an infinite resume failure loop.
+ *
+ * Verifies:
+ * 1. Session files are strictly scoped per engine: `<agentId>.<engine>.session`
+ * 2. AgentRunner methods loadSessionId/persistSessionId isolate session state across engine switches
+ * 3. AgentRunner.loadSessionId safely purges legacy unscoped session files (`<agentId>.session`)
+ * 4. isStaleResumeError accurately detects unmasked Claude resume errors
+ * 5. AgentRunner.mustResetSession distinguishes stale resumes from fresh runs and context overflows
+ * 6. AgentRunner.runEngineTurn retries once with resumeSessionId: null on stale-resume error and succeeds
+ * 7. AgentRunner.runEngineTurn never retries a turn that reported model usage (preventing duplicate side effects)
+ *
+ * Run: node --import tsx --test server/src/__tests__/agents-computer-session-isolation.test.ts
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import {
+  AgentRunner,
+  type AgentInfo,
+  type DaemonConfig,
+  hasNonZeroUsage,
+  isStaleResumeError,
+  sessionFileFor,
+  SESSIONS_DIR,
+} from '../agents/computer/daemon.js'
+import type { EngineRunResult } from '../agents/computer/engine.js'
+
+function makeConfig(): DaemonConfig {
+  return {
+    serverUrl: 'http://127.0.0.1:8787',
+    computerId: 'test-comp',
+    deviceToken: 'test-device-token',
+  }
+}
+
+function makeAgent(id: string): AgentInfo {
+  return {
+    id,
+    name: `Agent ${id}`,
+    role: 'tester',
+    systemPrompt: 'Standing instructions',
+    engine: 'claude',
+    model: null,
+    fastModel: null,
+  }
+}
+
+function uniqueAgentId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+}
+
+test('sessionFileFor scopes the session path to the specific engine', () => {
+  const agentId = 'atlas-a745'
+  const claudeFile = sessionFileFor(agentId, 'claude')
+  const codexFile = sessionFileFor(agentId, 'codex')
+  const geminiFile = sessionFileFor(agentId, 'gemini')
+
+  assert.equal(claudeFile, join(SESSIONS_DIR, 'atlas-a745.claude.session'))
+  assert.equal(codexFile, join(SESSIONS_DIR, 'atlas-a745.codex.session'))
+  assert.equal(geminiFile, join(SESSIONS_DIR, 'atlas-a745.gemini.session'))
+  assert.notEqual(claudeFile, codexFile)
+  assert.notEqual(claudeFile, geminiFile)
+})
+
+test('switching engines isolates session state on disk via AgentRunner', async () => {
+  const agentId = uniqueAgentId('agent-switch')
+  const cfg = makeConfig()
+  const agent = makeAgent(agentId)
+
+  const claudeRunner = new AgentRunner(cfg, agent, 'claude')
+  const codexRunner = new AgentRunner(cfg, agent, 'codex')
+
+  try {
+    assert.equal(claudeRunner.sessionFile, join(SESSIONS_DIR, `${agentId}.claude.session`))
+    assert.equal(codexRunner.sessionFile, join(SESSIONS_DIR, `${agentId}.codex.session`))
+
+    // Agent starts on Claude and persists a session ID
+    claudeRunner.setSessionId('claude-uuid-1234')
+    await claudeRunner.persistSessionId()
+    assert.equal(claudeRunner.currentSessionId, 'claude-uuid-1234')
+    assert.equal(await readFile(claudeRunner.sessionFile, 'utf8'), 'claude-uuid-1234')
+
+    // Hot-switch to Codex: Codex loads its session file and sees nothing
+    assert.equal(codexRunner.currentSessionId, null)
+    await codexRunner.loadSessionId()
+    assert.equal(codexRunner.currentSessionId, null, 'Codex must start fresh, not inherit Claude session')
+
+    // Codex persists its own thread session
+    codexRunner.setSessionId('codex-thread-5678')
+    await codexRunner.persistSessionId()
+    assert.equal(codexRunner.currentSessionId, 'codex-thread-5678')
+    assert.equal(await readFile(codexRunner.sessionFile, 'utf8'), 'codex-thread-5678')
+
+    // Hot-switch back to Claude: a new Claude runner restores its own session untouched
+    const restoredClaude = new AgentRunner(cfg, agent, 'claude')
+    await restoredClaude.loadSessionId()
+    assert.equal(restoredClaude.currentSessionId, 'claude-uuid-1234', 'Claude restored its own prior session')
+    assert.notEqual(restoredClaude.currentSessionId, codexRunner.currentSessionId)
+  } finally {
+    await rm(claudeRunner.sessionFile, { force: true })
+    await rm(codexRunner.sessionFile, { force: true })
+  }
+})
+
+test('legacy unscoped session files are purged by AgentRunner.loadSessionId', async () => {
+  const agentId = uniqueAgentId('agent-legacy')
+  const cfg = makeConfig()
+  const agent = makeAgent(agentId)
+  const legacyFile = join(SESSIONS_DIR, `${agentId}.session`)
+  const runner = new AgentRunner(cfg, agent, 'claude')
+
+  try {
+    await mkdir(SESSIONS_DIR, { recursive: true })
+    // Legacy unversioned session written before session isolation (could be from any engine)
+    await writeFile(legacyFile, 'unverified-session-id', 'utf8')
+
+    // AgentRunner loads its engine-scoped session:
+    // It must purge the legacy file and start fresh
+    await runner.loadSessionId()
+
+    assert.equal(runner.currentSessionId, null, 'No session adopted from legacy unscoped file')
+
+    let legacyExists = true
+    try {
+      await readFile(legacyFile, 'utf8')
+    } catch {
+      legacyExists = false
+    }
+    assert.equal(legacyExists, false, 'Legacy unversioned session file was purged by loadSessionId')
+  } finally {
+    await rm(legacyFile, { force: true })
+    await rm(runner.sessionFile, { force: true })
+  }
+})
+
+test('isStaleResumeError accurately detects unmasked Claude resume errors', () => {
+  // When ClaudeSession extracts the actual error from ev.error / stderr:
+  const err1 = 'local claude failed (exit 1): engine turn error (error_during_execution): No conversation found with session ID: 01a06f71-2b77-4a3f-9d51-4c0a1b2e3f44'
+  assert.equal(isStaleResumeError(err1), true)
+
+  const err2 = 'local claude failed (exit 1): engine turn error: process exited with code 1\nNo conversation found with session ID: 01a06f71'
+  assert.equal(isStaleResumeError(err2), true)
+
+  const err3 = 'local claude failed (exit 1): engine turn error: Session not found'
+  assert.equal(isStaleResumeError(err3), true)
+
+  // Verify that an unrelated turn error without stale wording is NOT treated as stale
+  const unrelated = 'local claude failed (exit 1): engine turn error (network_error): connection reset by peer'
+  assert.equal(isStaleResumeError(unrelated), false)
+})
+
+test('AgentRunner.mustResetSession behavior on stale resume vs fresh runs and overflows', () => {
+  const agentId = uniqueAgentId('agent-reset-rules')
+  const runner = new AgentRunner(makeConfig(), makeAgent(agentId), 'claude')
+
+  const staleErr = 'local claude failed (exit 1): engine turn error: No conversation found with session ID: 01a06f71'
+  // When hadResume is true, stale resume target must reset
+  assert.equal(runner.mustResetSession(staleErr, true), true)
+  // When hadResume is false, stale resume wording does not reset a fresh session
+  assert.equal(runner.mustResetSession(staleErr, false), false)
+
+  // Context overflow must reset regardless of hadResume
+  const overflowErr = 'local claude failed (exit 1): prompt is too long'
+  assert.equal(runner.mustResetSession(overflowErr, true), true)
+  assert.equal(runner.mustResetSession(overflowErr, false), true)
+
+  // Poisoned transcript must reset regardless of hadResume
+  const poisonedErr = 'local claude failed (exit 1): lone surrogate in input body'
+  assert.equal(runner.mustResetSession(poisonedErr, false), true)
+
+  // Transient / network errors do not reset
+  const normalErr = 'local claude failed (exit 1): engine turn error: connection timeout'
+  assert.equal(runner.mustResetSession(normalErr, true), false)
+  assert.equal(runner.mustResetSession(normalErr, false), false)
+})
+
+test('AgentRunner.runEngineTurn retries once with resumeSessionId: null on stale-resume error and succeeds', async () => {
+  const agentId = uniqueAgentId('agent-stale-retry')
+  const cfg = makeConfig()
+  const agent = makeAgent(agentId)
+  const runner = new AgentRunner(cfg, agent, 'claude')
+
+  try {
+    const staleId = 'stale-uuid-9999'
+    runner.setSessionId(staleId)
+    await runner.persistSessionId()
+    assert.equal(runner.currentSessionId, staleId)
+
+    const attempts: { delta: string; resumeSessionId: string | null; purpose: string }[] = []
+
+    runner.runEngineAttempt = async (delta, resumeSessionId, purpose): Promise<EngineRunResult> => {
+      attempts.push({ delta, resumeSessionId, purpose })
+      if (attempts.length === 1) {
+        // First attempt with stale session fails with missing session error (no usage)
+        return {
+          exitCode: 1,
+          error: `local claude failed (exit 1): engine turn error: No conversation found with session ID: ${resumeSessionId}`,
+        }
+      }
+      // Second attempt (retry fresh with null session) succeeds
+      return {
+        exitCode: 0,
+        sessionId: 'fresh-uuid-1111',
+        usage: { input_tokens: 42, output_tokens: 10 },
+        model: 'claude-3-7-sonnet',
+      }
+    }
+
+    const result = await runner.runEngineTurn('proactive scan', runner.currentSessionId, 'agent-turn')
+
+    // Verifications:
+    // 1. Exactly two attempts were made
+    assert.equal(attempts.length, 2, 'Must retry exactly once on stale resume error')
+    // 2. First attempt passed the stale session ID
+    assert.equal(attempts[0].resumeSessionId, staleId)
+    // 3. Second attempt passed resumeSessionId = null (fresh cold start)
+    assert.equal(attempts[1].resumeSessionId, null)
+    // 4. Stale session on runner was reset during the retry
+    assert.equal(runner.currentSessionId, null)
+    // 5. Final outcome is the successful fresh run
+    assert.equal(result.exitCode, 0)
+    assert.equal(result.sessionId, 'fresh-uuid-1111')
+    assert.deepEqual(result.usage, { input_tokens: 42, output_tokens: 10 })
+  } finally {
+    await rm(runner.sessionFile, { force: true })
+  }
+})
+
+test('AgentRunner.runEngineTurn never retries a turn that reported usage (e.g. context overflow)', async () => {
+  const agentId = uniqueAgentId('agent-no-retry-usage')
+  const cfg = makeConfig()
+  const agent = makeAgent(agentId)
+  const runner = new AgentRunner(cfg, agent, 'claude')
+
+  try {
+    const resumeId = 'resumed-session-3333'
+    runner.setSessionId(resumeId)
+    await runner.persistSessionId()
+
+    const attempts: { delta: string; resumeSessionId: string | null }[] = []
+
+    runner.runEngineAttempt = async (delta, resumeSessionId): Promise<EngineRunResult> => {
+      attempts.push({ delta, resumeSessionId })
+      // Failure that occurred mid-turn after model execution (has usage)
+      return {
+        exitCode: 1,
+        error: 'local claude failed (exit 1): prompt is too long',
+        usage: { input_tokens: 200000, output_tokens: 150 },
+      }
+    }
+
+    const result = await runner.runEngineTurn('run task', runner.currentSessionId, 'agent-turn')
+
+    // Invariant: Because usage > 0, the turn must NEVER be retried in-turn!
+    // Retrying would duplicate hops 1..N-1 side effects (posts, edits) and double-charge tokens.
+    assert.equal(attempts.length, 1, 'Turn with reported usage must NOT be retried')
+    assert.equal(result.exitCode, 1)
+    assert.match(result.error ?? '', /prompt is too long/)
+    assert.deepEqual(result.usage, { input_tokens: 200000, output_tokens: 150 })
+  } finally {
+    await rm(runner.sessionFile, { force: true })
+  }
+})
+
+test('AgentRunner.runEngineTurn does not retry non-stale errors or errors with usage even if stale text appears', async () => {
+  const agentId = uniqueAgentId('agent-edge-safety')
+  const runner = new AgentRunner(makeConfig(), makeAgent(agentId), 'claude')
+
+  // Case A: Unrelated error without usage (e.g. network timeout)
+  let attempts = 0
+  runner.runEngineAttempt = async (): Promise<EngineRunResult> => {
+    attempts++
+    return {
+      exitCode: 1,
+      error: 'local claude failed (exit 1): connection timed out',
+    }
+  }
+  const resA = await runner.runEngineTurn('test delta', 'some-session', 'agent-turn')
+  assert.equal(attempts, 1, 'Network timeout must not be retried')
+  assert.equal(resA.exitCode, 1)
+
+  // Case B: Stale resume text appears, BUT usage is reported (model did execute work)
+  attempts = 0
+  runner.runEngineAttempt = async (): Promise<EngineRunResult> => {
+    attempts++
+    return {
+      exitCode: 1,
+      error: 'local claude failed (exit 1): No conversation found with session ID: some-session',
+      usage: { input_tokens: 100, output_tokens: 10 },
+    }
+  }
+  const resB = await runner.runEngineTurn('test delta', 'some-session', 'agent-turn')
+  assert.equal(attempts, 1, 'Error with usage must not be retried even if text matches stale resume')
+  assert.equal(resB.exitCode, 1)
+})
+
+test('hasNonZeroUsage distinguishes zero tokens from actual model execution', () => {
+  assert.equal(hasNonZeroUsage(undefined), false)
+  assert.equal(hasNonZeroUsage({}), false)
+  assert.equal(hasNonZeroUsage({ input_tokens: 0, output_tokens: 0 }), false)
+  assert.equal(hasNonZeroUsage({ input_tokens: 0, output_tokens: undefined }), false)
+  assert.equal(hasNonZeroUsage({ input_tokens: 10, output_tokens: 0 }), true)
+  assert.equal(hasNonZeroUsage({ input_tokens: 0, output_tokens: 5 }), true)
+  assert.equal(hasNonZeroUsage({ input_tokens: 12, output_tokens: 34 }), true)
+})
+
+test('Claude 2.1.207 empirical error shape: errors array and zero usage retries successfully', async () => {
+  const agentId = uniqueAgentId('agent-claude-2-1-207')
+  const cfg = makeConfig()
+  const agent = makeAgent(agentId)
+  const runner = new AgentRunner(cfg, agent, 'claude')
+
+  try {
+    const staleId = 'stale-claude-session-207'
+    runner.setSessionId(staleId)
+    await runner.persistSessionId()
+
+    const attempts: { delta: string; resumeSessionId: string | null; purpose: string }[] = []
+
+    runner.runEngineAttempt = async (delta, resumeSessionId, purpose): Promise<EngineRunResult> => {
+      attempts.push({ delta, resumeSessionId, purpose })
+      if (attempts.length === 1) {
+        // Exact shape captured from Claude 2.1.207:
+        // Result is undefined, error extracted from errors array, usage is 0 tokens
+        return {
+          exitCode: 1,
+          error: `engine turn error (error_during_execution): No conversation found with session ID: ${resumeSessionId}`,
+          usage: { input_tokens: 0, output_tokens: 0 },
+        }
+      }
+      return {
+        exitCode: 0,
+        sessionId: 'fresh-claude-session-207',
+        usage: { input_tokens: 150, output_tokens: 30 },
+        model: 'claude-3-7-sonnet',
+      }
+    }
+
+    const result = await runner.runEngineTurn('audit code', runner.currentSessionId, 'agent-turn')
+
+    assert.equal(attempts.length, 2, 'Must retry turn fresh when zero usage is reported')
+    assert.equal(attempts[0].resumeSessionId, staleId)
+    assert.equal(attempts[1].resumeSessionId, null)
+    assert.equal(result.exitCode, 0)
+    assert.equal(result.sessionId, 'fresh-claude-session-207')
+    assert.deepEqual(result.usage, { input_tokens: 150, output_tokens: 30 })
+  } finally {
+    await rm(runner.sessionFile, { force: true })
+  }
+})
+

--- a/server/src/__tests__/agents-computer-session-reset.test.ts
+++ b/server/src/__tests__/agents-computer-session-reset.test.ts
@@ -58,6 +58,11 @@ test('Claude: "No conversation found with session ID" IS a stale resume target',
   assert.equal(isStaleResumeError(err), true)
 })
 
+test('Claude: engine turn error with "No conversation found with session ID" IS a stale resume target', () => {
+  const err = 'local claude failed (exit 1): engine turn error (error_during_execution): No conversation found with session ID: 6f1c2e30-2b77-4a3f-9d51-4c0a1b2e3f44'
+  assert.equal(isStaleResumeError(err), true)
+})
+
 test('a stale resume target reported inside a FAILED result event still resets', () => {
   // Same verdict whether the engine puts it on stderr or in an error event.
   const err = 'local claude failed (exit 1): process exited with code 1\n' +

--- a/server/src/agents/computer/daemon.ts
+++ b/server/src/agents/computer/daemon.ts
@@ -48,7 +48,7 @@ import {
 import { SKYPE_EMOTICONS_GUIDE } from '../skype-emoticons.js'
 import { finalizeTriage, isRateLimited, parseTriage } from '../triage-core.js'
 import { type ActionSurface, actionSurfaceFor, actionSurfaceText, calendarExampleText, postingMechanicsText } from './prompt-surface.js'
-import { allowUnsandboxedByoa, detectEnginesWithStatus, ENGINE_IDS, type DetectedEngineSnapshot, type EngineHopReport, type EngineId, type EngineRunResult, type EngineSession, type EngineUsage, enrichDetectedEngines, evaluateRunnableEngines, getAdapter, runEngineDoctor, type RunnableEngineEvaluation, snapshotDetectedEngines } from './engine.js'
+import { allowUnsandboxedByoa, detectEnginesWithStatus, ENGINE_IDS, type DetectedEngineSnapshot, type EngineAdapter, type EngineHopReport, type EngineId, type EngineRunResult, type EngineSession, type EngineUsage, enrichDetectedEngines, evaluateRunnableEngines, getAdapter, runEngineDoctor, type RunnableEngineEvaluation, snapshotDetectedEngines } from './engine.js'
 
 export { conversationHeader }
 
@@ -86,7 +86,11 @@ const AGENTS_ROOT = join(CONFIG_DIR, 'agents')
 // own cwd can't clobber it). Survives a daemon restart so the next wake can
 // `--resume` the SAME engine session — recovering the in-turn context an
 // interrupted long task was building, instead of starting cold.
-const SESSIONS_DIR = join(CONFIG_DIR, 'sessions')
+export const SESSIONS_DIR = join(CONFIG_DIR, 'sessions')
+
+export function sessionFileFor(agentId: string, engine: EngineId): string {
+  return join(SESSIONS_DIR, `${agentId}.${engine}.session`)
+}
 // Bounded grace on a forced shutdown (SIGTERM/SIGINT): let an in-flight turn try
 // to finish before we kill the engine child. The OS supervisor SIGKILLs not long
 // after SIGTERM, so this is best-effort for SHORT turns; long tasks rely on the
@@ -415,13 +419,13 @@ function versionGt(a: string, b: string): boolean {
   return false
 }
 
-interface DaemonConfig {
+export interface DaemonConfig {
   serverUrl: string
   computerId: string
   deviceToken: string
 }
 
-interface AgentInfo {
+export interface AgentInfo {
   id: string
   name: string
   role: string | null
@@ -746,6 +750,15 @@ export function engineDiagnosticProse(err: string): string {
 /** True when an engine error really says the `--resume` target is gone. */
 export function isStaleResumeError(err: string): boolean {
   return STALE_RESUME_RE.test(engineDiagnosticProse(err))
+}
+
+/** True when usage indicates that the model actually ran and consumed tokens.
+ *  Engines rejecting a bogus resume target before running report zero usage,
+ *  which makes an in-turn retry safe; turns that produced non-zero usage must
+ *  not be retried in-turn to avoid duplicate side effects and double billing. */
+export function hasNonZeroUsage(u?: EngineUsage): boolean {
+  if (!u) return false
+  return (u.input_tokens ?? 0) > 0 || (u.output_tokens ?? 0) > 0
 }
 
 export function authFailureHint(engine: EngineId, detail: string): string {
@@ -1568,7 +1581,7 @@ export function resolveTriageModel(
   return resolveEngineFastModel(configured, engineOverride)?.trim() || computerDefault?.trim() || undefined
 }
 
-class AgentRunner {
+export class AgentRunner {
   /** Aborted once in stop(). Handed to every one-shot `adapter.run(...)` so the
    *  engine child dies with its runner, the way the persistent session already
    *  does. Without it those children were orphaned: they keep the `cumora` IPC
@@ -1581,7 +1594,7 @@ class AgentRunner {
   private binDir: string
   private trustedCliDir: string
   private ipcDir: string
-  private sessionFile: string
+  readonly sessionFile: string
   private busy = false
   private pendingRerun = false
   // Triage-trouble backoff: when the small-brain triage is rate-limited OR
@@ -1646,7 +1659,7 @@ class AgentRunner {
   private lastGroupSteeredMsgId: string | null = null
   private lastGroupSteerAt = 0
   private pollTimer: ReturnType<typeof setInterval> | undefined
-  private readonly adapter
+  private readonly adapter: EngineAdapter
   /** Privileged local broker: the engine sees only its IPC directory, while the
    *  daemon keeps the short-lived runtime JWT in memory. */
   private cliBroker: RuntimeCliBroker | null = null
@@ -1663,6 +1676,7 @@ class AgentRunner {
     private readonly cfg: DaemonConfig,
     private readonly agent: AgentInfo,
     engine: EngineId,
+    adapter?: EngineAdapter,
   ) {
     this.home = join(AGENTS_ROOT, agent.id)
     this.binDir = join(this.home, 'bin')
@@ -1673,8 +1687,8 @@ class AgentRunner {
     // granted only the two leaf request/response directories; Claude reaches
     // them through the fixed MCP bridge, not a model-controlled shell.
     this.ipcDir = join(CONFIG_DIR, '.runtime-cli-ipc', this.agent.id)
-    this.sessionFile = join(SESSIONS_DIR, `${agent.id}.session`)
-    this.adapter = getAdapter(engine)
+    this.sessionFile = sessionFileFor(agent.id, engine)
+    this.adapter = adapter ?? getAdapter(engine)
   }
 
   private get reporter(): HopReporter {
@@ -1723,9 +1737,11 @@ class AgentRunner {
    *  restarting/auto-updating mid-turn.) */
   get isBusy(): boolean { return this.busy }
 
+  get currentSessionId(): string | null { return this.sessionId }
+
   /** Update the engine session id AND persist it to disk, so a daemon restart can
    *  `--resume` the same session and recover the interrupted turn's context. */
-  private setSessionId(id: string | null): void {
+  setSessionId(id: string | null): void {
     if (id === this.sessionId) return
     this.sessionId = id
     void this.persistSessionId()
@@ -1743,7 +1759,7 @@ class AgentRunner {
    *      only when the engine SAYS SO: a mid-turn crash (OOM, sleep, provider
    *      hangup) leaves a resumable session, so it must NOT reset — that would
    *      discard the context the interrupted turn was building. */
-  private mustResetSession(err: string, hadResume: boolean): boolean {
+  mustResetSession(err: string, hadResume: boolean): boolean {
     if (this.isContextOverflow(err)) return true
     if (this.isPoisonedTranscript(err)) return true
     if (hadResume && isStaleResumeError(err)) return true
@@ -1767,7 +1783,7 @@ class AgentRunner {
 
   /** Drop the session id AND tear down any persistent engine process so the next
    *  wake spawns a genuinely clean session (no --resume of the bad context). */
-  private async resetEngineSession(reason: string): Promise<void> {
+  async resetEngineSession(reason: string): Promise<void> {
     console.warn(`[computer] ${this.agent.id} ${reason} — starting a FRESH engine session next wake`)
     this.setSessionId(null)
     await this.engineSession?.stop({ force: true })
@@ -1780,7 +1796,7 @@ class AgentRunner {
     finally { if (this.activeEngineRun === run) this.activeEngineRun = null }
   }
 
-  private async persistSessionId(): Promise<void> {
+  async persistSessionId(): Promise<void> {
     try {
       if (this.sessionId) {
         await mkdir(SESSIONS_DIR, { recursive: true })
@@ -1791,12 +1807,20 @@ class AgentRunner {
     } catch { /* best-effort — a lost session id just means a cold next wake */ }
   }
 
-  private async loadSessionId(): Promise<void> {
+  async loadSessionId(): Promise<void> {
+    // Versions before session isolation stored an unscoped `<agentId>.session`.
+    // Do not migrate legacy sessions when engine ownership cannot be verified;
+    // remove the stale file so it cannot poison any engine path.
+    try {
+      const legacy = join(SESSIONS_DIR, `${this.agent.id}.session`)
+      await rm(legacy, { force: true })
+    } catch { /* best-effort */ }
+
     try {
       const s = (await readFile(this.sessionFile, 'utf8')).trim()
       if (s) {
         this.sessionId = s
-        console.log(`[computer] ${this.agent.id} restored engine session ${s.slice(0, 8)} from disk — will --resume (continuity across restart)`)
+        console.log(`[computer] ${this.agent.id} restored ${this.adapter.id} engine session ${s.slice(0, 8)} from disk — will --resume (continuity across restart)`)
       }
     } catch { /* no prior session on disk — start cold */ }
   }
@@ -1965,7 +1989,7 @@ class AgentRunner {
    *  fallback, or custom args) — the caller then uses one-shot run(). If the
    *  prior process has died it respawns, resuming this.sessionId so context
    *  carries across the restart. */
-  private ensureEngineSession(): EngineSession | null {
+  private ensureEngineSession(resumeSessionId: string | null = this.sessionId): EngineSession | null {
     if (!this.adapter.startSession) return null
     if (this.persistentUnusable) return null
     if (this.engineSession?.alive) return this.engineSession
@@ -1974,7 +1998,7 @@ class AgentRunner {
       env: this.engineEnv(),
       model: this.engineModel(),
       fastModel: this.engineFastModel(),
-      resumeSessionId: this.sessionId,
+      resumeSessionId,
       standingPrompt: this.standingPrompt(),
       onLog: (line) => this.logEngineLine(line),
       // Trajectory hook — every assistant hop (Claude) / turn-completed (Codex)
@@ -1984,9 +2008,102 @@ class AgentRunner {
       onHopUsage: (r) => this.onEngineHop(r, 'agent-turn'),
     })
     if (this.engineSession) {
-      console.log(`[computer] ${this.agent.id} engine session ${this.sessionId ? `respawned (resume ${this.sessionId.slice(0, 8)})` : 'spawned fresh'} — persistent, no per-wake cold start`)
+      console.log(`[computer] ${this.agent.id} engine session ${resumeSessionId ? `respawned (resume ${resumeSessionId.slice(0, 8)})` : 'spawned fresh'} — persistent, no per-wake cold start`)
     }
     return this.engineSession
+  }
+
+  /** Execute a single engine attempt for chat or agenda. Session capture,
+   *  hop tracking, and the persistent-to-one-shot fallback live here. */
+  async runEngineAttempt(
+    delta: string,
+    resumeSessionId: string | null,
+    purpose: PendingHop['purpose'],
+  ): Promise<EngineRunResult> {
+    const session = this.ensureEngineSession(resumeSessionId)
+    const prompt = this.turnPrompt(session, delta)
+    let result: EngineRunResult
+    if (session) {
+      // PERSISTENT path: feed this turn into the long-lived process — no cold
+      // start (the first turn paid it; turns 2..N reuse the booted process).
+      // Persist the session id EARLY (the engine reports it ~1-2s in) so an
+      // interrupt mid-turn — even on a brand-new session — still leaves a
+      // resumable id on disk, not just when the turn finishes.
+      const capture = setInterval(() => { if (session.sessionId) this.setSessionId(session.sessionId) }, 2000)
+      capture.unref?.()
+      try {
+        result = await this.trackEngineRun(session.send(prompt))
+      } finally {
+        clearInterval(capture)
+      }
+      if (session.sessionId) this.setSessionId(session.sessionId)
+      // Process died during/after the turn → drop it so the next wake respawns
+      // (with --resume this.sessionId to carry context across the restart).
+      if (!session.alive) this.engineSession = null
+      // A persistent process that dies without producing a turn is not a
+      // transient hiccup, it is this machine telling us the persistent
+      // transport does not work here. Retry THIS turn one-shot and stay
+      // there: the alternative is failing every wake forever, which is the
+      // shape the codex sandbox outage took.
+      // No usage means the model never ran — the process died in the
+      // transport, not mid-answer, so re-running the turn cannot duplicate
+      // work or double-charge.
+      //
+      // BUT a stale resume target is NOT a transport failure — the requested
+      // session is simply missing. Do not permanently poison persistentUnusable
+      // when the failure is a stale resume target.
+      if (result.error && !result.usage && !session.alive) {
+        if (!isStaleResumeError(result.error)) {
+          this.persistentUnusable = true
+          this.engineSession = null
+          this.logEngineLine(`[engine] persistent session failed to produce a turn (${result.error.slice(0, 160)}) — falling back to one-shot for the rest of this process`)
+          result = await this.trackEngineRun(this.adapter.run({
+            home: this.home,
+            prompt: this.turnPrompt(null, delta),
+            env: this.engineEnv(),
+            model: this.engineModel(),
+            fastModel: this.engineFastModel(),
+            resumeSessionId,
+            onLog: (line) => this.logEngineLine(line),
+            onHopUsage: (r) => this.onEngineHop(r, purpose),
+            signal: this.teardown.signal,
+          }))
+          if (result.sessionId) this.setSessionId(result.sessionId)
+        }
+      }
+    } else {
+      // One-shot path: Cursor/OpenCode, Codex fallback, or a custom args override.
+      result = await this.trackEngineRun(this.adapter.run({
+        home: this.home,
+        prompt,
+        env: this.engineEnv(),
+        model: this.engineModel(),
+        fastModel: this.engineFastModel(),
+        resumeSessionId,
+        onLog: (line) => this.logEngineLine(line),
+        onHopUsage: (r) => this.onEngineHop(r, purpose),
+        signal: this.teardown.signal,
+      }))
+      if (result.sessionId) this.setSessionId(result.sessionId)
+    }
+    return result
+  }
+
+  /** Execute an engine turn with single-attempt retry on stale resume target.
+   *  Scoped strictly to stale resumes where no model usage occurred, preventing
+   *  duplicate side effects or double billing. */
+  async runEngineTurn(
+    delta: string,
+    resumeSessionId: string | null,
+    purpose: PendingHop['purpose'],
+  ): Promise<EngineRunResult> {
+    let result = await this.runEngineAttempt(delta, resumeSessionId, purpose)
+    if (result.error && !hasNonZeroUsage(result.usage) && resumeSessionId && isStaleResumeError(result.error)) {
+      console.log(`[computer] ${this.agent.id} resume target is stale — resetting and retrying turn fresh`)
+      await this.resetEngineSession('stale resume target')
+      result = await this.runEngineAttempt(delta, null, purpose)
+    }
+    return result
   }
 
   /** Enter, or clear, this agent's engine pause for a finished turn. Both turn
@@ -2524,24 +2641,8 @@ class AgentRunner {
         runtimeGet<{ roster: string }>(this.cfg.serverUrl, '/roster', token).then((r) => r?.roster ?? '').catch(() => ''),
       ])
       const resumeSessionId = this.sessionId
-      const session = this.ensureEngineSession()
-      const prompt = this.turnPrompt(session, this.agendaDelta(ag.brief, memoryDigest, roster))
-      const engineRun = session
-        ? session.send(prompt)
-        : this.adapter.run({
-          home: this.home, prompt, env: this.engineEnv(),
-          model: this.engineModel(), fastModel: this.engineFastModel(),
-          resumeSessionId: this.sessionId, onLog: (line) => this.logEngineLine(line),
-          // Same trajectory hook as the persistent-session path so the
-          // one-shot fallback (or codex `exec` path) also lands hops in the
-          // universal ledger.
-          onHopUsage: (r) => this.onEngineHop(r, 'agent-turn'),
-          signal: this.teardown.signal,
-        })
-      const result = await this.trackEngineRun(engineRun)
-      if (session?.sessionId) this.setSessionId(session.sessionId)
-      if (session && !session.alive) this.engineSession = null
-      if (!session && result.sessionId) this.setSessionId(result.sessionId)
+      const delta = this.agendaDelta(ag.brief, memoryDigest, roster)
+      const result = await this.runEngineTurn(delta, resumeSessionId, 'agent-turn')
       exitCode = result.exitCode
       turnUsage = result.usage
       turnModel = result.model
@@ -2922,78 +3023,14 @@ class AgentRunner {
               .then((r) => r?.roster ?? '').catch(() => ''),
           ])
           const resumeSessionId = this.sessionId
-          let result: EngineRunResult
-          const session = this.ensureEngineSession()
-          // Standing scaffold rides the session's system-prompt file; send only the
-          // small per-turn delta when it does (else inline it — see turnPrompt).
           const delta = turnBackgroundBrief
             ? this.manualBriefDelta(turnBackgroundBrief, memoryDigest, digest, roster)
             : this.chatDelta(memoryDigest, triageNote, digest, roster)
-          const prompt = this.turnPrompt(session, delta)
-          if (session) {
-            // PERSISTENT path: feed this turn into the long-lived process — no cold
-            // start (the first turn paid it; turns 2..N reuse the booted process).
-            // Persist the session id EARLY (the engine reports it ~1-2s in) so an
-            // interrupt mid-turn — even on a brand-new session — still leaves a
-            // resumable id on disk, not just when the turn finishes.
-            const capture = setInterval(() => { if (session.sessionId) this.setSessionId(session.sessionId) }, 2000)
-            capture.unref?.()
-            try {
-              result = await this.trackEngineRun(session.send(prompt))
-            } finally {
-              clearInterval(capture)
-            }
-            if (session.sessionId) this.setSessionId(session.sessionId)
-            // Process died during/after the turn → drop it so the next wake respawns
-            // (with --resume this.sessionId to carry context across the restart).
-            if (!session.alive) this.engineSession = null
-            // A persistent process that dies without producing a turn is not a
-            // transient hiccup, it is this machine telling us the persistent
-            // transport does not work here. Retry THIS turn one-shot and stay
-            // there: the alternative is failing every wake forever, which is the
-            // shape the codex sandbox outage took.
-            // No usage means the model never ran — the process died in the
-            // transport, not mid-answer, so re-running the turn cannot duplicate
-            // work or double-charge.
-            if (result.error && !result.usage && !session.alive) {
-              this.persistentUnusable = true
-              this.engineSession = null
-              this.logEngineLine(`[engine] persistent session failed to produce a turn (${result.error.slice(0, 160)}) — falling back to one-shot for the rest of this process`)
-              result = await this.trackEngineRun(this.adapter.run({
-                home: this.home,
-                prompt: this.turnPrompt(null, delta),
-                env: this.engineEnv(),
-                model: this.engineModel(),
-                fastModel: this.engineFastModel(),
-                resumeSessionId,
-                onLog: (line) => this.logEngineLine(line),
-                onHopUsage: (r) => this.onEngineHop(r, 'agent-turn'),
-                signal: this.teardown.signal,
-              }))
-              if (result.sessionId) this.setSessionId(result.sessionId)
-            }
-          } else {
-            // One-shot path: Cursor/OpenCode, Codex fallback, or a custom args override.
-            result = await this.trackEngineRun(this.adapter.run({
-              home: this.home,
-              prompt,
-              env: this.engineEnv(),
-              model: this.engineModel(),
-              fastModel: this.engineFastModel(),
-              resumeSessionId,
-              onLog: (line) => this.logEngineLine(line),
-              onHopUsage: (r) => this.onEngineHop(r, 'agent-turn'),
-              signal: this.teardown.signal,
-            }))
-            if (result.sessionId) this.setSessionId(result.sessionId)
-          }
+          const result = await this.runEngineTurn(delta, resumeSessionId, 'agent-turn')
           exitCode = result.exitCode
           turnUsage = result.usage
           turnModel = result.model
           if (result.error) engineError = this.visibleEngineError(exitCode, result.error)
-          // A stale resume OR a context-window overflow means this session can't
-          // be carried forward — drop it AND tear down any persistent process so
-          // the next wake starts clean (otherwise --resume re-overflows forever).
           if (engineError && this.mustResetSession(engineError, !!resumeSessionId)) {
             await this.resetEngineSession(this.resetReason(engineError))
           }

--- a/server/src/agents/computer/engine.ts
+++ b/server/src/agents/computer/engine.ts
@@ -1230,7 +1230,7 @@ class ClaudeSession implements EngineSession {
       if (this.pending) pushTail(this.pending.stdout, line)
       this.onLog(line)
       if (!line.startsWith('{')) continue
-      let ev: { type?: unknown; session_id?: unknown; is_error?: unknown; subtype?: unknown; status?: unknown; result?: unknown; usage?: EngineUsage; model?: unknown; message?: { model?: unknown; usage?: EngineUsage; content?: unknown } }
+      let ev: { type?: unknown; session_id?: unknown; is_error?: unknown; subtype?: unknown; status?: unknown; result?: unknown; usage?: EngineUsage; model?: unknown; message?: { model?: unknown; usage?: EngineUsage; content?: unknown }; error?: unknown }
       try { ev = JSON.parse(line) } catch { continue }
       if (typeof ev.session_id === 'string' && ev.session_id) this.sid = ev.session_id
       // Capture the real model id (assistant events carry message.model) for pricing.
@@ -1273,11 +1273,38 @@ class ClaudeSession implements EngineSession {
         this.hopIndex = 0        // reset the per-turn hop counter
         this.steerQueue = [] // turn ending — any unflushed steer falls to the daemon's coalesced rerun
         const isErr = ev.is_error === true
+        let error: string | undefined
+        if (isErr) {
+          let detail =
+            (typeof ev.result === 'string' && ev.result.trim()) ||
+            (Array.isArray((ev as { errors?: unknown[] }).errors) &&
+              ((ev as { errors: unknown[] }).errors.filter(Boolean).map(String).join('\n').trim())) ||
+            (typeof ev.error === 'string' && ev.error.trim()) ||
+            (typeof (ev.error as { message?: unknown })?.message === 'string' && ((ev.error as { message: string }).message.trim())) ||
+            ''
+          if (!detail || detail === 'see log') {
+            const stderrLines = (this.pending?.stderr.length ? this.pending.stderr : this.stderrTail)
+              .filter(Boolean)
+              .slice(-30)
+              .join('\n')
+              .trim()
+            if (stderrLines) {
+              detail = stderrLines
+            } else {
+              const stdoutLines = (this.pending?.stdout.length ? this.pending.stdout : this.stdoutTail)
+                .filter((l) => !l.startsWith('{'))
+                .slice(-30)
+                .join('\n')
+                .trim()
+              if (stdoutLines) detail = stdoutLines
+            }
+          }
+          if (!detail) detail = 'see log'
+          error = `engine turn error${typeof ev.subtype === 'string' ? ` (${ev.subtype})` : ''}: ${detail.slice(0, MAX_FAILURE_CHARS)}`
+        }
         this.settle({
           exitCode: isErr ? 1 : 0,
-          error: isErr
-            ? `engine turn error${typeof ev.subtype === 'string' ? ` (${ev.subtype})` : ''}: ${typeof ev.result === 'string' ? ev.result.slice(0, MAX_FAILURE_CHARS) : 'see log'}`
-            : undefined,
+          error,
           sessionId: this.sid,
           usage: ev.usage && typeof ev.usage === 'object' ? ev.usage : undefined,
           model: this.curModel,


### PR DESCRIPTION
Closes #209

### Background & Root Cause

In Cumora BYOA, session IDs were stored in a single unversioned file per agent (`~/.cumora/sessions/<agentId>.session`).

When local engine availability drifted (e.g. transient version probe failure causing fallback from Claude Code to Codex, and subsequently recovering back to Claude):
1. The agent runner on Claude restored the session ID created by Codex;
2. `claude --resume <codex-session-id>` was invoked;
3. Claude rejected the ID with `No conversation found with session ID`;
4. `ClaudeSession.onStdout` masked the error event as `engine turn error (...): see log` because `ev.result` was not a string, losing the underlying failure diagnostic;
5. As a result, `isStaleResumeError()` failed to match `'see log'`, the dead session ID was never cleared from disk, and `persistentUnusable` was permanently set to `true`;
6. The daemon was trapped in an infinite retry failure loop across wakes.

### Changes

1. **Engine Session File Isolation**:
   - Scoped session files to each engine: `sessionFileFor(agentId, engine)` maps to `~/.cumora/sessions/<agentId>.<engine>.session`.
   - Different engines maintain independent continuity without ever cross-resuming.
   - On startup, legacy unversioned `<agentId>.session` files are safely purged rather than adopted into unverified engines.

2. **Error Preservation in `ClaudeSession`**:
   - In `ClaudeSession.onStdout`, when an error `result` event is processed, error details are extracted from `ev.result`, `ev.error`, `ev.error.message`, and the tail of `stderr` / unparsed `stdout` lines before falling back to `'see log'`.
   - This ensures `No conversation found with session ID` is preserved for `isStaleResumeError()`.

3. **Stale Resume Single Fresh Retry**:
   - Extracted `runEngineAttempt` shared by chat and agenda turns.
   - Stale resume errors no longer poison `persistentUnusable`.
   - When an engine explicitly reports a stale resume target, the stale session file is cleared and the turn is retried **once fresh** (`resumeSessionId: null`), succeeding in the same wake.

### Verification

- New unit tests in `server/src/__tests__/agents-computer-session-isolation.test.ts`:
  - `sessionFileFor` engine scoping;
  - Multi-engine disk state isolation across hot-switches;
  - Legacy session purge;
  - Detection of unmasked Claude resume errors;
  - Single-retry fresh recovery behavior.
- Existing tests:
  - `agents-computer-session-reset.test.ts`: 15/15 passed
  - All 32 `agents-computer-*.test.ts`: 249 passed, 0 failed
- Quality checks:
  - `npm run lint` (Biome): clean, 0 errors
  - `npm run typecheck` & `npm run server:typecheck`: 0 errors
  - Source guards (`guard:big-brain`, `guard:llm-tracked`, `guard:engine-registry`): all passed
