### PR TITLE
docs(db-gc): the sweep indexes are load-bearing, and the header said otherwise

### DIFF
--- a/server/src/__integration__/db-gc-sweep-index.test.ts
+++ b/server/src/__integration__/db-gc-sweep-index.test.ts
@@ -1,0 +1,91 @@
+/**
+ * The GC sweep's indexes are load-bearing, and nothing said so.
+ *
+ * Each batch selects victims with `WHERE timeCol < … ORDER BY timeCol ASC
+ * LIMIT n` — time alone, no leading-column predicate — so the composite
+ * (agent_id, created_at) indexes cannot serve it. Only a bare index on the time
+ * column can. Three of them are annotated `-- db-gc sweep` in migrate.ts and
+ * have no other reader, which is exactly what makes them look droppable.
+ *
+ * Measured on 300k rows of agent_log, the same batch:
+ *
+ *   with idx_agent_log_created:  Index Scan,          15 buffers
+ *   without it:                  Seq Scan + Sort,   2244 buffers
+ *
+ * On the 31GB table this GC was written for, that is the difference between a
+ * batch and the 55s timeout — the incident `deleteBatch` documents.
+ *
+ * Scope, precisely: the three declarations that exist today are already
+ * immutable — they live in migration 1, and the manifest's checksum refuses any
+ * edit to applied history (verified: deleting one fails with "migration 1
+ * source checksum changed" before this test even runs). What is NOT protected
+ * is the next sweep target. `targets()` is read from db-gc itself, so adding a
+ * table there without adding its index turns this red immediately, naming the
+ * table and what it will cost:
+ *
+ *   messages has no bare index on created_at — the GC sweep falls back to a
+ *   seq scan + sort of the whole table and will blow its 55s timeout as the
+ *   table grows, deleting nothing.
+ */
+import { test, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { pool } from '../db/pool.js'
+import { ensureSchemaOnce, teardownAll } from './_helpers.js'
+import { targets } from '../db-gc.js'
+
+before(async () => { await ensureSchemaOnce() })
+after(async () => { await teardownAll() })
+
+/** Bare = one column, that column, no partial predicate, valid. A partial
+ *  index does not serve a sweep that must reach every expired row. */
+async function bareTimeIndexes(table: string, column: string): Promise<string[]> {
+  const { rows } = await pool.query<{ name: string }>(
+    `SELECT i.indexrelid::regclass::text AS name
+       FROM pg_index i
+       JOIN pg_class c ON c.oid = i.indrelid
+       JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = current_schema()
+        AND c.relname = $1
+        AND i.indnatts = 1
+        AND i.indisvalid
+        AND i.indpred IS NULL
+        AND pg_get_indexdef(i.indexrelid) LIKE '%(' || $2 || ')'`,
+    [table, column],
+  )
+  return rows.map((r) => r.name)
+}
+
+test('[integration] every db-gc sweep target keeps a bare index on its time column', async () => {
+  const sweeps = targets()
+  assert.ok(sweeps.length > 0, 'db-gc has no sweep targets')
+
+  for (const t of sweeps) {
+    const found = await bareTimeIndexes(t.table, t.timeCol)
+    assert.ok(
+      found.length > 0,
+      `${t.table} has no bare index on ${t.timeCol} — the GC sweep falls back to a seq scan + sort of the whole table and will blow its 55s timeout as the table grows, deleting nothing. Composite indexes do not help: the sweep filters and orders on ${t.timeCol} alone.`,
+    )
+  }
+})
+
+test('[integration] the sweep query is the one the index is for', async () => {
+  // Pin the shape too. An index on the time column is only useful while the
+  // sweep still filters and orders on that column and nothing else; a future
+  // `ORDER BY id` or an added predicate would silently strip the plan back to
+  // a sort, and the index check above would keep passing.
+  const { readFile } = await import('node:fs/promises')
+  const source = await readFile(new URL('../db-gc.ts', import.meta.url), 'utf8')
+  const fn = source.slice(source.indexOf('async function deleteBatch'))
+  const body = fn.slice(0, fn.indexOf('\n}\n') + 2)
+
+  assert.match(body, /WHERE \$\{t\.timeCol\} </, 'the sweep no longer filters on the time column')
+  assert.match(body, /ORDER BY \$\{t\.timeCol\} ASC/, 'the sweep no longer orders by the time column')
+})
+
+test('[integration] a composite index alone would not satisfy the check', async () => {
+  // The guard has to be able to fail. agent_log carries both shapes, so ask for
+  // the composite's leading column: no BARE index exists on agent_id, and that
+  // is precisely the case the sweep cannot use.
+  assert.deepEqual(await bareTimeIndexes('agent_log', 'agent_id'), [])
+  assert.ok((await bareTimeIndexes('agent_log', 'created_at')).length > 0)
+})

--- a/server/src/db-gc.ts
+++ b/server/src/db-gc.ts
@@ -14,13 +14,24 @@
  * forever), so old rows are pure dead weight.
  *
  * Strategy: a periodic sweep deletes rows past a per-table retention
