### PR TITLE
fix(byoa): a failing model-list CLI is not a catalog

### DIFF
--- a/server/src/__tests__/agents-computer-model-catalog.test.ts
+++ b/server/src/__tests__/agents-computer-model-catalog.test.ts
@@ -121,3 +121,82 @@ test('Antigravity catalog parses tab-separated models, ignores fetching banner, 
     { id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6 (Thinking)', description: null, recommendedFor: ['big'] },
   ])
 })
+
+// ─── a failing CLI is not a catalog ─────────────────────────────────────────
+//
+// `runText` folds stderr into stdout and ignores the exit status, so whatever a
+// CLI printed instead of a model list lands in the parser. The exit status
+// would not have caught it either: measured against a real cursor-agent, an
+// account with nothing provisioned prints a sentence and exits 0.
+
+test('Cursor catalog does not turn "no models" prose into a model', () => {
+  // Verbatim from `cursor-agent models` on an account with nothing provisioned
+  // (exit code 0). This used to parse to a model with the id "No".
+  assert.deepEqual(parseListedModels('No models available for this account.\n', 'cursor'), [])
+})
+
+test('Antigravity catalog does not turn an error into a model', () => {
+  const output = [
+    'Error: not authenticated. Run `antigravity login`.',
+    'Failed to fetch models: connect ETIMEDOUT',
+  ].join('\n')
+  assert.deepEqual(parseListedModels(output, 'antigravity'), [])
+})
+
+test('a model id is the whole column, so prose cannot be one', () => {
+  // The rule carries no vendor's error wording on purpose — the next CLI's
+  // phrasing, in a locale we have never seen, fails the same test.
+  assert.deepEqual(parseListedModels('Es sind keine Modelle verfügbar.', 'cursor'), [])
+  assert.deepEqual(parseListedModels('该账户没有可用的模型', 'cursor'), [])
+  // …while a genuine id still parses, bare word or not.
+  assert.deepEqual(parseListedModels('auto\ngpt-5.5\n', 'cursor').map((m) => m.id), ['auto', 'gpt-5.5'])
+})
+
+test('Antigravity catalog reads space-aligned columns, not just tabs', () => {
+  // A column separator is a tab OR a run of 2+ spaces; a sentence uses single
+  // spaces. Reading the wider separator means the label is the label rather
+  // than the whole line repeated.
+  assert.deepEqual(parseListedModels('gemini-3.8-flash-high   Gemini 3.8 Flash (High)', 'antigravity'), [
+    { id: 'gemini-3.8-flash-high', label: 'Gemini 3.8 Flash (High)', description: null, recommendedFor: ['small'] },
+  ])
+})
+
+async function stubEngineCli(name: string, stdout: string): Promise<{ bin: string; cleanup: () => Promise<void> }> {
+  const root = await mkdtemp(join(tmpdir(), `cumora-${name}-catalog-`))
+  const bin = join(root, name)
+  await writeFile(bin, `#!/bin/sh\necho ${JSON.stringify(stdout)}\nexit 0\n`, { mode: 0o755 })
+  return { bin, cleanup: () => rm(root, { recursive: true, force: true }) }
+}
+
+test('a CLI that listed nothing offers nothing, not a model named after its excuse', async () => {
+  // End to end through the real dispatch. Cursor has no preset — cumora takes
+  // its whole catalog from the CLI — so before the fix the picker's only entry
+  // was "No", and picking it would have run `--model No`.
+  const { bin, cleanup } = await stubEngineCli('cursor-agent', 'No models available for this account.')
+  try {
+    clearModelCatalogCache()
+    const catalog = await discoverEngineModelCatalog('cursor', bin, true)
+    assert.deepEqual(catalog.models, [])
+    assert.equal(catalog.source, 'presets', 'a CLI that listed nothing was treated as having listed models')
+  } finally {
+    clearModelCatalogCache()
+    await cleanup()
+  }
+})
+
+test('an engine with a preset keeps it when its CLI fails to list', async () => {
+  // Discovered models are merged AHEAD of the preset, so a parsed error line
+  // does not just add noise — it takes the top of the picker and drops the
+  // engine's real default.
+  const { bin, cleanup } = await stubEngineCli('antigravity', 'Error: not authenticated. Run antigravity login.')
+  try {
+    clearModelCatalogCache()
+    const catalog = await discoverEngineModelCatalog('antigravity', bin, true)
+    assert.equal(catalog.source, 'presets')
+    assert.equal(catalog.models[0]?.id, 'gemini-3.8-flash-high')
+    assert.equal(catalog.models.some((model) => /^Error/.test(model.id)), false)
+  } finally {
+    clearModelCatalogCache()
+    await cleanup()
+  }
+})

