### PR TITLE
fix(push): an agent opening a conversation must reach the phone too

### DIFF
--- a/server/src/__integration__/agent-reply-push.test.ts
+++ b/server/src/__integration__/agent-reply-push.test.ts
@@ -27,6 +27,8 @@ import assert from 'node:assert/strict'
 import { pool } from '../db/pool.js'
 import { ensureSchemaOnce, resetAllTables, seedCompanyWithAgent, teardownAll } from './_helpers.js'
 import { runCli } from '../agents/cli.js'
+import { startPrivateChat } from '../agents/private_chat.js'
+import { startPulledGroup } from '../agents/scanner_helper.js'
 import { __setNotifyHookForTesting } from '../push.js'
 
 interface Captured {
@@ -142,4 +144,73 @@ test('[integration] a muted conversation is still muted', async () => {
 
   const withRecipients = sent.filter((s) => s.recipientUserIds.length > 0)
   assert.equal(withRecipients.length, 0, 'pushed into a muted conversation')
+})
+
+// ─── an agent can also START the conversation ───────────────────────────────
+//
+// A reply lands in a thread the human already knows about. The `dm_with` and
+// `pull_group` tools open a brand-new one, so their opening line is the message
+// a human has the least other way to discover — and both wrote the row and
+// enqueued the broadcast without ever dispatching a push. In-app they toast
+// like anything else (NotificationToasts skips only system rows); the phone was
+// the one surface that stayed quiet, which is the same asymmetry the reply
+// fix above was about.
+
+test('[integration] an agent opening a DM reaches the phone', async () => {
+  const { companyId, agentId } = await seedCompanyWithAgent()
+  const humanId = 'u-dm-target'
+  await seedOfflineHuman(companyId, humanId)
+
+  const { messageId } = await startPrivateChat({
+    instigatorId: agentId,
+    partnerId: humanId,
+    topic: 'the migration window',
+    opening: 'I need ten minutes on the migration window before Friday.',
+  })
+  await new Promise((r) => setTimeout(r, 150))
+
+  assert.equal(sent.length, 1, 'an agent-opened DM produced no push')
+  assert.deepEqual(sent[0].recipientUserIds, [humanId])
+  assert.match(sent[0].body, /migration window/)
+  assert.equal(sent[0].authorName, `Agent ${agentId}`, 'pushed with a raw agent id as the title')
+  assert.ok(messageId)
+})
+
+test('[integration] an agent pulling a group reaches the phone', async () => {
+  // A pull exists to interrupt someone — there is a six-hour cooldown on it for
+  // that reason — so it reaching every surface except the phone was backwards.
+  const { companyId, agentId } = await seedCompanyWithAgent()
+  const humanId = 'u-pulled'
+  await seedOfflineHuman(companyId, humanId)
+
+  await startPulledGroup({
+    instigatorId: agentId,
+    title: 'Friday migration',
+    members: [humanId],
+    reason: 'two teams are about to touch the same table',
+    opening: 'Pulling you in: two teams are about to touch the same table.',
+  })
+  await new Promise((r) => setTimeout(r, 150))
+
+  assert.equal(sent.length, 1, 'an agent-pulled group produced no push')
+  assert.deepEqual(sent[0].recipientUserIds, [humanId])
+  assert.match(sent[0].body, /same table/)
+})
+
+test('[integration] an agent-only conversation still pushes to nobody', async () => {
+  // The guard rail: this must not become "push on every agent write". Recipients
+  // are computed by joining `users`, and agents have no row there.
+  const { companyId, agentId } = await seedCompanyWithAgent()
+  const { agentId: peerId } = await seedCompanyWithAgent({ companyId })
+
+  await startPrivateChat({
+    instigatorId: agentId, partnerId: peerId, topic: 'handoff', opening: 'taking the deploy',
+  })
+  await startPulledGroup({
+    instigatorId: agentId, members: [peerId], title: 'deploy', reason: 'handoff', opening: 'ditto',
+  })
+  await new Promise((r) => setTimeout(r, 150))
+
+  const withRecipients = sent.filter((s) => s.recipientUserIds.length > 0)
+  assert.deepEqual(withRecipients, [], 'pushed for a conversation with no humans in it')
 })

--- a/server/src/agents/private_chat.ts
+++ b/server/src/agents/private_chat.ts
@@ -13,6 +13,7 @@ import { randomUUID } from 'node:crypto'
 import type { PoolClient } from 'pg'
 import { pool } from '../db/pool.js'
 import { CH_MESSAGE_NEW } from '../redis.js'
+import { dispatchMessagePush } from '../push.js'
 import { enqueueBroadcast, nudgeRealtimeOutbox } from '../realtime-outbox.js'
 
 /** Find an existing direct conversation between two participants, or
@@ -235,6 +236,17 @@ export async function startPrivateChat(args: {
   } finally {
     client.release()
   }
+
+  // #199 gave `cumora reply` the push it was missing, but an agent can also
+  // START a conversation, and this opening line is the one a human has the
+  // least other way to learn about: a brand-new thread they were not looking
+  // at, whose first message is authored by an agent. In-app it toasts like any
+  // other — NotificationToasts skips only system rows — so the phone was the
+  // one surface that stayed quiet. Fire-and-forget after COMMIT, for the same
+  // reason the other two dispatches are: a push must never hold up the write.
+  // A DM between two agents pushes to nobody on its own, because
+  // computeMessageRecipients joins `users`.
+  void dispatchMessagePush({ conversationId, authorId: instigatorId, messageId, body: opening, companyId })
 
   return { conversationId, messageId }
 }

--- a/server/src/agents/scanner_helper.ts
+++ b/server/src/agents/scanner_helper.ts
@@ -1,6 +1,7 @@
 /** Helper for tool-driven group pulls (separate from the periodic scanner). */
 import { randomUUID } from 'node:crypto'
 import { pool } from '../db/pool.js'
+import { dispatchMessagePush } from '../push.js'
 import { CH_GROUP_PULLED, CH_MESSAGE_NEW, publish } from '../redis.js'
 
 /** Hours an agent must wait between human-interrupting group pulls. */
@@ -142,6 +143,13 @@ export async function startPulledGroup(args: {
   }).catch((error) => {
     console.warn(`[pull_group] durable message ${messageId} committed but publish failed`, error)
   })
+
+  // The point of a pull is to interrupt someone — there is a six-hour cooldown
+  // on it for exactly that reason. Yet the interruption reached the websocket
+  // and the desktop toast and no phone, the same gap #199 closed for `cumora
+  // reply`. An agent-only pull pushes to nobody on its own, because
+  // computeMessageRecipients joins `users`.
+  void dispatchMessagePush({ conversationId, authorId: instigatorId, messageId, body: opening, companyId })
 
   console.log(`[pull_group] ${instigatorId} pulled ${conversationId}: ${title}`)
   return { conversationId }


### PR DESCRIPTION
Follow-on to #199, which gave `cumora reply` the push dispatch it was missing. Two more agent-authored writes never had it either — and unlike a reply, both of them **open a conversation that did not exist a second ago**.

## The gap

`dispatchMessagePush` has exactly two callers: `POST /conversations/:id/messages` and `cmdReply`. But an agent can also start a thread, through two of its own tools:

| tool | writer | kind | pushes |
|---|---|---|---|
| `dm_with` | `startPrivateChat` (`agents/private_chat.ts`) | `text` | no |
| `pull_group` | `startPulledGroup` (`agents/scanner_helper.ts`) | `text` | no |

Both commit the row and enqueue the same `message.new` broadcast that `cmdReply` does, and then stop. So the human's desktop toasts — `NotificationToasts` fires on any `message.new` that is not theirs and not a system row — and the phone stays silent. The same desktop/phone asymmetry #199 was about, in the two paths #199 did not touch.

An opening line is the worst message to drop. A reply lands in a thread the recipient already knows about and will see when they next open the app; the first message of a brand-new conversation is the one they have no other way to discover. And a pull exists *specifically* to interrupt someone — there is a six-hour per-agent cooldown on it for that reason — so reaching every surface except the phone was backwards.

`startPrivateChat` is not agent-to-agent only, despite what the tool's copy suggests: it validates `kind IN ('agent','human')` and carries a whole `users`/`company_members` existence branch for the human case. `pull_group`'s comment likewise says humans in `members[]` are a normal choice ("Do NOT auto-add a human — agents ... can pull true agent-only groups").

I checked every other `INSERT INTO messages` in the server. The rest are correct as they stand: `membership.ts`, `calendar.ts` and `inproc-client.ts` write `kind='system'`, which the in-app surface skips too, and `ws.ts`'s doc-mention row is addressed to an agent with the only human being its own author.

## The fix

One fire-and-forget `dispatchMessagePush` after `COMMIT` in each, matching how the other two callers do it — the row is durable first, and a push never holds up the write.

Recipients need no new filtering: `computeMessageRecipients` joins `users`, so an agent-to-agent DM or an agent-only pull pushes to nobody on its own, and the mute / "currently looking at the app" filters apply unchanged.

## Tests

Three added to the existing `agent-reply-push.test.ts`, which already owns this contract and its seed helpers:

- **an agent opening a DM reaches the phone** — recipient is the offline human, body is the opening line, and the title is the agent's name rather than its raw id (agents have no `users` row)
- **an agent pulling a group reaches the phone**
- **an agent-only conversation still pushes to nobody** — the guard rail against this becoming "push on every agent write"

The first two are red before the change; the third passes either way, on purpose:

```
without the fix:
  ok 1-4   (the existing reply tests)
  not ok 5 - an agent opening a DM reaches the phone
  not ok 6 - an agent pulling a group reaches the phone
  ok 7     - an agent-only conversation still pushes to nobody
  # pass 5  # fail 2

with the fix:  # pass 7  # fail 0
```

Also green: `tsc --noEmit`, `biome lint .`, all three `scripts/guard-*.mjs`, the `agent-tools` and `conversations` integration suites, and the unit suite.
