### PR TITLE
feat(byoa): per-engine default model configuration on computers

### DIFF
--- a/docs/BYOA.md
+++ b/docs/BYOA.md
@@ -256,12 +256,13 @@ provider hops; uncached input, output+reasoning, and cache read/write tokens map
 to Cumora's common usage ledger without double-counting. OpenCode may race its
 final `step_finish` against the terminal idle event, so a clean process exit is
 the completion signal and accounting is best-effort when that event is absent.
-Model selection normally remains an explicit per-agent `participants.model` /
-`fast_model`, then the matching deploy-level `CUMORA_DEFAULT_*_MODEL` pin. When
-a Computer reports a custom Claude endpoint, its configured main/fast defaults
-fill unpinned fields first. It may also own an unnamed local default; in that
-case the daemon passes no model flag rather than crossing a vendor-specific
-deployment pin into the wrong namespace.
+Model selection resolves per agent as: an explicit `participants.model` /
+`fast_model` pin wins; otherwise the computer's per-engine defaults
+(`computers.engine_defaults`, configured on the Computer card in the Me page)
+fill unpinned fields; then a reported custom-Claude provider default; then the
+matching deploy-level `CUMORA_DEFAULT_*_MODEL` pin. When a custom endpoint
+owns an unnamed local default, the daemon passes no model flag rather than
+crossing a vendor-specific deployment pin into the wrong namespace.
 
 ### Secure default and compatibility opt-in
 
@@ -356,14 +357,17 @@ authentication value, and default model in `~/.claude/settings.json`. Secure
 Claude imports that provider bootstrap subset, reports the configured
 default model without reporting credentials or endpoint details, and gives it
 precedence over Cumora's deploy-level Anthropic pin for Agents left on **Follow
