### PR TITLE
fix(email): a Bcc'd agent is delivered to, not bounced

### DIFF
--- a/server/src/__integration__/inbound.test.ts
+++ b/server/src/__integration__/inbound.test.ts
@@ -469,3 +469,90 @@ test('[integration] cleans up newly created conversation if message persistence 
   )
   assert.equal(remaining.length, 0, 'empty conversation should be cleaned up')
 })
+
+// ─── the envelope recipient ────────────────────────────────────────────────
+//
+// The gate admits a message on `recipientAccepted(message.to, …)` — the
+// ENVELOPE recipient, the address SMTP actually delivered to — and then used to
+// forward every field except that one. Whenever the agent is Bcc'd, or reached
+// through an alias, a list expansion or a forwarding rule, its address is in no
+// header, so matching on To/Cc alone resolved nobody: a 404 here, `setReject`
+// in the gate, and a permanent SMTP 550 telling the sender the address does not
+// exist — for mail the gate had already confirmed was addressed to us.
+
+test('[integration] a Bcc\'d agent is delivered to, not bounced', async () => {
+  const { agentId, agentEmail } = await seedCompanyWithAgent()
+
+  const smtpId = `bcc-${randomUUID()}@external.com`
+  const r = await postInbound({
+    messageId: smtpId,
+    from: 'alice@external.com',
+    // The visible header names someone else entirely — that is what Bcc means.
+    to: ['bob@external.com'],
+    envelopeTo: agentEmail,
+    subject: 'quietly looping you in',
+    text: 'no header carries your address',
+  })
+
+  assert.equal(r.status, 200, `a Bcc'd agent was bounced: ${JSON.stringify(r.body)}`)
+  assert.equal(r.body.deliveries.length, 1)
+  // …and it reached the agent's own thread, not merely "some 200".
+  const { rows } = await pool.query<{ members: string[] }>(
+    `SELECT c.members FROM email_messages e
+       JOIN conversations c ON c.id = e.conversation_id
+      WHERE e.smtp_message_id = $1`,
+    [smtpId],
+  )
+  assert.equal(rows.length, 1, 'no inbound email row was written')
+  assert.ok(rows[0].members.includes(agentId), `the thread does not include the Bcc'd agent: ${JSON.stringify(rows[0].members)}`)
+})
+
+test('[integration] the envelope recipient does not duplicate a visible one', async () => {
+  // The ordinary case: the agent is in To AND is the envelope recipient. It
+  // must resolve once, not twice.
+  const { agentEmail } = await seedCompanyWithAgent()
+
+  const r = await postInbound({
+    messageId: `plain-${randomUUID()}@external.com`,
+    from: 'alice@external.com',
+    to: [`Agent <${agentEmail.toUpperCase()}>`],
+    envelopeTo: agentEmail,
+    subject: 'hello',
+    text: 'body',
+  })
+
+  assert.equal(r.status, 200)
+  const { rows } = await pool.query<{ n: number }>(
+    `SELECT count(*)::int AS n FROM email_messages`,
+  )
+  assert.equal(rows[0].n, 1, 'the same recipient resolved twice')
+})
+
+test('[integration] an envelope recipient that is nobody still bounces', async () => {
+  // The 404 must survive for genuinely unknown addresses, or the gate loses the
+  // signal it uses to send a real 550.
+  await seedCompanyWithAgent()
+  const r = await postInbound({
+    messageId: `nobody-${randomUUID()}@external.com`,
+    from: 'alice@external.com',
+    to: ['bob@external.com'],
+    envelopeTo: 'ghost@cumora.local',
+    subject: 'hello',
+    text: 'body',
+  })
+  assert.equal(r.status, 404)
+})
+
+test('[integration] a gate that predates the field still works', async () => {
+  // envelopeTo is optional: the worker and the server deploy independently, so
+  // a payload without it must behave exactly as before.
+  const { agentEmail } = await seedCompanyWithAgent()
+  const r = await postInbound({
+    messageId: `old-${randomUUID()}@external.com`,
+    from: 'alice@external.com',
+    to: [agentEmail],
+    subject: 'hello',
+    text: 'body',
+  })
+  assert.equal(r.status, 200)
+})

