### PR TITLE
fix(scheduler): a synthetic wake that reached nobody is not a success

### DIFF
--- a/server/src/__integration__/synthetic-wake-undelivered.test.ts
+++ b/server/src/__integration__/synthetic-wake-undelivered.test.ts
@@ -1,0 +1,119 @@
+/**
+ * A synthetic wake that reached nobody is not a wake that happened.
+ *
+ * `message.new` is backed by the message row: an offline runtime finds it on
+ * its next drain, so reporting success for an undelivered one is honest. Every
+ * other reason carries its whole content in the wake payload — the scanner's
+ * brief, an idle nudge, a manual poke — and that payload exists nowhere else.
+ *
+ * The scanner is built on this distinction already: on `false` it declines to
+ * spend the activity fingerprint so the next pass can retry. When wakeOne
+ * reported `true` for a BYOA daemon that was asleep, the scan was logged as
+ * queued, the fingerprint was claimed, and the brief was never sent — and never
+ * regenerated, because the fingerprint of that same activity is now spent.
+ */
+import { test, before, beforeEach, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { randomUUID } from 'node:crypto'
+import { pool } from '../db/pool.js'
+import { ensureSchemaOnce, resetAllTables, teardownAll } from './_helpers.js'
+import { wakeAgent } from '../agents/scheduler.js'
+import { _resetBackgroundScannerForTests, runBackgroundScans } from '../agents/scanner.js'
+
+before(async () => { await ensureSchemaOnce() })
+beforeEach(async () => { await resetAllTables(); await _resetBackgroundScannerForTests() })
+after(async () => { await _resetBackgroundScannerForTests(); await teardownAll() })
+
+/** A workspace whose scanner-capable agent has no runtime subscribed — the
+ *  ordinary state of a BYOA agent whose laptop is asleep. */
+async function seedSleepingScannerAgent(): Promise<{ companyId: string; agentId: string }> {
+  const companyId = `c-${randomUUID().slice(0, 8)}`
+  const agentId = `agent-${randomUUID().slice(0, 8)}`
+  const humanA = `u-${randomUUID().slice(0, 8)}`
+  const humanB = `u-${randomUUID().slice(0, 8)}`
+  const conversationId = `group-${randomUUID().slice(0, 8)}`
+
+  await pool.query(
+    `INSERT INTO companies (id, name, slug, owner_user_id) VALUES ($1, $2, $3, $4)`,
+    [companyId, `Test ${companyId}`, companyId, humanA],
+  )
+  for (const userId of [humanA, humanB]) {
+    await pool.query(
+      `INSERT INTO users (id, email, display_name, tier) VALUES ($1, $2, $3, 'free')`,
+      [userId, `${userId}@test.local`, userId],
+    )
+    await pool.query(
+      `INSERT INTO company_members (company_id, user_id, role) VALUES ($1, $2, 'member')`,
+      [companyId, userId],
+    )
+    await pool.query(
+      `INSERT INTO participants (id, company_id, kind, name, role, initial, avatar_bg, status)
+       VALUES ($1, $2, 'human', $3, 'member', 'X', '#abcdef', 'avail')`,
+      [userId, companyId, userId],
+    )
+  }
+  await pool.query(
+    `INSERT INTO participants (id, company_id, kind, name, role, initial, avatar_bg, status, bio, tools, system_prompt)
+     VALUES ($1, $2, 'agent', 'Scanner', 'Strategist', 'S', '#abcdef', 'avail', 'I watch.', $3::jsonb, 'You are Scanner.')`,
+    [agentId, companyId, JSON.stringify(['bash', 'background.scan'])],
+  )
+  await pool.query(
+    `INSERT INTO conversations (id, kind, title, members, tag, company_id)
+     VALUES ($1, 'group', 'Campaign planning', $2::jsonb, 'team', $3)`,
+    [conversationId, JSON.stringify([humanA, humanB]), companyId],
+  )
+  for (let i = 1; i <= 8; i++) {
+    await pool.query(
+      `INSERT INTO messages (id, conversation_id, author_id, kind, body, sequence, company_id)
+       VALUES ($1, $2, $3, 'text', $4, $5, $6)`,
+      [`m-${randomUUID()}`, conversationId, i % 2 === 0 ? humanA : humanB, `campaign note ${i}`, i, companyId],
+    )
+  }
+  return { companyId, agentId }
+}
+
+test('[integration] an undelivered synthetic wake reports failure, an undelivered message wake does not', async () => {
+  const { agentId } = await seedSleepingScannerAgent()
+
+  const scan = await wakeAgent(agentId, 'background_scan', null, null, {
+    backgroundBrief: { source: 'background_scanner', title: 'Recent company activity scan', body: 'the brief' },
+  })
+  assert.equal(scan, false, 'a scanner brief that reached no subscriber was reported as delivered')
+
+  const idle = await wakeAgent(agentId, 'idle', null, null, { idleReason: 'nothing to do' })
+  assert.equal(idle, false, 'an idle nudge that reached no subscriber was reported as delivered')
+
+  // The message wake is genuinely durable: the row is in the inbox and the
+  // daemon reads it on reconnect. This must keep reporting success, or every
+  // offline BYOA agent starts looking like a delivery failure.
+  const message = await wakeAgent(agentId, 'message.new', null)
+  assert.equal(message, true, 'a message wake is durable in the inbox and must still report success')
+})
+
+test('[integration] the scanner keeps the scan for when the daemon is back', async () => {
+  const { agentId } = await seedSleepingScannerAgent()
+
+  await runBackgroundScans()
+
+  const logged = await pool.query<{ body: string }>(
+    `SELECT body FROM agent_log WHERE agent_id = $1`, [agentId],
+  )
+  assert.equal(
+    logged.rowCount, 0,
+    `the scan was recorded as queued although nothing received it: ${JSON.stringify(logged.rows)}`,
+  )
+
+  // And it is still owed: the fingerprint was not spent, so the very next pass
+  // over the same activity tries again. Before the fix this second pass was a
+  // no-op and the brief was gone for good.
+  const wakes: string[] = []
+  const { __setBackgroundScannerWakeForTesting } = await import('../agents/scanner.js')
+  __setBackgroundScannerWakeForTesting(async (id) => { wakes.push(id); return true })
+  await runBackgroundScans()
+
+  assert.deepEqual(wakes, [agentId], 'the scan was not retried once a runtime was listening')
+  const after = await pool.query<{ n: number }>(
+    `SELECT count(*)::int AS n FROM agent_log WHERE agent_id = $1`, [agentId],
+  )
+  assert.equal(after.rows[0].n, 1, 'the delivered scan should be recorded exactly once')
+})

--- a/server/src/agents/scheduler.ts
+++ b/server/src/agents/scheduler.ts
@@ -469,15 +469,31 @@ async function wakeOne(
     if (!host) return false
   }
 
+  // Is there anything left to catch up ON? `message.new` is backed by the
+  // message row, so a runtime that was offline finds it on its next drain and
+  // an undelivered wake still comes true. Every other reason carries its whole
+  // content in the payload — an idle nudge, the scanner's brief, a manual poke
+  // — and that payload is gone the moment nobody is subscribed. The managed-pod
+  // path below already draws this line (it replays a synthetic wake until the
+  // pod attaches, and returns false if it never does); these two early returns
+  // are the same wake taking a different exit, and they were reporting success
+  // for a brief that reached no one.
+  //
+  // The scanner is the caller that notices: on `false` it declines to spend the
+  // activity fingerprint, so the next pass re-evaluates once the daemon is back.
+  // On `true` it records "background scan wake queued", claims the fingerprint,
+  // and that scan is never offered again.
+  const durableWithoutDelivery = reason === 'message.new'
+
   // BYOA agents run on a user-paired Computer (the `cumora agent computer`
   // daemon), never a server-managed pod. If delivered === 0 the daemon
   // simply isn't subscribed right now (host offline / asleep) — there's
-  // nothing to spin up. The wake is durable via the inbox, so the daemon
-  // catches up on its next reconnect drain, same as a cold pod would.
-  // Skip the pod path entirely; do NOT ensurePod / wake-retry kubectl.
+  // nothing to spin up. Skip the pod path entirely; do NOT ensurePod /
+  // wake-retry kubectl.
   if (isByoaKind(host.kind)) {
-    console.log(`[scheduler] ${agentId} is BYOA (${host.kind}); daemon offline — wake deferred to reconnect`)
-    return true
+    console.log(`[scheduler] ${agentId} is BYOA (${host.kind}); daemon offline — ${
+      durableWithoutDelivery ? 'wake deferred to reconnect' : `${reason} wake not delivered`}`)
+    return durableWithoutDelivery
   }
 
   // Free tier is BYOA-only: it must NEVER spin a managed Cumora Cloud pod. A free
@@ -489,8 +505,9 @@ async function wakeOne(
   // leak; the polluted legacy data (cloud computers + managed engines) was cleaned
   // up separately. The wake stays durable in the inbox for whenever they pair.
   if (host.tier === 'free') {
-    console.log(`[scheduler] ${agentId} is free-tier (BYOA-only); no managed pod — wake deferred until paired`)
-    return true
+    console.log(`[scheduler] ${agentId} is free-tier (BYOA-only); no managed pod — ${
+      durableWithoutDelivery ? 'wake deferred until paired' : `${reason} wake not delivered`}`)
+    return durableWithoutDelivery
   }
 
   // Paid (pro/max) managed agent — spin up a Pod. The Pod will catch up on first


### PR DESCRIPTION
## The bug

`wakeOne` has two early returns for a runtime it cannot start — a BYOA daemon that is offline, and a free-tier agent with no paired computer. Both return `true`, on this reasoning:

> The wake is durable via the inbox, so the daemon catches up on its next reconnect drain, same as a cold pod would.

That is true for `message.new` and false for everything else. An idle nudge, a manual poke, and the background scanner's brief carry their whole content in the wake payload; the payload is a Redis publish, so it is gone the moment nobody is subscribed. There is no row to catch up on.

The same function already draws this line correctly, about 30 lines further down, on the managed-pod path:

```ts
// Message wakes are durable because the message is already in the inbox,
// and the pod's cold-start drain reads that source of truth. Synthetic
// idle/background wakes have no inbox row, so replay the wake briefly after
// the pod is created until its SSE stream attaches.
if (reason !== 'message.new') {
  … replay for 20s …
  console.warn(`… synthetic wake (${reason}) was not delivered after pod start`)
  return false
}
```

The two early returns are the same wake taking a different exit.

## Why it costs a scan

The background scanner is built on that return value, and says so:

```ts
if (woken === false) {
  // Budget exceeded or wake dropped — do not record or spend the fingerprint,
  // so the next pass can re-evaluate as intended.
  continue
}
precedentRemember(digest)
await claimScan(digest)
await recordScanWake(agent, fingerprint)
```

So for a BYOA agent whose laptop was asleep — the ordinary state of a BYOA agent, and free tier is BYOA-only — the pass claimed the activity fingerprint and wrote a log note saying the scan was queued, while nothing had been sent. The fingerprint is keyed on the message ids it covers, so that scan is never offered again: the next pass recomputes the same digest, finds it claimed, and skips.

Measured end to end against a real Postgres and Redis, no subscribers:

```
>>> wakeAgent('background_scan') with 0 subscribers returned: true
>>> agent_log rows: 1  [{"body":"background scan wake queued for Scanner", …}]
>>> after a SECOND pass: 1 row(s) — the brief is never re-sent
```

## The fix

Return `reason === 'message.new'` from both early returns, which is the criterion the managed path already uses, and say in the log line which of the two actually happened.

The scanner then does what it was written to do: leaves the fingerprint unspent, and the next pass delivers the scan once the daemon is back.

Only the scanner reads this boolean (`kanban-wake` fires and forgets; the retry worker and the message fan-out ignore it), so the change is confined to that path.

## Tests

New `server/src/__integration__/synthetic-wake-undelivered.test.ts`, against real Postgres + Redis with nothing subscribed:

- **an undelivered synthetic wake reports failure, an undelivered message wake does not** — `background_scan` → `false`, `idle` → `false`, and `message.new` → still `true`, because that one really is durable and every offline BYOA agent would otherwise start looking like a delivery failure.
- **the scanner keeps the scan for when the daemon is back** — after a pass with nobody listening, `agent_log` is empty; the next pass, with a runtime subscribed, delivers the scan and records it exactly once. Before the fix that second pass was a no-op.

Both are red before the change and green after. Also green: `tsc --noEmit`, `biome lint .`, all three `scripts/guard-*.mjs`, the existing `agent-scanner` and `agent-idle-agenda` suites, and the unit suite.