- * window, in small ctid batches so locks stay short and vacuums keep up.
- * These tables have no standalone index on their time column (only
- * composite (agent_id, created_at) style), so batches select victims by
- * partial seq scan — cheap in practice because old rows cluster at the
- * heap's start on append-mostly tables. Each batch runs under its own
- * statement_timeout so a pathological scan can't wedge the worker; a
- * timed-out batch just retries next tick.
+ * window, in small batches so locks stay short and vacuums keep up. Each
+ * batch runs under its own statement_timeout so a pathological scan can't
+ * wedge the worker; a timed-out batch just retries next tick.
+ *
+ * Every sweep target carries a BARE index on its time column — the ones
+ * named `-- db-gc sweep` in migrate.ts exist for no other reader. The
+ * composite (agent_id, created_at) indexes cannot serve this query: it
+ * filters and orders on time alone, with no leading-column predicate.
+ * Measured on 300k rows of agent_log, the same batch:
+ *
+ *   with idx_agent_log_created:  Index Scan,          15 buffers
+ *   without it:                  Seq Scan + Sort,   2244 buffers
+ *
+ * and that gap grows with the table. On the 31GB agent_log this GC was
+ * written for it is the difference between a batch and the 55s timeout —
+ * see the note on deleteBatch, which is the incident this comes from. So
+ * these indexes are load-bearing rather than incidental, and
+ * `db-gc-sweep-index.test.ts` fails if one goes missing.
  *
  * Deleting agent_runs cascades to its remaining agent_events (FK ON
  * DELETE CASCADE); agent_events is swept first with the same window so
@@ -38,7 +49,7 @@ import { pool } from './db/pool.js'
 import { env } from './env.js'
 import { inc } from './metrics.js'
 
-interface SweepTarget {
+export interface SweepTarget {
   table: string
   /** Primary-key column used to address the delete batch. */
   pkCol: string
@@ -48,7 +59,7 @@ interface SweepTarget {
   days: number
 }
 
-function targets(): SweepTarget[] {
+export function targets(): SweepTarget[] {
   return [
     // ws_tickets keys off expires_at: a ticket is garbage once expired,
     // the extra day is just diagnostic slack.


### PR DESCRIPTION
## What is wrong

`db-gc.ts`'s module header explains the sweep's plan:

> These tables have **no standalone index on their time column** (only composite `(agent_id, created_at)` style), so batches select victims by **partial seq scan — cheap in practice** because old rows cluster at the heap's start on append-mostly tables.

Every clause of that is now false.

All five sweep targets carry a bare index on their time column, and three are annotated in `migrate.ts` for this exact reader:

```sql
CREATE INDEX IF NOT EXISTS idx_agent_events_created ON agent_events(created_at);  -- db-gc sweep
CREATE INDEX IF NOT EXISTS idx_agent_runs_started   ON agent_runs(started_at);    -- db-gc sweep
CREATE INDEX IF NOT EXISTS idx_llm_calls_created    ON llm_calls(created_at);     -- db-gc sweep
```

And the plan it calls "cheap in practice" is the one the comment on `deleteBatch`, thirty lines below, says "blew the 55s timeout every tick and deleted nothing".

Measured on 300k rows of `agent_log`, the same batch the sweep issues:

```
with idx_agent_log_created:   Limit → Index Scan using idx_agent_log_created
                              Buffers: shared hit=15        cost 45

without it:                   Limit → Gather Merge → Sort → Parallel Seq Scan
                              Buffers: shared hit=2244      cost 14700
```

150× the buffers at 300k rows, and the gap grows with the table. On the 31 GB `agent_log` this GC was written for, that is the difference between a batch and the timeout.

So the header does not merely describe the wrong plan. It tells the next reader that three indexes with no other reader are unnecessary — and that dropping them would be fine.

## What this changes

The header now says what is true, carries the measurement, and says the indexes are load-bearing. Plus a test that keeps it that way.

**The scope of that test, stated precisely**, because I checked how far it actually reaches: the three declarations that exist today are already immutable. They live in migration 1, and the manifest's checksum refuses any edit to applied history — deleting one fails with `migration 1 source checksum changed` before this test even runs. I verified that rather than assuming it.

What the checksum does **not** protect is the *next* sweep target. `targets()` is read from `db-gc` itself, so adding a table there without adding its index turns the test red the moment it is added:

```
not ok 1 - every db-gc sweep target keeps a bare index on its time column
  messages has no bare index on created_at — the GC sweep falls back to a
  seq scan + sort of the whole table and will blow its 55s timeout as the
  table grows, deleting nothing. Composite indexes do not help: the sweep
  filters and orders on created_at alone.
```

(Demonstrated by adding `messages` as a sweep target; `messages`, `conversations`, `documents` and `agent_tasks` all lack a bare `created_at` index today, so this is a live foot-gun and not a hypothetical.)

Three tests:

1. **every db-gc sweep target keeps a bare index on its time column** — bare meaning single-column, that column, not partial, valid. A partial index does not serve a sweep that must reach every expired row.
2. **the sweep query is the one the index is for** — an index on the time column only helps while the sweep still filters *and* orders on that column alone. A future `ORDER BY id` would silently strip the plan back to a sort while check 1 kept passing.
3. **a composite index alone would not satisfy the check** — asks for a bare index on `agent_log(agent_id)`, the composite's leading column, which has none. This is the test that proves the assertion can fail at all, so check 1 is not a test that cannot fail.

`targets()` and `SweepTarget` become exported so the test reads the real list rather than a copy of it.

Green: `tsc --noEmit`, `biome lint .`, all three `scripts/guard-*.mjs`, `schema-migrations.test.ts`, and the unit suite (1226 tests, 0 failures).