--- a/server/src/api/inbound-email.ts
+++ b/server/src/api/inbound-email.ts
@@ -103,6 +103,10 @@ interface InboundPayload {
   references?: string[] | null
   /** Each address is a "Name <addr@host>" or just "addr@host" string. */
   from: string
+  /** The envelope recipient — the address SMTP actually delivered to, which
+   *  the gate already checked is one of ours before admitting the message.
+   *  Optional so a gate deployed before this field still works. */
+  envelopeTo?: string | null
   to?: string[]
   cc?: string[]
   subject?: string
@@ -265,7 +269,14 @@ inboundEmailRouter.post('/inbound', async (req: Request, res: Response) => {
     res.status(400).json({ error: `unparseable from: ${payload.from}` })
     return
   }
-  const rawRecipients = [...(payload.to ?? []), ...(payload.cc ?? [])]
+  // The envelope recipient belongs in this set, not just the headers. A Bcc'd
+  // agent appears in no header at all; so does one reached through an alias, a
+  // list expansion or a forwarding rule. Matching on To/Cc alone resolved
+  // nobody for those, which is a 404 here and `setReject` in the gate — a
+  // permanent 550 telling the sender the address does not exist, for mail the
+  // gate had already confirmed was addressed to us. Dedup below folds it away
+  // in the ordinary case where it is also in To.
+  const rawRecipients = [...(payload.to ?? []), ...(payload.cc ?? []), ...(payload.envelopeTo ? [payload.envelopeTo] : [])]
     .map((s) => parseAddress(s))
     .filter((x): x is { addr: string; name: string | null } => Boolean(x))
   if (rawRecipients.length === 0) {

--- a/workers/email-gate/src/index.test.ts
+++ b/workers/email-gate/src/index.test.ts
@@ -193,43 +193,6 @@ test('email handler throws on upstream 5xx error (triggering SMTP tempfail)', as
   }
 })
 
-test('email handler rejects with 550 bounce on 404 no recipient', async () => {
-  const { message, rejected } = createFakeMessage()
-  const originalFetch = globalThis.fetch
-  globalThis.fetch = async () => new Response('Not Found', { status: 404 })
-  try {
-    await worker.email(message, fakeEnv, fakeCtx)
-    assert.deepEqual(rejected, ['No such recipient'])
-  } finally {
-    globalThis.fetch = originalFetch
-  }
-})
-
-test('email handler rejects with 550 bounce on 4xx client errors', async () => {
-  const { message, rejected } = createFakeMessage()
-  const originalFetch = globalThis.fetch
-  globalThis.fetch = async () => new Response('Bad Request', { status: 400 })
-  try {
-    await worker.email(message, fakeEnv, fakeCtx)
-    assert.deepEqual(rejected, ['Upstream 400'])
-  } finally {
-    globalThis.fetch = originalFetch
-  }
-})
-
-test('email handler accepts email on 200 response without setReject', async () => {
-  const { message, rejected } = createFakeMessage()
-  const originalFetch = globalThis.fetch
-  globalThis.fetch = async () => new Response('OK', { status: 200 })
-  try {
-    await worker.email(message, fakeEnv, fakeCtx)
-    assert.deepEqual(rejected, [])
-  } finally {
-    globalThis.fetch = originalFetch
-  }
-})
-
-
 /* ===================== the envelope recipient is forwarded ================= */
 
 test('email handler forwards the envelope recipient it admitted the message on', async () => {
@@ -269,4 +232,40 @@ test('email handler forwards the envelope recipient it admitted the message on',
   )
   // The visible header is still reported as-is; envelopeTo is additive.
   assert.deepEqual((posted as { to?: string[] }).to, ['bob@example.com'])
+})
+
+test('email handler rejects with 550 bounce on 404 no recipient', async () => {
+  const { message, rejected } = createFakeMessage()
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = async () => new Response('Not Found', { status: 404 })
+  try {
+    await worker.email(message, fakeEnv, fakeCtx)
+    assert.deepEqual(rejected, ['No such recipient'])
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test('email handler rejects with 550 bounce on 4xx client errors', async () => {
+  const { message, rejected } = createFakeMessage()
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = async () => new Response('Bad Request', { status: 400 })
+  try {
+    await worker.email(message, fakeEnv, fakeCtx)
+    assert.deepEqual(rejected, ['Upstream 400'])
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test('email handler accepts email on 200 response without setReject', async () => {
+  const { message, rejected } = createFakeMessage()
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = async () => new Response('OK', { status: 200 })
+  try {
+    await worker.email(message, fakeEnv, fakeCtx)
+    assert.deepEqual(rejected, [])
+  } finally {
+    globalThis.fetch = originalFetch
+  }
 })

--- a/workers/email-gate/src/index.test.ts
+++ b/workers/email-gate/src/index.test.ts
@@ -269,3 +269,4 @@ test('email handler accepts email on 200 response without setReject', async () =
     globalThis.fetch = originalFetch
   }
 })
+

--- a/workers/email-gate/src/index.test.ts
+++ b/workers/email-gate/src/index.test.ts
@@ -229,3 +229,44 @@ test('email handler accepts email on 200 response without setReject', async () =
   }
 })
 
+
+/* ===================== the envelope recipient is forwarded ================= */
+
+test('email handler forwards the envelope recipient it admitted the message on', async () => {
+  // The handler gates on recipientAccepted(message.to) — the ENVELOPE
+  // recipient — and then forwarded every field except that one. Whenever the
+  // agent is Bcc'd or reached via an alias, a list expansion or a forwarding
+  // rule, its address is in no header, so the server resolved nobody and
+  // answered 404, which this handler turns into a permanent SMTP 550.
+  const rejected: string[] = []
+  const message = {
+    // Delivered to the agent; the visible header names someone else.
+    to: 'agent@cumora.ai',
+    from: 'alice@example.com',
+    raw: new Response(
+      'From: alice@example.com\r\nTo: bob@example.com\r\nSubject: Test\r\nMessage-ID: <msg-2@example.com>\r\n\r\nHello',
+    ).body!,
+    setReject: (reason: string) => { rejected.push(reason) },
+  } as unknown as Parameters<typeof worker.email>[0]
+
+  let posted: Record<string, unknown> | null = null
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = async (_url, init) => {
+    posted = JSON.parse(String((init as RequestInit).body))
+    return new Response('ok', { status: 200 })
+  }
+  try {
+    await worker.email(message, fakeEnv, fakeCtx)
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+
+  assert.deepEqual(rejected, [])
+  assert.ok(posted, 'nothing was posted upstream')
+  assert.equal(
+    (posted as { envelopeTo?: string }).envelopeTo, 'agent@cumora.ai',
+    'the address the handler admitted this message on was not forwarded — a Bcc\'d agent resolves to nobody and gets a 550',
+  )
+  // The visible header is still reported as-is; envelopeTo is additive.
+  assert.deepEqual((posted as { to?: string[] }).to, ['bob@example.com'])
+})

--- a/workers/email-gate/src/index.ts
+++ b/workers/email-gate/src/index.ts
@@ -42,6 +42,7 @@ interface InboundAttachment {
 
 interface InboundPayload {
   messageId: string
+  envelopeTo: string
   inReplyTo: string | null
   references: string[]
   from: string
@@ -196,6 +197,12 @@ export default {
       // To / Cc — postal-mime returns Address[]. Fall back to the envelope
       // recipient if the header is missing (rare but happens).
       to: (parsed.to ?? []).map(fmtAddress).filter(Boolean),
+      // The address SMTP actually delivered to, and the one this worker
+      // admitted the message on two dozen lines up. It is absent from the
+      // headers whenever the agent was Bcc'd or reached through an alias or a
+      // forwarding rule, and then it is the ONLY thing identifying the
+      // recipient — so send it always, not just when To: happens to be empty.
+      envelopeTo: message.to,
       cc: (parsed.cc ?? []).map(fmtAddress).filter(Boolean),
       subject: parsed.subject ?? '',
       text: (parsed.text ?? '').trim(),


### PR DESCRIPTION
## The bug

The gate admits a message on the **envelope** recipient — the address SMTP actually delivered to:

```js
async email(message, env, ctx) {
  if (!recipientAccepted(message.to, env)) {
    message.setReject('Recipient domain not served')
    return
  }
```

…and then forwards every field except that one. `message.to` reached the server in exactly one case:

```js
if (payload.to.length === 0) payload.to = [message.to]   // "rare but happens"
```

But the `To:` header is present *and points at someone else* whenever the agent was **Bcc'd**, or reached through an **alias**, a **list expansion**, or a **forwarding rule**. The server builds its recipient set from `To` + `Cc` alone:

```ts
const rawRecipients = [...(payload.to ?? []), ...(payload.cc ?? [])]
```

so for all of those it resolves nobody and answers 404 — which the gate turns into:

```js
if (res.status === 404) {
  // Server says no agent matches this recipient — permanent rejection (SMTP 550 bounce).
  message.setReject('No such recipient')
```

A **permanent 550**, telling the sender the address does not exist — for mail the gate had already confirmed was addressed to us. That is worse than a silent drop: the sending MTA stops retrying and reports to a human that the agent has no mailbox.

## The fix

Forward the envelope recipient as its own field, and include it in the recipient set.

- **De-duplication is already there.** Recipients are deduped by lowercased address, so in the ordinary case where the agent is both in `To:` and the envelope recipient, it resolves once. A test pins that.
- **`envelopeTo` is optional server-side.** The worker and the server deploy independently, so a gate built before this field must keep working unchanged. A test pins that too.
- **The 404 still fires** for a genuinely unknown envelope recipient — otherwise the gate loses the signal it uses to send a real bounce. Pinned.
- **The visible `To:`/`Cc:` are untouched.** `envelopeTo` is additive, not a header rewrite, so what the app displays does not change.

On whether this could over-deliver: the envelope recipient is, by definition, an address the mail was routed to, and the gate has already checked it is in a served domain. Adding it can only resolve a recipient that should have resolved.

## Tests

**Server** — four added to `inbound.test.ts`:

- **a Bcc'd agent is delivered to, not bounced** — `To: bob@external.com`, `envelopeTo: <agent>`; asserts 200, one delivery, and that the thread actually contains the agent rather than merely "some 200"
- **the envelope recipient does not duplicate a visible one** — agent in `To:` (upper-cased) *and* as envelope recipient → exactly one row
- **an envelope recipient that is nobody still bounces** — 404 preserved
- **a gate that predates the field still works** — no `envelopeTo` at all

**Worker** — one added to `index.test.ts`:

- **forwards the envelope recipient it admitted the message on** — stubs `fetch`, reads the posted body, asserts `envelopeTo` is the delivered-to address while `to` still reports the visible header verbatim

Only the first server test and the worker test are red before the change; the other three pass either way, on purpose — they are the guard rails around de-duplication, the surviving bounce, and backward compatibility.

```
server, without the fix:  not ok 17 - a Bcc'd agent is delivered to, not bounced
                          # pass 19  # fail 1
server, with the fix:     # pass 20  # fail 0

worker, without the fix:  not ok 22 - email handler forwards the envelope recipient …
                            the address the handler admitted this message on was not
                            forwarded — a Bcc'd agent resolves to nobody and gets a 550
worker, with the fix:     # pass 22  # fail 0
```

Also green: `tsc --noEmit` for both the server and the worker, `biome lint .`, all three `scripts/guard-*.mjs`, and the unit suite (1227 tests, 0 failures).
