### PR TITLE
fix(byoa): --stop now kills the daemon started by --pair

### DIFF
--- a/server/src/__tests__/agents-computer-stop-paired-daemon.test.ts
+++ b/server/src/__tests__/agents-computer-stop-paired-daemon.test.ts
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+// `--stop` must kill the daemon the user actually started. The one it kept
+// missing is the first-run path: `agent computer --pair <code>` on a machine
+// with no service installed pairs and then falls through to `doRun`, so the
+// live daemon's own command line carries `--pair` — a one-shot flag. Judged by
+// its flags it was spared, while `--stop` still printed "daemon process(es)
+// killed"; the daemon kept claiming agent turns until the terminal was closed.
+//
+// These drive the real `runComputerDaemon(['--stop'])` against real processes,
+// because the bug was never in the predicate (which is right, and stays) but in
+// what the caller does with it. A pure test of `isStoppableDaemonCommand` still
+// passes on the broken code.
+
+const REPO_ROOT = fileURLToPath(new URL('../../..', import.meta.url))
+const DAEMON = join(REPO_ROOT, 'server/src/agents/computer/daemon.ts')
+const isWindows = process.platform === 'win32'
+
+/** A process whose `ps` command line is exactly what the real CLI produces. */
+function spawnDecoy(home: string, flags: string[]): { pid: number; kill: () => void } {
+  const child = spawn(
+    process.execPath,
+    ['-e', 'setInterval(() => {}, 1 << 30)', 'agent', 'computer', ...flags],
+    { stdio: 'ignore', env: { ...process.env, HOME: home } },
+  )
+  assert.ok(child.pid, 'decoy failed to start')
+  return { pid: child.pid, kill: () => { try { child.kill('SIGKILL') } catch { /* gone */ } } }
+}
+
+function alive(pid: number): boolean {
+  try { process.kill(pid, 0); return true } catch { return false }
+}
+
+/** Run the real `--stop` in a child, so it reads OUR sandbox HOME rather than
+ *  the developer's — CONFIG_DIR is resolved once, at module load. */
+async function runStop(home: string): Promise<string> {
+  const script = `const { runComputerDaemon } = await import(${JSON.stringify(DAEMON)}); await runComputerDaemon(['--stop'])`
+  const child = spawn(process.execPath, ['--import', 'tsx', '--input-type=module', '-e', script], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, HOME: home },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  let out = ''
+  child.stdout.on('data', (c) => { out += String(c) })
+  child.stderr.on('data', (c) => { out += String(c) })
+  await new Promise((resolve) => child.on('close', resolve))
+  return out
+}
+
+async function sandbox(): Promise<string> {
+  const home = await mkdtemp(join(tmpdir(), 'cumora-stop-'))
+  await mkdir(join(home, '.cumora'), { recursive: true })
+  return home
+}
+
+async function recordRunning(home: string, pid: number): Promise<void> {
+  await writeFile(
+    join(home, '.cumora', 'running.json'),
+    JSON.stringify({ version: '0.0.0-test', pid, startedAt: new Date().toISOString() }),
+    'utf8',
+  )
+}
+
+/** SIGTERM then SIGKILL, with a grace window matching the daemon's own. */
+async function settle(): Promise<void> {
+  await new Promise((r) => setTimeout(r, 2500))
+}
+
+test('--stop kills the foreground daemon started by --pair', { skip: isWindows }, async () => {
+  const home = await sandbox()
+  const daemon = spawnDecoy(home, ['--pair', '8lkqelTbO'])
+  try {
+    // What `doRun` writes about itself once it becomes the daemon.
+    await recordRunning(home, daemon.pid)
+    const out = await runStop(home)
+    await settle()
+    assert.equal(alive(daemon.pid), false, `--stop left the paired daemon running. Output:\n${out}`)
+  } finally {
+    daemon.kill()
+  }
+})
+
+test('a --pair CLI that never became the daemon is still spared', { skip: isWindows }, async () => {
+  const home = await sandbox()
+  // Someone re-pairing in another terminal: same command line, but it is NOT the
+  // pid in running.json, so it has never declared itself a daemon.
+  const oneShot = spawnDecoy(home, ['--pair', '8lkqelTbO'])
+  const daemon = spawnDecoy(home, ['--server', 'https://api.cumora.ai'])
+  try {
+    await recordRunning(home, daemon.pid)
+    const out = await runStop(home)
+    await settle()
+    assert.equal(alive(daemon.pid), false, `the real daemon survived --stop. Output:\n${out}`)
+    assert.equal(alive(oneShot.pid), true, `--stop killed a sibling one-shot CLI. Output:\n${out}`)
+  } finally {
+    oneShot.kill()
+    daemon.kill()
+  }
+})
+
+test('a recycled pid in running.json is not killed', { skip: isWindows }, async () => {
+  const home = await sandbox()
+  // The pid file is stale and the OS has handed that pid to something else. The
+  // recorded pid buys a process out of the flag rule, never out of being ours.
+  const stranger = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1 << 30)', 'some-other-tool', 'serve'], {
+    stdio: 'ignore', env: { ...process.env, HOME: home },
+  })
+  assert.ok(stranger.pid)
+  try {
+    await recordRunning(home, stranger.pid)
+    const out = await runStop(home)
+    await settle()
+    assert.equal(alive(stranger.pid), true, `--stop killed an unrelated process. Output:\n${out}`)
+  } finally {
+    try { stranger.kill('SIGKILL') } catch { /* gone */ }
+  }
+})

