### PR TITLE
fix(ops): align startup probes with schema boot budget

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -251,16 +251,13 @@ jobs:
 
           # Apply one atomic Pod-template patch: select the candidate server,
           # remove the retired per-replica migration init container, and
-          # re-assert the liveness probe path. Liveness MUST hit
-          # /api/livez (a DB-free "process alive" check), NOT /api/health
-          # (which runs SELECT 1). A DB-backed liveness probe let a slow /
-          # overloaded DB fail the probe and SIGTERM-kill otherwise-healthy
-          # pods — the connection-exhaustion outage on 2026-05-27. Readiness
-          # stays on /api/health (a pod that can't reach the DB shouldn't get
-          # traffic, but should NOT be killed). Idempotent: a no-op when the
-          # path is already /api/livez. This keeps the fix durable even if the
-          # Deployment is ever recreated from a base manifest that still has
-          # the old /api/health liveness path.
+          # re-assert the startup/readiness/liveness probe contract. Startup
+          # allows the server's bounded schema transport retry to finish;
+          # liveness MUST hit /api/livez (a DB-free "process alive" check),
+          # NOT /api/health (which runs SELECT 1). Readiness stays on
+          # /api/health so a pod that cannot reach the DB is kept out of
+          # rotation without being killed. This keeps the fix durable even if
+          # the Deployment is recreated from an older base manifest.
           AGENT="${{ steps.digest.outputs.agent }}"
           PATCH=$(jq -nc --arg server "$SERVER" --arg agent "$AGENT" '
             {
@@ -272,7 +269,22 @@ jobs:
                   ({
                     name: "server",
                     image: $server,
-                    livenessProbe: { httpGet: { path: "/api/livez" } }
+                    startupProbe: {
+                      httpGet: { path: "/api/livez", port: "http" },
+                      periodSeconds: 5,
+                      timeoutSeconds: 2,
+                      failureThreshold: 60
+                    },
+                    readinessProbe: {
+                      httpGet: { path: "/api/health", port: "http" },
+                      periodSeconds: 5,
+                      timeoutSeconds: 2
+                    },
+                    livenessProbe: {
+                      httpGet: { path: "/api/livez", port: "http" },
+                      periodSeconds: 30,
+                      timeoutSeconds: 3
+                    }
                   } + if $agent == "" then {} else {
                     env: [{ name: "CUMORA_AGENT_COMPUTER_IMAGE", value: $agent }]
                   } end)
@@ -290,7 +302,7 @@ jobs:
           # the job fails, otherwise GHA just shows "Process completed
           # with exit code 1" and we have to manually kubectl-investigate.
           set +e
-          kubectl rollout status deployment/cumora-server --timeout=5m
+          kubectl rollout status deployment/cumora-server --timeout=10m
           RC=$?
           set -e
           echo "rc=$RC" >> $GITHUB_OUTPUT
@@ -349,7 +361,7 @@ jobs:
         run: |
           echo "::warning::Authenticated smoke failed; rolling deployment back to the previous revision."
           kubectl rollout undo deployment/cumora-server
-          kubectl rollout status deployment/cumora-server --timeout=5m
+          kubectl rollout status deployment/cumora-server --timeout=10m
           echo "::error::Candidate was rolled back. Previous server was ${{ steps.patch.outputs.previous_server }}."
 
       - name: Fail release after rollback

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.5.8",
         "@types/express": "^5.0.6",
+        "@types/js-yaml": "^4.0.9",
         "@types/pg": "^8.20.0",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
@@ -81,6 +82,7 @@
         "drizzle-kit": "^0.31.10",
         "electron": "^33.4.11",
         "electron-builder": "^25.1.8",
+        "js-yaml": "^4.1.1",
         "postcss": "^8.4.47",
         "tailwindcss": "^3.4.14",
         "typescript": "^5.6.3",
@@ -5798,6 +5800,13 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/keyv": {

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.5.8",
     "@types/express": "^5.0.6",
+    "@types/js-yaml": "^4.0.9",
     "@types/pg": "^8.20.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
@@ -119,6 +120,7 @@
     "drizzle-kit": "^0.31.10",
     "electron": "^33.4.11",
     "electron-builder": "^25.1.8",
+    "js-yaml": "^4.1.1",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.14",
     "typescript": "^5.6.3",

--- a/server/k8s/cumora-server.gke.yaml
+++ b/server/k8s/cumora-server.gke.yaml
@@ -155,14 +155,20 @@ spec:
         # Optional: pin agent pods to a specific node pool / GKE
         # Workload Identity SA via CUMORA_AGENT_SERVICE_ACCOUNT
         # (defaults to namespace `default` SA when unset).
-        # `/` now serves the SPA's index.html, so we point probes at the
-        # DB-touching /api/health instead.
+        # Startup waits for the schema gate's bounded DB retry budget. Liveness
+        # only checks the process; readiness checks DB reachability and keeps a
+        # booting or degraded pod out of service without killing it.
+        startupProbe:
+          httpGet: { path: /api/livez, port: http }
+          periodSeconds: 5
+          timeoutSeconds: 2
+          failureThreshold: 60
         readinessProbe:
           httpGet: { path: /api/health, port: http }
           periodSeconds: 5
           timeoutSeconds: 2
         livenessProbe:
-          httpGet: { path: /api/health, port: http }
+          httpGet: { path: /api/livez, port: http }
           periodSeconds: 30
           timeoutSeconds: 3
         resources:

--- a/server/k8s/cumora-server.orbstack.yaml
+++ b/server/k8s/cumora-server.orbstack.yaml
@@ -94,15 +94,20 @@ spec:
         # for the agent FUSE driver's HTTP traffic; PG itself lives
         # on the host in dev (host.docker.internal:5432, set in the
         # Secret's DATABASE_URL).
-        # `/` now serves the SPA's index.html (when dist/ is baked in) —
-        # /api/health is the right place for liveness/readiness because
-        # it actually hits the DB.
+        # Startup waits for the schema gate's bounded DB retry budget. Liveness
+        # only checks the process; readiness checks DB reachability and keeps a
+        # booting or degraded pod out of service without killing it.
+        startupProbe:
+          httpGet: { path: /api/livez, port: http }
+          periodSeconds: 5
+          timeoutSeconds: 2
+          failureThreshold: 60
         readinessProbe:
           httpGet: { path: /api/health, port: http }
           periodSeconds: 5
           timeoutSeconds: 2
         livenessProbe:
-          httpGet: { path: /api/health, port: http }
+          httpGet: { path: /api/livez, port: http }
           periodSeconds: 30
           timeoutSeconds: 3
         resources:

--- a/server/k8s/gke.md
+++ b/server/k8s/gke.md
@@ -228,23 +228,14 @@ kubectl rollout status deployment/cumora-server
 The application Pods only read `schema_migrations` and refuse to start outside
 their supported version range. They never execute DDL during startup.
 
-> **Patch the liveness probe after applying.** The checked-in manifest still
-> points `livenessProbe` at `/api/health`, which touches the database. The
-> Deploy workflow patches it to `/api/livez` on every rollout precisely
-> because a DB-backed liveness probe turned a connection-pool stall into a
-> restart loop (2026-05-27). A manual `kubectl apply` re-introduces the bad
-> config, so follow it with:
->
-> ```sh
-> kubectl patch deployment/cumora-server --type=json -p='[{
->   "op": "replace",
->   "path": "/spec/template/spec/containers/0/livenessProbe/httpGet/path",
->   "value": "/api/livez"
-> }]'
-> ```
->
-> Readiness should stay on `/api/health` — that one *should* pull a pod out of
-> rotation when its dependencies are gone.
+The checked-in manifest gives the server a startup grace window for the
+schema gate: `/api/livez` is checked every 5 seconds with a 60-failure budget
+(about 5 minutes). Once startup succeeds, liveness continues to use the
+DB-free `/api/livez` process check while readiness uses `/api/health` to keep a
+pod out of rotation when its dependencies are unavailable. The production
+Deploy workflow reapplies the same probe contract during its Pod-template
+patch, so a manual `kubectl apply` does not require a follow-up imperative
+probe patch.
 
 ## 7. Verify end-to-end
 

--- a/server/src/__tests__/startup-probes.test.ts
+++ b/server/src/__tests__/startup-probes.test.ts
@@ -1,0 +1,178 @@
+import assert from 'node:assert/strict'
+import { execFile as execFileCallback } from 'node:child_process'
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { test } from 'node:test'
+import { promisify } from 'node:util'
+import { load, loadAll } from 'js-yaml'
+import { MigrationHistoryError } from '../db/migrations/manifest.js'
+
+process.env.CUMORA_RUNTIME_CLIENT = 'http'
+process.env.OPENAI_API_KEY ??= 'test-key'
+
+const { verifySchemaWithBootRetry } = await import('../db/schema-version.js')
+const { pool } = await import('../db/pool.js')
+const execFile = promisify(execFileCallback)
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
+const readRepo = (path: string): Promise<string> => readFile(resolve(repoRoot, path), 'utf8')
+
+interface Probe {
+  httpGet?: { path?: string; port?: string | number }
+  periodSeconds?: number
+  timeoutSeconds?: number
+  failureThreshold?: number
+}
+
+interface Container {
+  name?: string
+  startupProbe?: Probe
+  livenessProbe?: Probe
+  readinessProbe?: Probe
+}
+
+interface Deployment {
+  kind?: string
+  spec?: { template?: { spec?: { containers?: Container[] } } }
+}
+
+interface WorkflowStep {
+  name?: string
+  run?: string
+}
+
+interface Workflow {
+  jobs?: Record<string, { steps?: WorkflowStep[] }>
+}
+
+interface ProbePatch {
+  spec?: { template?: { spec?: { containers?: Container[] } } }
+}
+
+const manifestPaths = [
+  'server/k8s/cumora-server.gke.yaml',
+  'server/k8s/cumora-server.orbstack.yaml',
+]
+
+async function serverContainer(path: string): Promise<Container> {
+  const docs = loadAll(await readRepo(path)) as unknown[]
+  const deployment = docs
+    .filter((doc): doc is Deployment => typeof doc === 'object' && doc !== null)
+    .find((doc) => doc.kind === 'Deployment')
+  const server = deployment?.spec?.template?.spec?.containers?.find((container) => container.name === 'server')
+  assert.ok(server, `${path} must contain a server container in its Deployment`)
+  return server
+}
+
+function assertProbe(
+  probe: Probe | undefined,
+  expectedPath: string,
+  pathLabel: string,
+  expectedPeriod: number,
+  expectedTimeout: number,
+): asserts probe is Probe {
+  assert.ok(probe, `${pathLabel} probe is required`)
+  assert.deepEqual(probe.httpGet, { path: expectedPath, port: 'http' }, `${pathLabel} endpoint`)
+  assert.equal(probe.periodSeconds, expectedPeriod, `${pathLabel} period`)
+  assert.equal(probe.timeoutSeconds, expectedTimeout, `${pathLabel} timeout`)
+}
+
+test('both server manifests keep startup, liveness, and readiness probes on the server container', async () => {
+  for (const path of manifestPaths) {
+    const server = await serverContainer(path)
+    assertProbe(server.startupProbe, '/api/livez', `${path} startup`, 5, 2)
+    assert.equal(server.startupProbe.failureThreshold, 60, `${path} startup failure threshold`)
+    assertProbe(server.livenessProbe, '/api/livez', `${path} liveness`, 30, 3)
+    assertProbe(server.readinessProbe, '/api/health', `${path} readiness`, 5, 2)
+    assert.notEqual(server.livenessProbe.httpGet?.path, server.readinessProbe.httpGet?.path)
+  }
+})
+
+test('the deploy patch reapplies the same probe contract and rollout deadline', async (t) => {
+  const workflow = load(await readRepo('.github/workflows/deploy.yml')) as Workflow
+  const patchStep = workflow.jobs?.deploy?.steps?.find((step) => step.name === 'Patch deployment')
+  assert.ok(patchStep?.run, 'deploy must have a parsed Patch deployment step')
+  const patch = patchStep.run
+  assert.match(patch, /startupProbe:\s*\{\s*httpGet:\s*\{\s*path: "\/api\/livez",\s*port: "http"\s*\}/)
+  assert.match(patch, /readinessProbe:\s*\{\s*httpGet:\s*\{\s*path: "\/api\/health",\s*port: "http"\s*\}/)
+  assert.match(patch, /livenessProbe:\s*\{\s*httpGet:\s*\{\s*path: "\/api\/livez",\s*port: "http"\s*\}/)
+  assert.match(patch, /periodSeconds: 5/)
+  assert.match(patch, /timeoutSeconds: 2/)
+  assert.match(patch, /failureThreshold: 60/)
+  const rolloutStep = workflow.jobs?.deploy?.steps?.find((step) => step.name === 'Wait for rollout')
+  assert.match(rolloutStep?.run ?? '', /kubectl rollout status deployment\/cumora-server --timeout=10m/)
+
+  const filterOpen = patch.indexOf("'\n")
+  const filterClose = patch.indexOf("\n')", filterOpen + 2)
+  assert.ok(filterOpen >= 0 && filterClose > filterOpen, 'Patch deployment must contain a jq filter')
+  const jqFilter = patch.slice(filterOpen + 2, filterClose)
+  let jq: { stdout: string }
+  try {
+    jq = await execFile(
+      'jq',
+      ['-nc', '--arg', 'server', 'fixture-server', '--arg', 'agent', 'fixture-agent', jqFilter],
+      { encoding: 'utf8' },
+    ) as { stdout: string }
+  } catch (error) {
+    if (!process.env.CI && (error as { code?: unknown })?.code === 'ENOENT') {
+      t.skip('jq is unavailable locally; CI must provide jq for this workflow patch test')
+      return
+    }
+    throw error
+  }
+  const patchObject = JSON.parse(String(jq.stdout)) as ProbePatch
+  const patchedServer = patchObject.spec?.template?.spec?.containers?.find((container) => container.name === 'server')
+  assert.ok(patchedServer, 'evaluated deploy patch must target the server container')
+  for (const path of manifestPaths) {
+    const manifestServer = await serverContainer(path)
+    assert.deepEqual(patchedServer.startupProbe, manifestServer.startupProbe, `${path} startup contract`)
+    assert.deepEqual(patchedServer.readinessProbe, manifestServer.readinessProbe, `${path} readiness contract`)
+    assert.deepEqual(patchedServer.livenessProbe, manifestServer.livenessProbe, `${path} liveness contract`)
+  }
+})
+
+test('startup grace exceeds the schema retry and bounded connection budget', async () => {
+  const delays: number[] = []
+  let attempts = 0
+  await assert.rejects(
+    () => verifySchemaWithBootRetry({
+      verifyFn: async () => {
+        attempts++
+        throw new Error('connect ECONNREFUSED 127.0.0.1:5432')
+      },
+      sleep: async (ms) => { delays.push(ms) },
+    }),
+    /ECONNREFUSED/,
+  )
+  const retryDelayMs = delays.reduce((sum, delay) => sum + delay, 0)
+  assert.equal(attempts, delays.length + 1)
+  const connectionTimeoutMs = pool.options.connectionTimeoutMillis ?? 0
+  assert.ok(connectionTimeoutMs > 0, 'pool connection timeout must be bounded')
+  const boundedConnectionMs = attempts * connectionTimeoutMs
+  for (const path of manifestPaths) {
+    const server = await serverContainer(path)
+    const startup = server.startupProbe
+    assert.ok(startup)
+    const startupBudgetMs = (startup.periodSeconds ?? 0) * (startup.failureThreshold ?? 0) * 1000
+    assert.ok(
+      startupBudgetMs > retryDelayMs + boundedConnectionMs,
+      `${path} startup budget ${startupBudgetMs}ms must exceed ${retryDelayMs + boundedConnectionMs}ms`,
+    )
+  }
+})
+
+test('schema history errors remain fail-closed without transport retries', async () => {
+  let calls = 0
+  await assert.rejects(
+    () => verifySchemaWithBootRetry({
+      verifyFn: async () => {
+        calls++
+        throw new MigrationHistoryError('schema_behind', 'run migrations')
+      },
+      sleep: async () => {},
+    }),
+    /run migrations/,
+  )
+  assert.equal(calls, 1)
+})


### PR DESCRIPTION
## Problem

The server validates schema compatibility before it starts listening and can spend up to the configured transport retry budget waiting for Postgres. Both checked-in server manifests used the DB-backed `/api/health` endpoint for liveness without a startup grace period, while the production deploy patch only corrected the liveness path. A slow database could therefore make a booting or otherwise live process fail its liveness contract before it was ready.

## Change

- Add a 5-minute `/api/livez` startup budget to the GKE and OrbStack server containers.
- Keep liveness on DB-free `/api/livez` and readiness on DB-backed `/api/health`.
- Make the production deploy patch reapply all three probes and extend rollout/rollback waits to 10 minutes.
- Replace the stale manual liveness patch instructions with the manifest/deploy contract.
- Add parsed-manifest, evaluated-`jq`-patch, retry-budget, and fail-closed schema regression tests.

## Validation

- Baseline at `a0ee0b6`: both server manifests used `/api/health` for liveness and had no `startupProbe`; the deploy patch only set the liveness path.
- Focused probe tests: 4 passed.
- Static gates: lint, client/server typecheck, architecture guards, build, and R2 Worker typecheck passed.
- Root unit tests: 1,282 passed, 4 skipped, 0 failed.
- Integration tests: 370 passed, 5 skipped, 0 failed.

No deployment was performed.
