### PR TITLE
fix: unsubscribe ws listener in WorkspaceSettingsModal on unmount

### DIFF
--- a/src/components/WorkspaceSettingsModal.tsx
+++ b/src/components/WorkspaceSettingsModal.tsx
@@ -52,10 +52,13 @@ export function WorkspaceSettingsModal({ company, companyCount, onInvite, onClos
     return () => { memberLoadGeneration.current += 1 }
   }, [loadMembers])
 
-  useEffect(() => ws.on((event) => {
-    if (event.type !== 'workspace.membership' || event.companyId !== company.id) return
-    void loadMembers(false)
-  }), [company.id, loadMembers])
+  useEffect(() => {
+    const unsub = ws.on((event) => {
+      if (event.type !== 'workspace.membership' || event.companyId !== company.id) return
+      void loadMembers(false)
+    })
+    return () => unsub()
+  }, [company.id, loadMembers])
 
   const changeRole = async (member: ApiWorkspaceMember, role: 'member' | 'admin') => {
     if (member.role === role) return


### PR DESCRIPTION
ws.on() returns an unsubscribe function, but the useEffect did not return it as cleanup. Each open/close cycle leaked a listener that would trigger redundant loadMembers() calls on every membership event, accumulating over the session lifetime.