--- a/server/src/agents/computer/daemon.ts
+++ b/server/src/agents/computer/daemon.ts
@@ -3929,8 +3929,16 @@ const ONE_SHOT_SUBCOMMAND_RE = /\bagent computer (?:doctor|help)\b/
  *  candidate set. Killing the wrapper's child is what actually stops the daemon,
  *  and the wrapper exits with it. */
 export function isStoppableDaemonCommand(cmd: string): boolean {
-  if (!/agent computer/.test(cmd)) return false
+  if (!isCumoraAgentCommand(cmd)) return false
   return !ONE_SHOT_FLAG_RE.test(cmd) && !ONE_SHOT_SUBCOMMAND_RE.test(cmd)
+}
+
+/** Is this `ps`-reported command line one of ours at all? Weaker than
+ *  `isStoppableDaemonCommand` on purpose: it says nothing about whether the
+ *  process is the long-running daemon, only that a pid we already have other
+ *  evidence for has not been recycled by some unrelated program. */
+export function isCumoraAgentCommand(cmd: string): boolean {
+  return /agent computer/.test(cmd)
 }
 
 async function commandLineForPid(pid: number): Promise<string> {
@@ -4013,9 +4021,10 @@ async function stopWindowsWatchdog(taskName: string): Promise<void> {
  *  bounded fallback so engine descendants cannot be orphaned. */
 async function killRunningDaemons(): Promise<void> {
   const candidates = new Set<number>()
+  let recordedPid: number | null = null
   try {
     const pid = (JSON.parse(await readFile(RUNNING_STATE_PATH, 'utf8')) as { pid?: number }).pid
-    if (typeof pid === 'number' && pid > 0) candidates.add(pid)
+    if (typeof pid === 'number' && pid > 0) { candidates.add(pid); recordedPid = pid }
   } catch { /* no pid file */ }
   if (process.platform === 'win32') {
     for (const item of await windowsDaemonProcesses()) candidates.add(item.ProcessId)
@@ -4027,16 +4036,26 @@ async function killRunningDaemons(): Promise<void> {
   }
   candidates.delete(process.pid)
   if (typeof process.ppid === 'number') candidates.delete(process.ppid)
+
+  // running.json is written by `doRun` itself, so a pid recorded there HAS
+  // become the long-running daemon whatever its flags say. That matters because
+  // one real daemon's command line does carry a one-shot flag: `--pair` on a
+  // machine with no service installed pairs and then falls through to `doRun`,
+  // which is the whole first-run onboarding path. Judging it by its flags left
+  // `--stop` reporting "daemon process(es) killed" while that daemon kept
+  // running, kept claiming agent turns, and could only be stopped by closing the
+  // terminal. For that pid we only re-confirm it is still one of ours, so a
+  // stale file whose pid the OS has recycled cannot make us kill a stranger.
+  //
+  // Every other candidate comes from a bare pgrep and carries no such evidence,
+  // so it keeps the strict rule — a sibling one-shot CLI must never be killed.
+  const isVictimCommand = (pid: number, cmd: string): boolean =>
+    pid === recordedPid ? isCumoraAgentCommand(cmd) : isStoppableDaemonCommand(cmd)
+
   const victims: number[] = []
   for (const pid of candidates) {
     try {
-      const cmd = await commandLineForPid(pid)
-      // A genuine long-running daemon: "agent computer" with NO one-shot flag —
-      // so we never kill a sibling one-shot CLI. (Ourselves and our parent are
-      // already out of `candidates`.)
-      if (isStoppableDaemonCommand(cmd)) {
-        victims.push(pid)
-      }
+      if (isVictimCommand(pid, await commandLineForPid(pid))) victims.push(pid)
     } catch { /* gone */ }
   }
   if (process.platform === 'win32') {
@@ -4051,7 +4070,7 @@ async function killRunningDaemons(): Promise<void> {
       const next: number[] = []
       for (const pid of survivors) {
         try {
-          if (isStoppableDaemonCommand(await commandLineForPid(pid))) next.push(pid)
+          if (isVictimCommand(pid, await commandLineForPid(pid))) next.push(pid)
         } catch { /* exited */ }
       }
       survivors = next
@@ -4061,14 +4080,14 @@ async function killRunningDaemons(): Promise<void> {
     }
     for (const pid of victims) await rm(windowsShutdownRequestPath(pid), { force: true }).catch(() => {})
     const forceDeadline = Date.now() + 2_000
-    let remaining = (await windowsDaemonProcesses()).filter((item) =>
-      item.ProcessId !== process.pid && item.ProcessId !== process.ppid &&
-      isStoppableDaemonCommand(item.CommandLine))
+    const stillRunning = async (): Promise<WindowsProcessInfo[]> =>
+      (await windowsDaemonProcesses()).filter((item) =>
+        item.ProcessId !== process.pid && item.ProcessId !== process.ppid &&
+        isVictimCommand(item.ProcessId, item.CommandLine))
+    let remaining = await stillRunning()
     while (remaining.length > 0 && Date.now() < forceDeadline) {
       await new Promise((resolve) => setTimeout(resolve, 100))
-      remaining = (await windowsDaemonProcesses()).filter((item) =>
-        item.ProcessId !== process.pid && item.ProcessId !== process.ppid &&
-        isStoppableDaemonCommand(item.CommandLine))
+      remaining = await stillRunning()
     }
     if (remaining.length > 0) {
       throw new Error(`Windows daemon process(es) still running: ${remaining.map((item) => item.ProcessId).join(', ')}`)


### PR DESCRIPTION
## The bug

`npx cumora@latest agent computer --pair <code>` on a machine with no service installed pairs, and then — by design — falls through to `doRun()`. That is the first-run onboarding path straight out of the docs, and the daemon it starts has `--pair` in its own command line.

`killRunningDaemons` classifies every candidate with `isStoppableDaemonCommand`, which spares any command line holding a one-shot flag. `pair` is one of them. So `--stop` skipped exactly that daemon — and still printed:

```
[computer] stopped — service removed and daemon process(es) killed. Re-pair to start again: …
```

It kept running, kept claiming agent turns, and could only be stopped by closing the terminal. `--status` doesn't help either: with no service installed it returns before it would say anything about a live process.

Reproduced end to end through the real `runComputerDaemon(['--stop'])`, with two processes whose `ps` lines are what the CLI actually produces:

```
service-shaped daemon : node … agent computer --server https://cumora.ai
pair-shaped    daemon : node … agent computer --pair ABC123

[computer] no background service installed — killing any running daemon process directly.
[computer] stopped 1 running daemon process(es)
[computer] stopped — service removed and daemon process(es) killed.

RESULT service-shaped: killed
RESULT pair-shaped:    STILL ALIVE
```

## The fix

Not by loosening the predicate. Dropping `pair` from `ONE_SHOT_FLAGS` would make a re-pair racing a `--stop` killable mid-write, and it would still be a guess.

`running.json` is written by `doRun` itself, so **a pid recorded there has already become the long-running daemon**, whatever its flags say. The caller had that evidence — it reads the pid file for its candidate set — and then threw it away by re-deciding with a command-line heuristic. The heuristic exists to classify strangers found by a bare `pgrep`; that is the only place it belongs.

So the recorded pid is judged only by whether it is *still one of ours* (`isCumoraAgentCommand`), which keeps a stale file whose pid the OS recycled from making us kill a stranger. Everything else keeps the strict rule.

This also generalizes: any future path that falls through to `doRun()` is covered without another flag list needing an edit.

`isStoppableDaemonCommand` is unchanged, and so are its 12 existing tests — including `--pair with a value is spared`, which remains the right answer for a command line judged on its own. That nothing had to be weakened is the point.

The two Windows survivor re-checks move to the same rule, or a paired daemon there would read as "already exited" and never be force-killed.

## Tests

New `server/src/__tests__/agents-computer-stop-paired-daemon.test.ts` — three tests driving the real `--stop` against real processes in a sandboxed `HOME`, because the bug was never in the predicate but in what the caller does with it (a pure predicate test passes on the broken code):

- **`--stop` kills the foreground daemon started by `--pair`** — red before, green after
- **a `--pair` CLI that never became the daemon is still spared** — someone re-pairing in another terminal, same command line, not the recorded pid
- **a recycled pid in `running.json` is not killed** — the pid file buys a process out of the flag rule, never out of being ours

The last two pass on both the broken and fixed code on purpose: they are the guard rails proving the fix does not over-reach.

```
against the shipped killRunningDaemons:
  not ok 1 - --stop kills the foreground daemon started by --pair
  ok 2 - a --pair CLI that never became the daemon is still spared
  ok 3 - a recycled pid in running.json is not killed
  # pass 2  # fail 1

with the fix:  # pass 3  # fail 0
```

Also green: `tsc --noEmit`, `biome lint .`, all three `scripts/guard-*.mjs`, and the unit suite (1208 tests, 0 failures).
