### PR TITLE
fix(email): the SES echo dedup only ever worked for one recipient

### DIFF
--- a/server/src/__integration__/inbound-echo-multi-recipient.test.ts
+++ b/server/src/__integration__/inbound-echo-multi-recipient.test.ts
@@ -1,0 +1,137 @@
+/**
+ * The SES echo dedup has to work for more than one recipient.
+ *
+ * SES rewrites Message-ID on the wire, so mail we send to a cumora-domain
+ * address boomerangs back through the gate carrying an id we never minted. The
+ * id-based dedup misses it, and a second pass matches on (from, to, subject)
+ * within ten minutes instead.
+ *
+ * That pass compared `LOWER(to_addrs::text) = LOWER($3)` — jsonb rendered as
+ * text against `JSON.stringify`. Postgres puts a space after every comma and
+ * JSON.stringify does not, so the two renderings coincide for exactly one
+ * recipient:
+ *
+ *   1 recipient   jsonb::text ["a@x.com"]              stringify ["a@x.com"]
+ *   2 recipients  jsonb::text ["a@x.com", "b@x.com"]   stringify ["a@x.com","b@x.com"]
+ *
+ * The existing boomerang test in inbound.test.ts sends to one address, which is
+ * why it passed. Every boomerang of a mail sent to two or more — an agent and a
+ * human, two agents, anyone Cc'd — fell through and created a fresh
+ * conversation containing our own outbound message.
+ */
+import { test, before, beforeEach, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { randomUUID } from 'node:crypto'
+import { createServer, type Server } from 'node:http'
+import {
+  buildTestApp, ensureSchemaOnce, resetAllTables, seedCompanyWithAgent,
+  signInboundPayload, teardownAll,
+} from './_helpers.js'
+import { pool } from '../db/pool.js'
+
+let server: Server
+let baseUrl = ''
+
+before(async () => {
+  await ensureSchemaOnce()
+  const app = await buildTestApp()
+  await new Promise<void>((resolve) => {
+    server = createServer(app).listen(0, () => {
+      const addr = server.address()
+      if (addr && typeof addr === 'object') baseUrl = `http://127.0.0.1:${addr.port}`
+      resolve()
+    })
+  })
+})
+beforeEach(async () => { await resetAllTables() })
+after(async () => { await teardownAll(server) })
+
+async function postInbound(body: unknown): Promise<{ status: number; body: any }> {
+  const raw = JSON.stringify(body)
+  const res = await fetch(`${baseUrl}/webhooks/email/inbound`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-cumora-signature': signInboundPayload(raw) },
+    body: raw,
+  })
+  const text = await res.text()
+  try { return { status: res.status, body: JSON.parse(text) } } catch { return { status: res.status, body: text } }
+}
+
+/** Seed the outbound row compose would have written, then fire the boomerang
+ *  SES sends back: same from/to/subject, an id we never minted.
+ *
+ *  `extra` are the additional recipients beside the agent. The agent's own
+ *  address has to be in the set or the request is refused for having no known
+ *  recipient long before the echo pass runs — which is also why a
+ *  single-recipient boomerang was the only shape anyone tested. */
+async function sendThenBoomerang(
+  extra: string[],
+  reorder?: (addrs: string[]) => string[],
+): Promise<{ status: number; body: any }> {
+  const { findOrCreateEmailConversation, persistEmailMessage, mintMessageId } = await import('../email.js')
+  const { companyId, agentId, agentEmail } = await seedCompanyWithAgent()
+  const toAddrs = [agentEmail, ...extra]
+  const boomerangTo = reorder ? reorder(toAddrs) : toAddrs
+  const fromAddrFull = `yetone <user-x@${process.env.EMAIL_DOMAIN}>`
+  const subject = 'ship it'
+
+  const conv = await findOrCreateEmailConversation({
+    companyId, inReplyTo: null, references: [], subject, memberIds: [agentId],
+  })
+  await persistEmailMessage({
+    conversationId: conv.conversationId, companyId, authorId: agentId,
+    direction: 'out', transportStatus: 'sent', smtpMessageId: mintMessageId(),
+    inReplyTo: null, references: [], subject, fromAddr: fromAddrFull,
+    toAddrs, body: 'shipping',
+  })
+
+  return postInbound({
+    messageId: `0106019e2ac91d15-${randomUUID().slice(0, 12)}-000000@ap-northeast-1.amazonses.com`,
+    from: fromAddrFull,
+    to: boomerangTo,
+    subject,
+    text: 'shipping',
+  })
+}
+
+async function counts(): Promise<{ conversations: number; emails: number }> {
+  const c = await pool.query<{ n: number }>(`SELECT count(*)::int AS n FROM conversations WHERE kind = 'email'`)
+  const e = await pool.query<{ n: number }>(`SELECT count(*)::int AS n FROM email_messages`)
+  return { conversations: c.rows[0].n, emails: e.rows[0].n }
+}
+
+test('[integration] a boomerang addressed to two recipients is still deduplicated', async () => {
+  const r = await sendThenBoomerang(['human@external.com'])
+
+  assert.equal(r.status, 200)
+  assert.equal(r.body.echo, true, 'a two-recipient boomerang was treated as a new email')
+  assert.deepEqual(await counts(), { conversations: 1, emails: 1 })
+})
+
+test('[integration] the recipients are compared as a set, not in header order', async () => {
+  // Nothing guarantees the To: header comes back in the order we wrote it.
+  const r = await sendThenBoomerang(
+    ['human@external.com'],
+    (addrs) => [addrs[1].toUpperCase(), addrs[0]],
+  )
+
+  assert.equal(r.body.echo, true, 'the same recipients in another order read as a different email')
+  assert.deepEqual(await counts(), { conversations: 1, emails: 1 })
+})
+
+test('[integration] one recipient still dedups', async () => {
+  // The case that already worked, kept honest.
+  const r = await sendThenBoomerang([])
+  assert.equal(r.body.echo, true)
+  assert.deepEqual(await counts(), { conversations: 1, emails: 1 })
+})
+
+test('[integration] a different recipient set is not an echo', async () => {
+  // The guard rail: set comparison must not become "close enough". A genuinely
+  // different audience is a genuinely different email.
+  const r = await sendThenBoomerang(
+    ['human@external.com'],
+    (addrs) => [addrs[0], 'someone-else@external.com'],
+  )
+  assert.notEqual(r.body.echo, true, 'a different recipient set was swallowed as an echo')
+})