--- a/server/src/agents/computer/model-catalog.ts
+++ b/server/src/agents/computer/model-catalog.ts
@@ -216,6 +216,40 @@ function runText(command: string, args: string[]): Promise<string> {
   })
 }
 
+/** Split a listing line into its id column and whatever follows. Columns are
+ *  separated by a tab or a run of two or more spaces — how a CLI lays out a
+ *  table. Single spaces are how a sentence is written, so prose stays in one
+ *  piece and `modelIdToken` can reject it whole. */
+function splitIdColumn(line: string): [string, string] {
+  const stripped = line.replace(/^[*✓>•-]+\s*/, '')
+  const sep = stripped.search(/\t| {2,}/)
+  if (sep < 0) return [stripped.trim(), '']
+  return [stripped.slice(0, sep).trim(), stripped.slice(sep).trim()]
+}
+
+/** The model id in a listing line's id column, or null when that column is not
+ *  an id at all.
+ *
+ *  `runText` folds stderr into stdout and ignores the exit status, so whatever
+ *  a CLI printed when it could not list models arrives here as if it were a
+ *  catalog — and the exit status would not have saved us. Measured against a
+ *  real cursor-agent: an account with nothing provisioned prints
+ *  "No models available for this account." and exits 0. That line used to
+ *  become a selectable model with the id "No", merged AHEAD of the built-in
+ *  preset, so the picker offered "No" and the real defaults vanished.
+ *
+ *  An id occupies its whole column — `auto`, `gpt-5.5`, `gemini-3.8-flash-high`
+ *  — and prose does not. That test needs no vendor's error wording, which is
+ *  the point: the next CLI's phrasing, in a locale we have never seen, still
+ *  fails it. */
+function modelIdToken(column: string): string | null {
+  if (!column || /\s/.test(column)) return null
+  // "Error:", "Warning:" — a bare word wearing sentence punctuation, which can
+  // survive the column rule when a CLI aligns its message.
+  if (/^[a-z]+[.:,;!?]+$/i.test(column)) return null
+  return column.match(/^[a-z0-9][\w./:@+-]*$/i)?.[0] ?? null
+}
+
 /** Parse model-list output shared by OpenCode, pi, Cursor and Antigravity. Exported so new
  * adapters can add fixtures without spawning a real account-bound CLI. */
 export function parseListedModels(text: string, style: 'provider' | 'pi' | 'cursor' | 'antigravity'): EngineModelOption[] {
@@ -237,10 +271,8 @@ export function parseListedModels(text: string, style: 'provider' | 'pi' | 'curs
         }
       }
     } else if (style === 'antigravity') {
-      const tabIdx = line.indexOf('\t')
-      const idPart = (tabIdx >= 0 ? line.slice(0, tabIdx) : line).trim()
-      const labelPart = (tabIdx >= 0 ? line.slice(tabIdx + 1) : idPart).trim()
-      const candidate = idPart.replace(/^[*✓>•-]+\s*/, '').match(/^([a-z0-9][\w./:@+-]*)/i)?.[1] ?? null
+      const [idPart, labelPart] = splitIdColumn(line)
+      const candidate = modelIdToken(idPart)
       if (candidate) {
         id = candidate
         label = labelPart || candidate
@@ -253,7 +285,7 @@ export function parseListedModels(text: string, style: 'provider' | 'pi' | 'curs
         if (recs.length) recommendedFor = recs
       }
     } else {
-      const candidate = line.replace(/^[*✓>•-]+\s*/, '').match(/^([a-z0-9][\w./:@+-]*)/i)?.[1] ?? null
+      const candidate = modelIdToken(splitIdColumn(line)[0])
       if (candidate && !/^(available|current|default|name|model)$/i.test(candidate)) id = candidate
     }
     const normalized = clean(id, 160)


### PR DESCRIPTION
## The bug

`runText` folds stderr into stdout and ignores the exit status, so whatever a CLI printed *instead of* a model list goes straight into `parseListedModels`. The single-token styles (`cursor`, `antigravity`) accept any line that begins with an alphanumeric, so a sentence becomes models.

Measured against a real `cursor-agent`, on an account with nothing provisioned:

```
$ cursor-agent models
No models available for this account.
$ echo $?
0

parseListedModels(…, 'cursor')  ->  [{ id: "No", label: "No", description: null }]
```

Checking the exit status would not have caught this — the CLI succeeded at telling us it had nothing.

The consequences are worse than cosmetic:

- **Cursor has an empty preset.** cumora takes its entire Cursor catalog from the CLI, so `"No"` was the picker's only entry — and selecting it would have run `--model No`.
- **For an engine that does have a preset, discovered models merge *ahead* of it** (`mergeModels(discovered, preset.models)`). So a parsed error line does not merely add noise: it takes the top of the list and the engine's real default disappears.

Antigravity is the same code path:

```
Error: not authenticated. Run `antigravity login`.
Failed to fetch models: connect ETIMEDOUT

  ->  [{ id: "Error:", label: "Error: not authenticated. Run `antigravity login`." },
       { id: "Failed", label: "Failed to fetch models: connect ETIMEDOUT" }]
```

## The fix

**An id occupies its whole column; prose does not.**

Columns are separated by a tab or a run of two or more spaces — how a CLI lays out a table. A sentence is written with single spaces, so it arrives as a single column and is rejected whole. `auto`, `gpt-5.5`, `gemini-3.8-flash-high` all still parse; a bare word is fine as long as it is the *only* thing in its column, which is what separates `auto` from `No`.

One extra line rejects `Error:` / `Warning:` — a bare word wearing sentence punctuation, which can survive the column rule when a CLI aligns its message.

The rule carries no vendor's error wording on purpose. The next CLI's phrasing, in a locale we have never seen, fails the same test:

```ts
parseListedModels('Es sind keine Modelle verfügbar.', 'cursor')  // []
parseListedModels('该账户没有可用的模型', 'cursor')                  // []
```

Reading the wider separator also improves the space-aligned Antigravity case, where the label used to be the whole line repeated:

```
gemini-3.8-flash-high   Gemini 3.8 Flash (High)
before: { id: 'gemini-3.8-flash-high', label: 'gemini-3.8-flash-high   Gemini 3.8 Flash (High)' }
after:  { id: 'gemini-3.8-flash-high', label: 'Gemini 3.8 Flash (High)' }
```

I did consider fixing `runText` instead — honouring the exit status, or not folding stderr into stdout. Neither helps here (exit 0), and both risk dropping output from a CLI that warns on stderr while listing correctly on stdout. The parser is where the wrong assumption lives.

## Tests

Six added to `agents-computer-model-catalog.test.ts`, all red before and green after; **all six existing fixtures are untouched and still pass**:

- `Cursor catalog does not turn "no models" prose into a model` — the verbatim real output
- `Antigravity catalog does not turn an error into a model`
- `a model id is the whole column, so prose cannot be one` — including the German and Chinese phrasings, plus `auto` still parsing
- `Antigravity catalog reads space-aligned columns, not just tabs`
- `a CLI that listed nothing offers nothing, not a model named after its excuse` — end to end through `discoverEngineModelCatalog` with a stub binary
- `an engine with a preset keeps it when its CLI fails to list` — asserts the preset's real default is still first

```
without the fix:  # pass 6  # fail 6
with the fix:     # pass 12 # fail 0
```

Also green: `tsc --noEmit`, `biome lint .`, all three `scripts/guard-*.mjs`, and the unit suite (1211 tests, 0 failures).