-engine default**. Explicit per-Agent model choices still win.
+engine default**. Explicit per-Agent model choices still win, as do per-engine
+defaults configured on the Computer card (`computers.engine_defaults`) — both
+let an operator name provider-specific model ids that the local CLI catalog
+cannot enumerate (e.g. a proxy endpoint's renamed model).
 
 `CUMORA_ENGINE_MODEL` remains the operator override when the provider needs a
 different policy or an older daemon has not reported its local default:
 
 | value | effect |
 | --- | --- |
-| unset | explicit Agent pin → reported local default → deploy pin → CLI default |
+| unset | explicit Agent pin → computer engine_defaults → reported local default → deploy pin → CLI default |
 | `local` | pass **no** model at all — the CLI runs on whatever it is already configured for, and the small/fast pin is dropped too |
 | any model id | use that model instead of the pinned one |
 

--- a/server/src/__tests__/computer-engine-defaults.test.ts
+++ b/server/src/__tests__/computer-engine-defaults.test.ts
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict'
+import { after, afterEach, test } from 'node:test'
+import type { EngineDefaultsMap } from '../agents/computer/registry.js'
+
+process.env.CUMORA_RUNTIME_CLIENT = 'http'
+process.env.OPENAI_API_KEY ??= 'test-key'
+const { updateEngineDefaults } = await import('../agents/computer/registry.js')
+const { pool } = await import('../db/pool.js')
+const originalConnect = pool.connect
+
+afterEach(() => { pool.connect = originalConnect })
+after(async () => { await pool.end() })
+
+// Model row locking and transaction-local writes without using a developer database.
+function database(initial: EngineDefaultsMap, options: { missing?: boolean; failWrite?: boolean } = {}) {
+  let stored = structuredClone(initial)
+  let tail = Promise.resolve()
+  let releases = 0
+  let commits = 0
+  let rollbacks = 0
+  const connect = async () => {
+    let unlock: (() => void) | undefined
+    let pending: EngineDefaultsMap | undefined
+    let inTransaction = false
+    return {
+      async query(sql: string, params: unknown[] = []) {
+        if (sql === 'BEGIN') {
+          inTransaction = true
+        } else if (sql.includes('SELECT engine_defaults')) {
+          assert.ok(inTransaction)
+          assert.match(sql, /FOR UPDATE/)
+          assert.match(sql, /company_id = \$2/)
+          assert.match(sql, /kind <> 'cloud'/)
+          assert.match(sql, /revoked_at IS NULL/)
+          assert.deepEqual(params, ['computer', 'company'])
+          const previous = tail
+          tail = new Promise<void>((resolve) => { unlock = resolve })
+          await previous
+          return { rows: options.missing ? [] : [{ engine_defaults: structuredClone(stored) }] }
+        } else if (sql.includes('UPDATE computers SET engine_defaults')) {
+          assert.ok(inTransaction && unlock)
+          if (options.failWrite) throw new Error('write failed')
+          pending = JSON.parse(params[1] as string) as EngineDefaultsMap
+        } else if (sql === 'COMMIT' || sql === 'ROLLBACK') {
+          if (sql === 'COMMIT') {
+            if (pending) stored = pending
+            commits++
+          } else {
+            rollbacks++
+          }
+          inTransaction = false
+          unlock?.()
+          unlock = undefined
+        } else {
+          throw new Error(`Unexpected query: ${sql}`)
+        }
+        return { rows: [] }
+      },
+      release() {
+        assert.equal(inTransaction, false)
+        assert.equal(unlock, undefined)
+        releases++
+      },
+    }
+  }
+  pool.connect = connect as unknown as typeof pool.connect
+  return () => ({ stored, releases, commits, rollbacks })
+}
+
+const save = (defaults: EngineDefaultsMap) => updateEngineDefaults({
+  computerId: 'computer', companyId: 'company', defaults,
+})
+
+test('concurrent updates to different engines preserve both changes', async () => {
+  const state = database({})
+  await Promise.all([save({ claude: { model: 'claude-main' } }), save({ codex: { model: 'codex-main' } })])
+  assert.deepEqual(state(), {
+    stored: { claude: { model: 'claude-main' }, codex: { model: 'codex-main' } },
+    releases: 2, commits: 2, rollbacks: 0,
+  })
+})
+
+test('concurrent updates to different fields of one engine preserve both changes', async () => {
+  const state = database({ claude: { model: 'old-main', fastModel: 'old-fast' } })
+  await Promise.all([save({ claude: { model: 'new-main' } }), save({ claude: { fastModel: 'new-fast' } })])
+  assert.deepEqual(state().stored, { claude: { model: 'new-main', fastModel: 'new-fast' } })
+})
+
+test('clearing a field preserves a concurrent change to the other field', async () => {
+  const state = database({ claude: { model: 'old-main', fastModel: 'old-fast' } })
+  await Promise.all([save({ claude: { model: null } }), save({ claude: { fastModel: 'new-fast' } })])
+  assert.deepEqual(state().stored, { claude: { fastModel: 'new-fast' } })
+})
+
+test('partial updates trim strings and clearing the last field removes the engine', async () => {
+  const state = database({ claude: { model: 'main', fastModel: 'fast' }, codex: { model: 'codex' } })
+  assert.deepEqual(await save({ claude: { model: ' updated ' } }), {
+    claude: { model: 'updated', fastModel: 'fast' }, codex: { model: 'codex' },
+  })
+  await save({ claude: { model: '  ' } })
+  assert.deepEqual(state().stored.claude, { fastModel: 'fast' })
+  await save({ claude: { fastModel: null } })
+  assert.deepEqual(state().stored, { codex: { model: 'codex' } })
+})
+
+test('a missing or inaccessible computer closes the transaction without writing', async () => {
+  const state = database({}, { missing: true })
+  assert.equal(await save({ claude: { model: 'main' } }), null)
+  assert.deepEqual(state(), { stored: {}, releases: 1, commits: 1, rollbacks: 0 })
+})
+
+test('a failed write rolls back and releases the connection', async () => {
+  const state = database({ claude: { model: 'original' } }, { failWrite: true })
+  await assert.rejects(save({ claude: { model: 'changed' } }), /write failed/)
+  assert.deepEqual(state(), {
+    stored: { claude: { model: 'original' } }, releases: 1, commits: 0, rollbacks: 1,
+  })
+})

--- a/server/src/__tests__/schema-migrations.test.ts
+++ b/server/src/__tests__/schema-migrations.test.ts
@@ -18,6 +18,7 @@ const { workspaceCleanupJobsChecksum } = await import('../db/migrations/0003-wor
 const { agentRuntimeAssignmentChecksum } = await import('../db/migrations/0004-agent-runtime-assignment.js')
 const { searchTrigramIndexChecksum } = await import('../db/migrations/0005-search-trigram-index.js')
 const { emailMessagesCompanySmtpIdChecksum } = await import('../db/migrations/0006-email-messages-company-smtp-id.js')
+const { engineDefaultsChecksum } = await import('../db/migrations/0007-engine-defaults.js')
 const { verifySchemaCompatibility } = await import('../db/schema-version.js')
 type SchemaVersionQueryable = import('../db/schema-version.js').SchemaVersionQueryable
 
@@ -45,6 +46,10 @@ test('the search trigram migration matches its immutable manifest checksum', () 
 
 test('the email messages company smtp id migration matches its immutable manifest checksum', () => {
   assert.equal(emailMessagesCompanySmtpIdChecksum(), SCHEMA_MIGRATIONS[5].checksum)
+})
+
+test('the engine defaults migration matches its immutable manifest checksum', () => {
+  assert.equal(engineDefaultsChecksum(), SCHEMA_MIGRATIONS[6].checksum)
 })
 
 test('the migration owner accepts an exact prefix and reports its pending suffix', () => {

--- a/server/src/agents/computer/registry.ts
+++ b/server/src/agents/computer/registry.ts
@@ -1113,36 +1113,50 @@ export async function updateEngineDefaults(args: {
   companyId: string
   defaults: EngineDefaultsMap
 }): Promise<EngineDefaultsMap | null> {
-  const { rows } = await pool.query<{ engine_defaults: unknown }>(
-    `SELECT engine_defaults FROM computers
-      WHERE id = $1 AND company_id = $2 AND kind <> 'cloud' AND revoked_at IS NULL LIMIT 1`,
-    [args.computerId, args.companyId],
-  )
-  if (!rows[0]) return null
-  const existing = sanitizeEngineDefaults(rows[0].engine_defaults)
-  const merged = sanitizeEngineDefaults(args.defaults)
-  // Deep merge: for each engine, merge model and fastModel
-  for (const [engineId, defaults] of Object.entries(merged)) {
-    if (defaults.model === null && defaults.fastModel === null) {
-      // Both null means remove this engine's defaults entirely
-      delete existing[engineId]
-    } else {
-      existing[engineId] = {
-        ...(existing[engineId] ?? {}),
-        ...(defaults.model !== undefined ? { model: defaults.model } : {}),
-        ...(defaults.fastModel !== undefined ? { fastModel: defaults.fastModel } : {}),
-      }
-      // Clean up nulls
-      if (existing[engineId].model === null) delete existing[engineId].model
-      if (existing[engineId].fastModel === null) delete existing[engineId].fastModel
-      if (!existing[engineId].model && !existing[engineId].fastModel) delete existing[engineId]
+  const client = await pool.connect()
+  try {
+    await client.query('BEGIN')
+    // Lock before reading so concurrent partial updates merge into the latest state.
+    const { rows } = await client.query<{ engine_defaults: unknown }>(
+      `SELECT engine_defaults FROM computers
+        WHERE id = $1 AND company_id = $2 AND kind <> 'cloud' AND revoked_at IS NULL LIMIT 1 FOR UPDATE`,
+      [args.computerId, args.companyId],
+    )
+    if (!rows[0]) {
+      await client.query('COMMIT')
+      return null
     }
+    const existing = sanitizeEngineDefaults(rows[0].engine_defaults)
+    const merged = sanitizeEngineDefaults(args.defaults)
+    // Deep merge: for each engine, merge model and fastModel
+    for (const [engineId, defaults] of Object.entries(merged)) {
+      if (defaults.model === null && defaults.fastModel === null) {
+        // Both null means remove this engine's defaults entirely
+        delete existing[engineId]
+      } else {
+        existing[engineId] = {
+          ...(existing[engineId] ?? {}),
+          ...(defaults.model !== undefined ? { model: defaults.model } : {}),
+          ...(defaults.fastModel !== undefined ? { fastModel: defaults.fastModel } : {}),
+        }
+        // Clean up nulls
+        if (existing[engineId].model === null) delete existing[engineId].model
+        if (existing[engineId].fastModel === null) delete existing[engineId].fastModel
+        if (!existing[engineId].model && !existing[engineId].fastModel) delete existing[engineId]
+      }
+    }
+    await client.query(
+      `UPDATE computers SET engine_defaults = $2::jsonb WHERE id = $1`,
+      [args.computerId, JSON.stringify(existing)],
+    )
+    await client.query('COMMIT')
+    return existing
+  } catch (error) {
+    await client.query('ROLLBACK').catch(() => {})
+    throw error
+  } finally {
+    client.release()
   }
-  await pool.query(
-    `UPDATE computers SET engine_defaults = $2::jsonb WHERE id = $1`,
-    [args.computerId, JSON.stringify(existing)],
-  )
-  return existing
 }
 
 /** Get the per-engine default model settings for a computer. */

--- a/server/src/agents/computer/registry.ts
+++ b/server/src/agents/computer/registry.ts
@@ -254,6 +254,15 @@ export function sanitizeDetectedEngines(
   return allowed.map((id) => byId.get(id) ?? unreportedEngine(id))
 }
 
+/** Per-engine default model settings stored on a Computer.
+ *  Structure: { "claude": { "model": "x", "fastModel": "y" }, ... } */
+export interface EngineDefaults {
+  model?: string | null
+  fastModel?: string | null
+}
+
+export type EngineDefaultsMap = Record<string, EngineDefaults>
+
 export interface ComputerRow {
   id: string
   company_id: string
@@ -275,6 +284,9 @@ export interface ComputerRow {
   detected_engines: DetectedEngine[]
   engines_detected_at: string | null
   detect_requested_at: string | null
+  /** Per-engine default model settings. Agents inherit these when their own
+   *  model/fastModel is not set. */
+  engine_defaults: EngineDefaultsMap
 }
 
 /** A computer plus the computed upgrade signal the app uses to show the banner. */
@@ -626,16 +638,12 @@ export async function mintAgentRuntimeToken(args: {
  *  Includes the per-agent big-brain (`model`) + small-brain (`fastModel`)
  *  overrides so the daemon can pass them to the engine.
  *
- *  When a row has no explicit model, a reported custom-Claude provider default
- *  takes precedence; otherwise fall back to the deploy-level default
- *  (CUMORA_DEFAULT_CLAUDE_MODEL / CUMORA_DEFAULT_CODEX_MODEL /
- *  CUMORA_DEFAULT_GROK_MODEL / CUMORA_DEFAULT_CURSOR_MODEL /
- *  CUMORA_DEFAULT_OPENCODE_MODEL / CUMORA_DEFAULT_PI_MODEL /
- *  CUMORA_DEFAULT_GEMINI_MODEL / CUMORA_DEFAULT_QWEN_MODEL /
- *  CUMORA_DEFAULT_ANTIGRAVITY_MODEL) so every BYOA
- *  daemon without a custom provider gets a consistent pin. Critical: a model
- *  upgrade in the underlying CLI (e.g. claude 4.7 → 4.8) silently changes
- *  agent behavior on every user's machine unless we pin here. A custom
+ *  When a row has no explicit model, the computer's engine_defaults take
+ *  precedence; then a reported custom-Claude provider default; then fall back
+ *  to the deploy-level default (CUMORA_DEFAULT_CLAUDE_MODEL / etc.) so every
+ *  BYOA daemon without a custom provider gets a consistent pin. Critical: a
+ *  model upgrade in the underlying CLI (e.g. claude 4.7 → 4.8) silently
+ *  changes agent behavior on every user's machine unless we pin here. A custom
  *  provider can explicitly make its unnamed local default authoritative so a
  *  vendor-specific deploy pin never crosses into the wrong namespace. */
 export async function listAgentsForComputer(computerId: string): Promise<
@@ -644,11 +652,12 @@ export async function listAgentsForComputer(computerId: string): Promise<
   const { rows } = await pool.query<{
     id: string; name: string; role: string | null; systemPrompt: string | null
     engine: EngineId | null; model: string | null; fastModel: string | null
-    availableEngines?: string[]; detectedEngines?: unknown
+    availableEngines?: string[]; detectedEngines?: unknown; engineDefaults?: unknown
   }>(
     `SELECT p.id, p.name, p.role, p.system_prompt AS "systemPrompt", p.engine, p.model,
             p.fast_model AS "fastModel", c.available_engines AS "availableEngines",
-            COALESCE(c.detected_engines, '[]'::jsonb) AS "detectedEngines"
+            COALESCE(c.detected_engines, '[]'::jsonb) AS "detectedEngines",
+            COALESCE(c.engine_defaults, '{}'::jsonb) AS "engineDefaults"
        FROM participants p
        JOIN computers c ON c.id = p.computer_id
       WHERE p.computer_id = $1 AND p.kind = 'agent' AND p.departed_at IS NULL
@@ -665,9 +674,14 @@ export async function listAgentsForComputer(computerId: string): Promise<
   const qwenDefault = process.env.CUMORA_DEFAULT_QWEN_MODEL?.trim() || null
   const antigravityDefault = process.env.CUMORA_DEFAULT_ANTIGRAVITY_MODEL?.trim() || null
   return rows.map((r) => {
-    const { availableEngines, detectedEngines, ...agent } = r
+    const { availableEngines, detectedEngines, engineDefaults, ...agent } = r
     const localCatalog = sanitizeDetectedEngines(detectedEngines, availableEngines ?? [])
       .find((entry) => entry.id === agent.engine)?.modelCatalog
+    // Parse the engine_defaults JSONB
+    const defaults = (engineDefaults && typeof engineDefaults === 'object'
+      ? engineDefaults as EngineDefaultsMap
+      : {}) as EngineDefaultsMap
+    const engineDefaultsForAgent = agent.engine ? defaults[agent.engine] : undefined
     // A custom Claude endpoint owns its model namespace. Its reported defaults
     // fill only unpinned fields; explicit per-Agent choices still win. When it
     // cannot name a main/fast default, leave that field null so the CLI chooses
@@ -675,11 +689,16 @@ export async function listAgentsForComputer(computerId: string): Promise<
     if (r.engine === 'claude' && localCatalog?.prefersLocalDefault) {
       return {
         ...agent,
-        model: agent.model ?? localCatalog.defaultModel,
-        fastModel: agent.fastModel ?? localCatalog.defaultFastModel,
+        model: agent.model ?? engineDefaultsForAgent?.model ?? localCatalog.defaultModel,
+        fastModel: agent.fastModel ?? engineDefaultsForAgent?.fastModel ?? localCatalog.defaultFastModel,
       }
     }
-    if (agent.model) return agent
+    // Apply engine_defaults before deploy-level defaults
+    const modelWithEngineDefault = agent.model ?? engineDefaultsForAgent?.model ?? null
+    const fastModelWithEngineDefault = agent.fastModel ?? engineDefaultsForAgent?.fastModel ?? null
+    if (modelWithEngineDefault) {
+      return { ...agent, model: modelWithEngineDefault, fastModel: fastModelWithEngineDefault }
+    }
     const dflt = r.engine === 'codex'
       ? codexDefault
       : r.engine === 'claude'
@@ -699,7 +718,7 @@ export async function listAgentsForComputer(computerId: string): Promise<
                     : r.engine === 'antigravity'
                       ? antigravityDefault
                     : null
-    return dflt ? { ...agent, model: dflt } : agent
+    return dflt ? { ...agent, model: dflt, fastModel: fastModelWithEngineDefault } : { ...agent, fastModel: fastModelWithEngineDefault }
   })
 }
 
@@ -711,7 +730,8 @@ export async function listComputers(companyId: string): Promise<ComputerWithUpgr
     `SELECT id, company_id, owner_user_id, name, kind, available_engines, status,
             last_seen_at, paired_at, revoked_at, created_at, daemon_version, daemon_supervised,
             COALESCE(detected_engines, '[]'::jsonb) AS detected_engines,
-            engines_detected_at, detect_requested_at
+            engines_detected_at, detect_requested_at,
+            COALESCE(engine_defaults, '{}'::jsonb) AS engine_defaults
        FROM computers
       WHERE company_id = $1 AND revoked_at IS NULL
       ORDER BY (kind = 'cloud') DESC, created_at ASC`,
@@ -1055,6 +1075,88 @@ export async function reportDetectedEngines(args: {
   )
   await broadcastComputerStatus(args.computerId, row.company_id, 'online')
   return true
+}
+
+/** Sanitize and validate engine defaults before storage. Only accepts known
+ *  engine ids and string model names within length limits. */
+function sanitizeEngineDefaults(raw: unknown): EngineDefaultsMap {
+  if (!raw || typeof raw !== 'object') return {}
+  const result: EngineDefaultsMap = {}
+  for (const [engineId, defaults] of Object.entries(raw as Record<string, unknown>)) {
+    if (!PAIRABLE_ENGINES.has(engineId)) continue
+    if (!defaults || typeof defaults !== 'object') continue
+    const rec = defaults as Record<string, unknown>
+    // Empty/whitespace-only strings mean "clear" — same as an explicit null.
+    const cleanModel = (value: unknown): string | null | undefined => {
+      if (typeof value === 'string') {
+        const trimmed = value.trim()
+        return trimmed ? trimmed.slice(0, 160) : null
+      }
+      return value === null ? null : undefined
+    }
+    const model = cleanModel(rec.model)
+    const fastModel = cleanModel(rec.fastModel)
+    if (model !== undefined || fastModel !== undefined) {
+      result[engineId] = {
+        ...(model !== undefined ? { model } : {}),
+        ...(fastModel !== undefined ? { fastModel } : {}),
+      }
+    }
+  }
+  return result
+}
+
+/** Update the per-engine default model settings for a computer.
+ *  Merges with existing defaults — pass null for a field to clear it. */
+export async function updateEngineDefaults(args: {
+  computerId: string
+  companyId: string
+  defaults: EngineDefaultsMap
+}): Promise<EngineDefaultsMap | null> {
+  const { rows } = await pool.query<{ engine_defaults: unknown }>(
+    `SELECT engine_defaults FROM computers
+      WHERE id = $1 AND company_id = $2 AND kind <> 'cloud' AND revoked_at IS NULL LIMIT 1`,
+    [args.computerId, args.companyId],
+  )
+  if (!rows[0]) return null
+  const existing = sanitizeEngineDefaults(rows[0].engine_defaults)
+  const merged = sanitizeEngineDefaults(args.defaults)
+  // Deep merge: for each engine, merge model and fastModel
+  for (const [engineId, defaults] of Object.entries(merged)) {
+    if (defaults.model === null && defaults.fastModel === null) {
+      // Both null means remove this engine's defaults entirely
+      delete existing[engineId]
+    } else {
+      existing[engineId] = {
+        ...(existing[engineId] ?? {}),
+        ...(defaults.model !== undefined ? { model: defaults.model } : {}),
+        ...(defaults.fastModel !== undefined ? { fastModel: defaults.fastModel } : {}),
+      }
+      // Clean up nulls
+      if (existing[engineId].model === null) delete existing[engineId].model
+      if (existing[engineId].fastModel === null) delete existing[engineId].fastModel
+      if (!existing[engineId].model && !existing[engineId].fastModel) delete existing[engineId]
+    }
+  }
+  await pool.query(
+    `UPDATE computers SET engine_defaults = $2::jsonb WHERE id = $1`,
+    [args.computerId, JSON.stringify(existing)],
+  )
+  return existing
+}
+
+/** Get the per-engine default model settings for a computer. */
+export async function getEngineDefaults(args: {
+  computerId: string
+  companyId: string
+}): Promise<EngineDefaultsMap | null> {
+  const { rows } = await pool.query<{ engine_defaults: unknown }>(
+    `SELECT engine_defaults FROM computers
+      WHERE id = $1 AND company_id = $2 AND kind <> 'cloud' AND revoked_at IS NULL LIMIT 1`,
+    [args.computerId, args.companyId],
+  )
+  if (!rows[0]) return null
+  return sanitizeEngineDefaults(rows[0].engine_defaults)
 }
 
 /** Make `engine` this computer's default and move every inheriting agent onto it. */

--- a/server/src/api/router.ts
+++ b/server/src/api/router.ts
@@ -40,7 +40,7 @@ import {
   resolveDevice, mintAgentRuntimeToken, listAgentsForComputer,
   listComputers, revokeComputer, assignAgentToComputer, heartbeatComputer,
   cloudComputerId, issueRepairCode, requestEngineDetect, reportDetectedEngines,
-  setComputerDefaultEngine,
+  setComputerDefaultEngine, updateEngineDefaults, getEngineDefaults,
   PAIRABLE_ENGINES, type EngineId,
 } from '../agents/computer/registry.js'
 import { attachComputerControlStream, deliverEngineDetect } from '../agents/computer/control-bus.js'
@@ -1309,6 +1309,30 @@ api.post('/computers/:id/default-engine', safe(async (req, res) => {
   const out = await setComputerDefaultEngine({ computerId: String(req.params.id), companyId, engine })
   if (!out) throw new HttpError(400, 'engine is not installed on this computer')
   res.json({ ok: true, ...out })
+}))
+
+// Per-engine default model settings. Read and write the models each engine
+// uses by default when an agent has no explicit model set.
+api.get('/computers/:id/engine-defaults', safe(async (req, res) => {
+  const { companyId } = await requireCompany(req)
+  const defaults = await getEngineDefaults({ computerId: String(req.params.id), companyId })
+  if (defaults === null) throw new HttpError(404, 'computer not found')
+  res.json({ defaults })
+}))
+
+api.put('/computers/:id/engine-defaults', safe(async (req, res) => {
+  const { companyId } = await requireCompanyRole(req)
+  const defaults = req.body?.defaults
+  if (!defaults || typeof defaults !== 'object') {
+    throw new HttpError(400, 'defaults object required')
+  }
+  const updated = await updateEngineDefaults({
+    computerId: String(req.params.id),
+    companyId,
+    defaults,
+  })
+  if (updated === null) throw new HttpError(404, 'computer not found')
+  res.json({ ok: true, defaults: updated })
 }))
 
 api.post('/computers/me/engines', safe(async (req, res) => {

--- a/server/src/db/migrate.ts
+++ b/server/src/db/migrate.ts
@@ -37,6 +37,10 @@ import {
   EMAIL_MESSAGES_COMPANY_SMTP_ID_SQL,
   emailMessagesCompanySmtpIdChecksum,
 } from './migrations/0006-email-messages-company-smtp-id.js'
+import {
+  ENGINE_DEFAULTS_SQL,
+  engineDefaultsChecksum,
+} from './migrations/0007-engine-defaults.js'
 
 /** Frozen data backfill embedded in migration 0001. Exported so its behavior
  * can be exercised against PostgreSQL without replaying the whole migration. */
@@ -2542,6 +2546,10 @@ async function applyEmailMessagesCompanySmtpId(client: import('pg').PoolClient):
   await client.query(DROP_LEGACY_EMAIL_MESSAGES_SMTP_ID_SQL)
 }
 
+async function applyEngineDefaults(client: import('pg').PoolClient): Promise<void> {
+  await client.query(ENGINE_DEFAULTS_SQL)
+}
+
 const VERSIONED_MIGRATIONS: readonly VersionedMigration[] = [
   {
     ...SCHEMA_MIGRATIONS[0],
@@ -2580,6 +2588,12 @@ const VERSIONED_MIGRATIONS: readonly VersionedMigration[] = [
     // CREATE/DROP INDEX CONCURRENTLY cannot run inside a transaction block.
     transactional: false,
     up: applyEmailMessagesCompanySmtpId,
+  },
+  {
+    ...SCHEMA_MIGRATIONS[6],
+    sourceChecksum: engineDefaultsChecksum(),
+    transactional: true,
+    up: applyEngineDefaults,
   },
 ]
 

--- a/server/src/db/migrations/0007-engine-defaults.ts
+++ b/server/src/db/migrations/0007-engine-defaults.ts
@@ -1,0 +1,19 @@
+import { createHash } from 'node:crypto'
+
+/**
+ * Migration 0007: per-engine default model settings on Computers.
+ *
+ * Cumora users with custom provider endpoints (CC Switch and friends) need a
+ * per-engine model policy: which main + fast model each local CLI should run
+ * when an agent has no explicit pin. Stored as a JSONB map on the Computer:
+ * { "claude": { "model": "…", "fastModel": "…" }, … }. Agents inherit these in
+ * listAgentsForComputer when participants.model / fast_model are unset.
+ */
+export const ENGINE_DEFAULTS_SQL = `
+ALTER TABLE computers
+  ADD COLUMN IF NOT EXISTS engine_defaults JSONB NOT NULL DEFAULT '{}'::jsonb;
+`
+
+export function engineDefaultsChecksum(): string {
+  return createHash('sha256').update(ENGINE_DEFAULTS_SQL).digest('hex')
+}

--- a/server/src/db/migrations/manifest.ts
+++ b/server/src/db/migrations/manifest.ts
@@ -47,12 +47,17 @@ export const SCHEMA_MIGRATIONS = [
     name: '0006_email_messages_company_smtp_id',
     checksum: 'a4a37d6d293f4b36eca5471f20ba3a6e5e40d8c15435133843ef9cb28a636331',
   },
+  {
+    version: 7,
+    name: '0007_engine_defaults',
+    checksum: '1d81ce74821ff467e73feac0d8116520c742775b7ef31badab22480e7c679632',
+  },
 ] as const satisfies readonly MigrationMetadata[]
 
 /** This build intentionally supports one exact schema range. Expand/contract
  * releases may widen the range, but both bounds must remain explicit. */
-export const MIN_SUPPORTED_SCHEMA_VERSION = 6
-export const MAX_SUPPORTED_SCHEMA_VERSION = 6
+export const MIN_SUPPORTED_SCHEMA_VERSION = 7
+export const MAX_SUPPORTED_SCHEMA_VERSION = 7
 
 function assertManifestShape(): void {
   for (let i = 0; i < SCHEMA_MIGRATIONS.length; i++) {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -2,8 +2,8 @@ import { getActiveCompanyId, getAuthToken, useAuth } from '@/stores/auth'
 import type {
   BoardCardComment, BoardCardLookup, BoardSnapshot, BoardSummary,
   CalendarDispatch, CalendarEvent, CalendarEventKind, CalendarEventStatus,
-  CalendarReminderChannel, ComputerKind, ComputerStatus, DetectedEngine, EngineId,
-  Message, RecurrenceRule, Status,
+  CalendarReminderChannel, ComputerKind, ComputerStatus, DetectedEngine,
+  EngineDefaultsMap, EngineId, Message, RecurrenceRule, Status,
 } from '@/types'
 
 const DEVTOOLS_KEY = 'cumora.devtools.enabled'
@@ -251,6 +251,8 @@ export interface ApiComputer {
   latest_daemon_version?: string | null
   /** True when this BYOA daemon is behind the latest version → show upgrade banner. */
   daemon_outdated?: boolean
+  /** Per-engine default model settings. */
+  engine_defaults?: EngineDefaultsMap
 }
 
 /** Universal-search response. The backend ranks results inside each bucket;
@@ -991,6 +993,15 @@ export const api = {
   requestComputerEngineDetect: (id: string) =>
     http<{ ok: boolean }>(
       `/computers/${encodeURIComponent(id)}/detect`, { method: 'POST', body: '{}' }),
+  /** Read per-engine default model settings for a computer. */
+  getEngineDefaults: (id: string) =>
+    http<{ defaults: EngineDefaultsMap }>(
+      `/computers/${encodeURIComponent(id)}/engine-defaults`),
+  /** Update per-engine default model settings for a computer. */
+  updateEngineDefaults: (id: string, defaults: EngineDefaultsMap) =>
+    http<{ ok: boolean; defaults: EngineDefaultsMap }>(
+      `/computers/${encodeURIComponent(id)}/engine-defaults`,
+      { method: 'PUT', body: JSON.stringify({ defaults }) }),
   /** Move an agent to a computer, choosing its engine (Cumora Cloud = managed). */
   assignAgentComputer: (
     agentId: string,

--- a/src/components/AgentEditor.tsx
+++ b/src/components/AgentEditor.tsx
@@ -97,11 +97,16 @@ export function AgentEditor({ agent, onClose, onSaved }: Props) {
   const modelCatalog = selectedComputer?.detectedEngines
     ?.find((engine) => engine.id === selectedEngineId)
     ?.modelCatalog
+  // Per-computer engine model defaults (configured on the Computer card).
+  // When the local CLI catalog can't name a default (e.g. custom endpoints),
+  // these Cumora-side settings show as the hint for "follow engine default".
+  const engineDefaultModel = selectedComputer?.engineDefaults?.[selectedEngineId]?.model ?? undefined
+  const engineDefaultFastModel = selectedComputer?.engineDefaults?.[selectedEngineId]?.fastModel ?? undefined
   const modelOptions: Array<ComboboxOption<string>> = [
     {
       value: '',
       label: t('agent.followEngineDefault'),
-      hint: modelCatalog?.defaultModel ?? undefined,
+      hint: modelCatalog?.defaultModel ?? engineDefaultModel,
     },
     ...(modelCatalog?.models ?? []).map((option) => ({
       value: option.id,
@@ -116,7 +121,7 @@ export function AgentEditor({ agent, onClose, onSaved }: Props) {
     {
       value: '',
       label: t('agent.followSmallBrainDefault'),
-      hint: modelCatalog?.defaultFastModel ?? undefined,
+      hint: modelCatalog?.defaultFastModel ?? engineDefaultFastModel,
     },
     ...(modelCatalog?.models ?? []).map((option) => ({
       value: option.id,

--- a/src/components/AgentEditor.tsx
+++ b/src/components/AgentEditor.tsx
@@ -106,7 +106,7 @@ export function AgentEditor({ agent, onClose, onSaved }: Props) {
     {
       value: '',
       label: t('agent.followEngineDefault'),
-      hint: modelCatalog?.defaultModel ?? engineDefaultModel,
+      hint: engineDefaultModel ?? modelCatalog?.defaultModel ?? undefined,
     },
     ...(modelCatalog?.models ?? []).map((option) => ({
       value: option.id,
@@ -121,7 +121,7 @@ export function AgentEditor({ agent, onClose, onSaved }: Props) {
     {
       value: '',
       label: t('agent.followSmallBrainDefault'),
-      hint: modelCatalog?.defaultFastModel ?? engineDefaultFastModel,
+      hint: engineDefaultFastModel ?? modelCatalog?.defaultFastModel ?? undefined,
     },
     ...(modelCatalog?.models ?? []).map((option) => ({
       value: option.id,

--- a/src/desktop/MeView.tsx
+++ b/src/desktop/MeView.tsx
@@ -858,6 +858,39 @@ function ComputersTab() {
   const [repairCopied, setRepairCopied] = useState(false)
   const [busyId, setBusyId] = useState<string | null>(null)
   const [copiedCli, setCopiedCli] = useState<string | null>(null)
+  // Engine model defaults editing: which computer+engine is being edited
+  const [editingModel, setEditingModel] = useState<{ computerId: string; engineId: string } | null>(null)
+  const [modelInput, setModelInput] = useState('')
+  const [fastModelInput, setFastModelInput] = useState('')
+  const [savingModel, setSavingModel] = useState(false)
+
+  const saveEngineDefaults = async (computerId: string, engineId: string) => {
+    setSavingModel(true)
+    setErr(null)
+    try {
+      const defaults = {
+        [engineId]: {
+          model: modelInput.trim() || null,
+          fastModel: fastModelInput.trim() || null,
+        },
+      }
+      await api.updateEngineDefaults(computerId, defaults)
+      await useComputers.getState().refresh()
+      setEditingModel(null)
+    } catch (e) {
+      console.warn('[engine-defaults] save failed', e)
+      setErr(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSavingModel(false)
+    }
+  }
+
+  const startEditModel = (computerId: string, engineId: string, currentModel?: string | null, currentFastModel?: string | null) => {
+    setEditingModel({ computerId, engineId })
+    setModelInput(currentModel ?? '')
+    setFastModelInput(currentFastModel ?? '')
+  }
+
   useEffect(() => {
     void useComputers.getState().refresh()
   }, [])
@@ -1150,6 +1183,99 @@ function ComputersTab() {
                                   {copiedCli === copyKey ? t('me.copied') : t('me.agentsCopyUpdate')}
                                 </button>
                                 </div>
+                              </div>
+                            )}
+                            {/* Engine model configuration */}
+                            {engineId && (
+                              <div className="mt-3 pt-3" style={{ borderTop: '1px dashed var(--ink-100)' }}>
+                                {editingModel?.computerId === c.id && editingModel?.engineId === row.id ? (
+                                  <div className="space-y-2">
+                                    <div className="text-[11px] font-semibold text-ink-600 uppercase tracking-wider">
+                                      {t('me.engineModelConfig', { engine: engineLabel(row.id) })}
+                                    </div>
+                                    <div>
+                                      <label className="block text-[11px] text-ink-500 mb-1">{t('me.engineDefaultModel')}</label>
+                                      <input
+                                        type="text"
+                                        value={modelInput}
+                                        onChange={(e) => setModelInput(e.target.value)}
+                                        placeholder={t('me.engineModelPlaceholder')}
+                                        className="w-full px-2 py-1.5 text-[12px] rounded-[8px] font-mono"
+                                        style={{ border: '1px solid var(--ink-100)', background: 'var(--paper)' }}
+                                      />
+                                    </div>
+                                    <div>
+                                      <label className="block text-[11px] text-ink-500 mb-1">{t('me.engineFastModel')}</label>
+                                      <input
+                                        type="text"
+                                        value={fastModelInput}
+                                        onChange={(e) => setFastModelInput(e.target.value)}
+                                        placeholder={t('me.engineFastModelPlaceholder')}
+                                        className="w-full px-2 py-1.5 text-[12px] rounded-[8px] font-mono"
+                                        style={{ border: '1px solid var(--ink-100)', background: 'var(--paper)' }}
+                                      />
+                                    </div>
+                                    <div className="flex gap-2">
+                                      <button
+                                        type="button"
+                                        onClick={() => saveEngineDefaults(c.id, row.id)}
+                                        disabled={savingModel}
+                                        className="px-3 py-1 rounded-[7px] text-[11px] font-semibold text-white disabled:opacity-50"
+                                        style={{ background: 'var(--skype)' }}
+                                      >
+                                        {savingModel ? t('common.saving') : t('common.save')}
+                                      </button>
+                                      <button
+                                        type="button"
+                                        onClick={() => setEditingModel(null)}
+                                        className="px-3 py-1 rounded-[7px] text-[11px] font-semibold text-ink-600 hover:bg-ink-50"
+                                      >
+                                        {t('common.cancel')}
+                                      </button>
+                                    </div>
+                                  </div>
+                                ) : (
+                                  <div className="flex items-center justify-between gap-3">
+                                    <div className="min-w-0">
+                                      {(() => {
+                                        const def = c.engineDefaults?.[engineId]
+                                        const main = def?.model?.trim()
+                                        const fast = def?.fastModel?.trim()
+                                        if (!main && !fast) {
+                                          return <span className="text-[11px] text-ink-400">{t('me.engineModelNotSet')}</span>
+                                        }
+                                        return (
+                                          <div className="flex items-center gap-2 flex-wrap">
+                                            {main && (
+                                              <span className="inline-flex items-center gap-1 rounded-[6px] px-1.5 py-0.5 font-mono text-[10.5px] text-ink-700"
+                                                style={{ background: 'var(--ink-100)' }}>
+                                                {main}
+                                              </span>
+                                            )}
+                                            {fast && (
+                                              <span className="inline-flex items-center gap-1 rounded-[6px] px-1.5 py-0.5 font-mono text-[10.5px] text-ink-500"
+                                                style={{ background: 'var(--sky2-100)' }}>
+                                                fast: {fast}
+                                              </span>
+                                            )}
+                                          </div>
+                                        )
+                                      })()}
+                                    </div>
+                                    <button
+                                      type="button"
+                                      onClick={() => startEditModel(
+                                        c.id,
+                                        row.id,
+                                        c.engineDefaults?.[engineId]?.model,
+                                        c.engineDefaults?.[engineId]?.fastModel
+                                      )}
+                                      className="shrink-0 text-[11px] font-semibold text-skype-deep hover:underline"
+                                    >
+                                      {t('me.engineModelConfigure')}
+                                    </button>
+                                  </div>
+                                )}
                               </div>
                             )}
                           </div>

--- a/src/desktop/MeView.tsx
+++ b/src/desktop/MeView.tsx
@@ -865,6 +865,7 @@ function ComputersTab() {
   const [savingModel, setSavingModel] = useState(false)
 
   const saveEngineDefaults = async (computerId: string, engineId: string) => {
+    const savedEditor = editingModel
     setSavingModel(true)
     setErr(null)
     try {
@@ -876,7 +877,8 @@ function ComputersTab() {
       }
       await api.updateEngineDefaults(computerId, defaults)
       await useComputers.getState().refresh()
-      setEditingModel(null)
+      // A late response must not close a different editing session.
+      setEditingModel((current) => current === savedEditor ? null : current)
     } catch (e) {
       console.warn('[engine-defaults] save failed', e)
       setErr(e instanceof Error ? e.message : String(e))
@@ -1198,6 +1200,7 @@ function ComputersTab() {
                                       <input
                                         type="text"
                                         value={modelInput}
+                                        disabled={savingModel}
                                         onChange={(e) => setModelInput(e.target.value)}
                                         placeholder={t('me.engineModelPlaceholder')}
                                         className="w-full px-2 py-1.5 text-[12px] rounded-[8px] font-mono"
@@ -1209,12 +1212,14 @@ function ComputersTab() {
                                       <input
                                         type="text"
                                         value={fastModelInput}
+                                        disabled={savingModel}
                                         onChange={(e) => setFastModelInput(e.target.value)}
                                         placeholder={t('me.engineFastModelPlaceholder')}
                                         className="w-full px-2 py-1.5 text-[12px] rounded-[8px] font-mono"
                                         style={{ border: '1px solid var(--ink-100)', background: 'var(--paper)' }}
                                       />
                                     </div>
+                                    <p className="text-[11px] text-ink-500">{t('me.engineModelHelp')}</p>
                                     <div className="flex gap-2">
                                       <button
                                         type="button"

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -32,6 +32,7 @@ export const en = {
   'common.cancel': 'Cancel',
   'common.done': 'Done',
   'common.save': 'Save',
+  'common.saving': 'Saving…',
   'common.delete': 'Delete',
   'common.you': 'You',
   'common.idle': 'idle',
@@ -1329,6 +1330,13 @@ export const en = {
   'me.computerStatus.online': 'online',
   'me.computerStatus.busy': 'busy',
   'me.computerStatus.offline': 'offline',
+  'me.engineModelConfig': 'Default models for {engine}',
+  'me.engineModelNotSet': 'Follow engine default',
+  'me.engineModelConfigure': 'Configure models',
+  'me.engineDefaultModel': 'Main (big-brain) model — blank = follow CLI default',
+  'me.engineFastModel': 'Fast (small-brain) model — blank = follow CLI default',
+  'me.engineModelPlaceholder': 'e.g. claude-sonnet-4-20250514',
+  'me.engineFastModelPlaceholder': 'e.g. claude-haiku-4-20250514',
 
   // ─── updater dialog + banner ──────────────────────────────────────
   'updater.bannerUpdateReady': 'Update ready',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1333,8 +1333,9 @@ export const en = {
   'me.engineModelConfig': 'Default models for {engine}',
   'me.engineModelNotSet': 'Follow engine default',
   'me.engineModelConfigure': 'Configure models',
-  'me.engineDefaultModel': 'Main (big-brain) model — blank = follow CLI default',
-  'me.engineFastModel': 'Fast (small-brain) model — blank = follow CLI default',
+  'me.engineDefaultModel': 'Main model (leave blank to use default settings)',
+  'me.engineFastModel': 'Fast model (leave blank to use default settings)',
+  'me.engineModelHelp': 'Models selected for an individual agent take priority. Blank fields use the local engine configuration or server defaults.',
   'me.engineModelPlaceholder': 'e.g. claude-sonnet-4-20250514',
   'me.engineFastModelPlaceholder': 'e.g. claude-haiku-4-20250514',
 

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -1335,8 +1335,9 @@ export const zhCN: Partial<Record<keyof typeof en, string>> = {
   'me.engineModelConfig': '{engine} 的默认模型',
   'me.engineModelNotSet': '跟随引擎默认',
   'me.engineModelConfigure': '配置模型',
-  'me.engineDefaultModel': '主模型（大模型）— 留空则跟随 CLI 默认',
-  'me.engineFastModel': '快速模型（小模型）— 留空则跟随 CLI 默认',
+  'me.engineDefaultModel': '主模型（留空使用默认设置）',
+  'me.engineFastModel': '快速模型（留空使用默认设置）',
+  'me.engineModelHelp': 'Agent 单独指定的模型优先；留空时，由本地引擎配置或服务端默认设置决定。',
   'me.engineModelPlaceholder': '例如 claude-sonnet-4-20250514',
   'me.engineFastModelPlaceholder': '例如 claude-haiku-4-20250514',
 

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -38,6 +38,7 @@ export const zhCN: Partial<Record<keyof typeof en, string>> = {
   'common.cancel': '取消',
   'common.done': '完成',
   'common.save': '保存',
+  'common.saving': '保存中…',
   'common.delete': '删除',
   'common.you': '你',
   'common.idle': '空闲',
@@ -1331,6 +1332,13 @@ export const zhCN: Partial<Record<keyof typeof en, string>> = {
   'me.computerStatus.online': '在线',
   'me.computerStatus.busy': '忙碌',
   'me.computerStatus.offline': '离线',
+  'me.engineModelConfig': '{engine} 的默认模型',
+  'me.engineModelNotSet': '跟随引擎默认',
+  'me.engineModelConfigure': '配置模型',
+  'me.engineDefaultModel': '主模型（大模型）— 留空则跟随 CLI 默认',
+  'me.engineFastModel': '快速模型（小模型）— 留空则跟随 CLI 默认',
+  'me.engineModelPlaceholder': '例如 claude-sonnet-4-20250514',
+  'me.engineFastModelPlaceholder': '例如 claude-haiku-4-20250514',
 
   // ─── 自动更新对话框 + 横幅 ────────────────────────────────────────
   'updater.bannerUpdateReady': '更新就绪',

--- a/src/stores/computers.ts
+++ b/src/stores/computers.ts
@@ -29,6 +29,7 @@ function fromApi(c: ApiComputer): Computer {
     daemonSupervised: c.daemon_supervised ?? null,
     latestDaemonVersion: c.latest_daemon_version ?? null,
     daemonOutdated: c.daemon_outdated ?? false,
+    engineDefaults: c.engine_defaults,
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,15 @@ export interface DetectedEngine {
   modelCatalog?: EngineModelCatalog
 }
 
+/** Per-engine default model settings. Stored on the Computer and inherited
+ *  by agents when their own model/fastModel is not set. */
+export interface EngineDefaults {
+  model?: string | null
+  fastModel?: string | null
+}
+
+export type EngineDefaultsMap = Partial<Record<EngineId, EngineDefaults>>
+
 export interface Computer {
   id: string
   name: string
@@ -66,6 +75,9 @@ export interface Computer {
   latestDaemonVersion?: string | null
   /** True when the daemon is behind the latest version → show the upgrade banner. */
   daemonOutdated?: boolean
+  /** Per-engine default model settings. Agents inherit these when their own
+   *  model/fastModel is not set. */
+  engineDefaults?: EngineDefaultsMap
 }
 
 export interface Participant {


### PR DESCRIPTION
## 背景 / Motivation

Users with custom provider endpoints (CC Switch and friends) need a per-engine model policy: which **main** + **fast** model each local CLI should run when an agent has no explicit pin. Custom endpoints often cannot enumerate their models, so the daemon's model catalog is empty and there is no durable place to name the models that actually work against the custom endpoint.

## 改动 / Changes

- **db**: versioned migration `0007_engine_defaults` adds `computers.engine_defaults` (JSONB map per engine: `{ model, fastModel }`)
- **server**: `listAgentsForComputer` model resolution priority becomes
  explicit agent pin → computer `engine_defaults` → reported local default (custom Claude endpoint) → deploy-level `CUMORA_DEFAULT_*_MODEL` pin
- **api**: `GET/PUT /computers/:id/engine-defaults` (merge-on-write; `null`/empty clears a field)
- **ui**: Me → Computers card gains a per-engine **"Configure models"** entry (main + fast inputs); AgentEditor "follow engine default" hint shows the configured engine default
- **daemon**: no change needed — the 60s roster poll picks up the resolved model and `sync()` rebuilds the runner on config change
- **docs**: `docs/BYOA.md` model-resolution section updated

## 验证 / Verification

- server + frontend `tsc` clean, `vite build` OK
- schema-migrations tests 11/11 (incl. new 0007 checksum), engine/computer unit tests pass
- rebased onto current `upstream/main`

## Note

Rebased on top of upstream main (v0.16.x). Base was ~v0.14.2, so migration number moved to `0007` (upstream already owns 0005/0006).
