### PR TITLE
release: v0.17.0

### DIFF
--- a/agent-cli/package.json
+++ b/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cumora",
-  "version": "0.16.2",
+  "version": "0.17.0",
   "description": "Run Cumora agents on your own machine with Claude Code, Codex, Antigravity, and other BYOA engines.",
   "license": "MIT",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cumora",
-  "version": "0.16.2",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cumora",
-      "version": "0.16.2",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1045.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cumora",
   "private": true,
-  "version": "0.16.2",
+  "version": "0.17.0",
   "type": "module",
   "main": "electron/main.cjs",
   "bin": {


### PR DESCRIPTION
Version bump to 0.17.0 (root + agent-cli).

Since v0.16.2, `main` accumulated a feature (#235, per-engine default model configuration) alongside a large batch of fixes, so this is a minor bump.

Headline changes:

- **#231** — BYOA engine sessions are isolated per engine, so a Codex session id can never reach `claude --resume`. Stale resume targets are now a structured failure kind and recover with exactly one fresh retry; ambiguous failures are never replayed.
- **#235** — per-engine default model configuration on computers.
- **#220** — multi-recipient inbound email delivery without ghost threads.
- **#228** — migration 0002 can clear its own precondition under an opt-in, archived, transactional repair.
- Plus fixes to email echo dedup, Bcc delivery, push for agent-opened conversations, synthetic wake reporting, search cancellation, `--stop` killing the paired daemon, model-catalog probing, and `CREATE INDEX CONCURRENTLY` lock timeouts.