--- a/server/src/api/inbound-email.ts
+++ b/server/src/api/inbound-email.ts
@@ -355,17 +355,35 @@ inboundEmailRouter.post('/inbound', async (req: Request, res: Response) => {
   // findOrCreateEmailConversation), so this only fires on the "received
   // a copy of what we just sent" case, not on real replies.
   const fromAddrFull = formatAddress(fromParsed.addr, fromParsed.name)
-  const inboundToJson = JSON.stringify((payload.to ?? []).map((s) => s))
+  const inboundTo = (payload.to ?? []).map((s) => s)
+  // Compare the recipients as a set, not as rendered JSON text. `to_addrs` is
+  // jsonb, and jsonb::text puts a space after every comma while JSON.stringify
+  // does not — so the old `LOWER(to_addrs::text) = LOWER($3)` matched only for
+  // a SINGLE recipient, where the two renderings happen to coincide:
+  //
+  //   1 recipient   jsonb::text ["a@x.com"]              stringify ["a@x.com"]
+  //   2 recipients  jsonb::text ["a@x.com", "b@x.com"]   stringify ["a@x.com","b@x.com"]
+  //
+  // Every boomerang of a mail sent to two or more addresses therefore fell
+  // through to a fresh conversation containing our own message — the exact
+  // thing this pass exists to stop. Sorting also drops the assumption that the
+  // header comes back in the order we sent it.
   const echo = await pool.query<{ message_id: string; conversation_id: string }>(
     `SELECT message_id, conversation_id FROM email_messages
       WHERE direction = 'out'
         AND created_at > NOW() - INTERVAL '10 minutes'
         AND LOWER(subject) = LOWER($1)
         AND LOWER(from_addr) = LOWER($2)
-        AND LOWER(to_addrs::text) = LOWER($3)
+        AND COALESCE(
+              (SELECT array_agg(LOWER(a) ORDER BY LOWER(a))
+                 FROM jsonb_array_elements_text(to_addrs) AS a), '{}'
+            ) = COALESCE(
+              (SELECT array_agg(LOWER(a) ORDER BY LOWER(a))
+                 FROM unnest($3::text[]) AS a), '{}'
+            )
       ORDER BY created_at DESC
       LIMIT 1`,
-    [subject || '(no subject)', fromAddrFull, inboundToJson],
+    [subject || '(no subject)', fromAddrFull, inboundTo],
   )
   if (echo.rows[0]) {
     console.log(JSON.stringify({


### PR DESCRIPTION
## The bug

SES rewrites `Message-ID` on the wire, so mail we send to a cumora-domain address boomerangs back through the gate carrying an id we never minted. The id-based dedup misses it, and a second pass matches on `(from, to, subject)` within ten minutes instead. Its recipient test was:

```sql
AND LOWER(to_addrs::text) = LOWER($3)      -- $3 = JSON.stringify(payload.to)
```

`to_addrs` is `jsonb`. Postgres renders jsonb text with a space after every comma; `JSON.stringify` does not. The two renderings coincide for **exactly one** address and diverge for every larger set:

```
1 recipient   jsonb::text ["a@x.com"]              stringify ["a@x.com"]
2 recipients  jsonb::text ["a@x.com", "b@x.com"]   stringify ["a@x.com","b@x.com"]
```

(measured against Postgres 16, not inferred)

So every boomerang of a mail sent to two or more addresses — an agent and a human, two agents, anyone Cc'd — fell straight through the pass and created a fresh conversation containing our own outbound message. That is precisely the bug the pass exists to stop; it only ever stopped it for the narrowest possible case.

The existing boomerang test in `inbound.test.ts` sends to a single address, which is why it has been passing.

## The fix

Compare the recipients as a **set**: unnest both sides, lowercase, sort, compare the arrays.

That fixes the whitespace, and it also drops an assumption nobody stated — that the `To:` header comes back in the order we wrote it. `COALESCE` on both sides so an empty set compares equal rather than `NULL`.

I kept the comparison on the full address strings rather than reducing to bare addresses. Changing that would alter what counts as a match beyond the defect at hand, and display names survive the SES round trip intact.

## Tests

New `server/src/__integration__/inbound-echo-multi-recipient.test.ts` — its own file so it does not collide with other work in `inbound.test.ts`:

- **a boomerang addressed to two recipients is still deduplicated** — the defect
- **the recipients are compared as a set, not in header order** — same addresses, reordered and re-cased
- **one recipient still dedups** — the case that already worked, kept honest
- **a different recipient set is not an echo** — the guard rail: set comparison must not become "close enough"

Only the first two are red before the change; the last two pass either way, on purpose.

```
without the fix:  not ok 1 - a boomerang addressed to two recipients is still deduplicated
                  not ok 2 - the recipients are compared as a set, not in header order
                  ok 3, ok 4
                  # pass 2  # fail 2

with the fix:     # pass 4  # fail 0
```

One thing the test harness made obvious and worth recording: the agent's own address has to be in the recipient set or the request is refused for having no known recipient long before the echo pass runs. That is part of why a single-recipient boomerang was the only shape anyone tested — it is the shape that is easiest to write.

Also green: `tsc --noEmit`, `biome lint .`, all three `scripts/guard-*.mjs`, the existing `inbound.test.ts` (16/16), and the unit suite (1226 tests, 0 failures).
