### PR TITLE
fix(threads): the person who writes a reply can open the thread they started

### DIFF
--- a/src/lib/replyCount.ts
+++ b/src/lib/replyCount.ts
@@ -1,0 +1,31 @@
+/**
+ * The "N replies" link under a message is driven by `replyCount`, and it is the
+ * only way into the thread drawer — `Message.tsx` gates the app's single
+ * `openThreadView` call site on `(msg.replyCount ?? 0) > 0`. So a root whose
+ * count is one short does not merely display a wrong number: at zero it hides
+ * the entrance entirely, and the person who wrote the reply cannot open the
+ * thread they just started.
+ *
+ * The count is maintained locally because the server does not publish a new one
+ * with the reply. That means every path that adds or removes a reply from the
+ * local list has to move it by exactly one — which is what this helper is for.
+ */
+import type { Message } from '@/types'
+
+/** Shift a quoted root's local reply count. No-op when the root is not in the
+ *  loaded page (an old message the user has not scrolled back to) or when the
+ *  message being counted is not a reply at all. Never goes below zero. */
+export function applyReplyCountDelta(
+  list: Message[],
+  rootId: string | null | undefined,
+  delta: number,
+): Message[] {
+  if (!rootId || delta === 0) return list
+  let hit = false
+  const next = list.map((m) => {
+    if (m.id !== rootId) return m
+    hit = true
+    return { ...m, replyCount: Math.max(0, (m.replyCount ?? 0) + delta) }
+  })
+  return hit ? next : list
+}

--- a/src/stores/messages.ts
+++ b/src/stores/messages.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import type { Message, ReactionEntry } from '@/types'
+import { applyReplyCountDelta } from '@/lib/replyCount'
 import { api, ApiError, ws, type WsEvent, type ApiMessage } from '@/api/client'
 import { useApp } from '@/stores/app'
 import { getMeId } from '@/stores/auth'
@@ -505,17 +506,18 @@ export const useMessages = create<MessagesState>((set, get) => ({
           const sb = (b as { sequence?: number }).sequence ?? 0
           return sa - sb
         })
-        // Live replyCount bump on the quoted-original. Server doesn't publish
-        // the new count separately; without this the "N replies" link on the
-        // root would only catch up on a full refetch. Only bump for fresh
-        // arrivals (`prior` was absent) so a server-echo of an optimistic
-        // bubble doesn't double-count.
-        if (!prior && m.quotedMessageId) {
-          const rootId = m.quotedMessageId
-          next = next.map((x) =>
-            x.id === rootId ? { ...x, replyCount: (x.replyCount ?? 0) + 1 } : x,
-          )
-        }
+        // Live replyCount bump on the quoted-original. The server doesn't
+        // publish the new count separately; without this the "N replies" link
+        // on the root would only catch up on a full refetch.
+        //
+        // Only for FRESH arrivals. A `prior` match means this is the server
+        // echo of our own optimistic bubble, and `sendUserMessage` already
+        // counted it at insert time — which it has to, because the author's
+        // echo ALWAYS matches `prior` (by real id once the POST resolves, or
+        // by clientId when the echo wins the race). Counting only here left
+        // the author's own root one short forever, and at zero that hides the
+        // only entrance to the thread they had just created.
+        if (!prior) next = applyReplyCountDelta(next, m.quotedMessageId, 1)
         const { [m.id]: _drop, ...rest } = s.streaming
         return {
           streaming: rest,
@@ -690,10 +692,19 @@ export async function sendUserMessage(
   // shouldn't shove our bubble up the timeline.
   ;(optimistic as Message & { sequence?: number }).sequence = Number.MAX_SAFE_INTEGER
 
+  // Count the reply against its root now, next to the bubble it belongs to.
+  // The author never gets a second chance: their server echo is always matched
+  // as a `prior` in applyEvent, so the bump there is skipped for them.
+  // `discardFailedMessage` takes it back if this send is thrown away, which is
+  // also what keeps a retry (discard, then send again) balanced at +1.
   useMessages.setState((s) => ({
     byConvo: {
       ...s.byConvo,
-      [convoId]: [...(s.byConvo[convoId] ?? []), optimistic],
+      [convoId]: applyReplyCountDelta(
+        [...(s.byConvo[convoId] ?? []), optimistic],
+        quotedMessageId,
+        1,
+      ),
     },
   }))
 
@@ -740,8 +751,15 @@ export function discardFailedMessage(convoId: string, tempId: string): void {
   useMessages.setState((s) => {
     const list = s.byConvo[convoId]
     if (!list) return s
-    const next = list.filter((m) => m.id !== tempId)
-    if (next.length === list.length) return s
+    const dropped = list.find((m) => m.id === tempId)
+    if (!dropped) return s
+    // Hand back the count this reply took on insert, or the root keeps a
+    // phantom reply for the rest of the session.
+    const next = applyReplyCountDelta(
+      list.filter((m) => m.id !== tempId),
+      dropped.quotedMessageId,
+      -1,
+    )
     return { byConvo: { ...s.byConvo, [convoId]: next } }
   })
 }

--- a/tests/reply-count.test.ts
+++ b/tests/reply-count.test.ts
@@ -1,0 +1,123 @@
+/**
+ * A reply has to move its root's count by exactly one, on every client.
+ *
+ * `applyEvent` bumped the quoted root only for arrivals with no local
+ * counterpart (`!prior`). That is never true on the client that WROTE the
+ * reply: its own server echo always matches the optimistic bubble — by real id
+ * once the POST resolves, or by clientId when the echo wins the race — and
+ * `sendUserMessage` never counted it at insert time either. So the author's
+ * copy of the root stayed one short, permanently: `loadConversation` bails on
+ * `loaded.has(id)`, so leaving and re-entering the conversation does not
+ * refetch, and only a full reload repaired it.
+ *
+ * At zero that is not a wrong number, it is a missing door. `Message.tsx` gates
+ * the app's ONLY `openThreadView` call site on `(msg.replyCount ?? 0) > 0`, so
+ * the person who wrote a thread's first reply could not open the thread they
+ * had just created. Their teammates could.
+ */
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { describe, it } from 'node:test'
+import type { Message } from '../src/types'
+import { applyReplyCountDelta } from '../src/lib/replyCount'
+
+function msg(over: Partial<Message> = {}): Message {
+  return {
+    id: 'm-root',
+    conversationId: 'g-1',
+    authorId: 'u-iris',
+    kind: 'text',
+    body: 'ship it?',
+    at: '2026-03-01T10:00:00.000Z',
+    ...over,
+  } as Message
+}
+
+describe('applyReplyCountDelta', () => {
+  it('takes a root from no-replies to one reply — the case that opens the door', () => {
+    const [root] = applyReplyCountDelta([msg()], 'm-root', 1)
+    assert.equal(root.replyCount, 1)
+  })
+
+  it('counts on top of what the server already reported', () => {
+    const [root] = applyReplyCountDelta([msg({ replyCount: 4 })], 'm-root', 1)
+    assert.equal(root.replyCount, 5)
+  })
+
+  it('gives the count back when a reply is thrown away', () => {
+    const [root] = applyReplyCountDelta([msg({ replyCount: 3 })], 'm-root', -1)
+    assert.equal(root.replyCount, 2)
+  })
+
+  it('never counts below zero', () => {
+    // A discard of a reply whose root was loaded after the fact.
+    const [root] = applyReplyCountDelta([msg({ replyCount: 0 })], 'm-root', -1)
+    assert.equal(root.replyCount, 0)
+  })
+
+  it('is a no-op for a message that is not a reply', () => {
+    const list = [msg({ replyCount: 2 })]
+    assert.equal(applyReplyCountDelta(list, null, 1), list)
+    assert.equal(applyReplyCountDelta(list, undefined, 1), list)
+  })
+
+  it('is a no-op when the root is not in the loaded page', () => {
+    // Replying to an old message the user scrolled back to and then away from.
+    const list = [msg({ replyCount: 2 })]
+    assert.equal(applyReplyCountDelta(list, 'm-somewhere-else', 1), list)
+  })
+
+  it('touches only the root, and does not mutate the array it was given', () => {
+    const list = [msg({ replyCount: 1 }), msg({ id: 'm-other', replyCount: 7 })]
+    const next = applyReplyCountDelta(list, 'm-root', 1)
+    assert.equal(next[1], list[1], 'an unrelated message was rebuilt')
+    assert.equal(list[0].replyCount, 1, 'the input list was mutated')
+    assert.equal(next[0].replyCount, 2)
+  })
+
+  it('the author\'s full sequence lands on exactly one', () => {
+    // insert the optimistic bubble (+1), then the server echo contributes 0
+    // because applyEvent skips arrivals that match a prior local copy.
+    let list = [msg()]
+    list = applyReplyCountDelta(list, 'm-root', 1)   // sendUserMessage
+    // echo: prior found -> no delta
+    assert.equal(list[0].replyCount, 1, 'the author must end at exactly one, not zero and not two')
+  })
+})
+
+describe('the three places that have to agree', () => {
+  // The helper is pure: every test above passes just as well against a build
+  // where sendUserMessage never counts. The bug was never in the arithmetic —
+  // it was that only one of the three sites did any.
+
+  it('the optimistic insert counts the reply', async () => {
+    const source = await readFile(new URL('../src/stores/messages.ts', import.meta.url), 'utf8')
+    const send = source.slice(source.indexOf('export async function sendUserMessage'))
+    const body = send.slice(0, send.indexOf('\nexport '))
+    assert.match(body, /applyReplyCountDelta\([\s\S]{0,120}quotedMessageId,\s*\n?\s*1,/,
+      'sendUserMessage no longer counts the reply it just inserted — the author\'s root will stay one short and, at zero, hide the only way into the thread')
+  })
+
+  it('the server echo does not count it a second time', async () => {
+    const source = await readFile(new URL('../src/stores/messages.ts', import.meta.url), 'utf8')
+    assert.match(source, /if \(!prior\) next = applyReplyCountDelta\(next, m\.quotedMessageId, 1\)/,
+      'the arrival bump is no longer guarded on `!prior`, so the author would double-count their own reply')
+  })
+
+  it('discarding a failed reply gives the count back', async () => {
+    // Also what keeps a retry balanced: retryFailedMessage discards, then sends.
+    const source = await readFile(new URL('../src/stores/messages.ts', import.meta.url), 'utf8')
+    const discard = source.slice(source.indexOf('export function discardFailedMessage'))
+    const body = discard.slice(0, discard.indexOf('\nexport '))
+    assert.match(body, /applyReplyCountDelta\([\s\S]{0,160}-1,/,
+      'a discarded reply leaves a phantom count on its root, and a retry would count twice')
+  })
+
+  it('the thread drawer is still gated on the count', async () => {
+    // If this ever stops being true the bug above stops being a missing door
+    // and becomes a wrong number — worth knowing which one we are fixing.
+    const source = await readFile(new URL('../src/components/Message.tsx', import.meta.url), 'utf8')
+    assert.match(source, /\(msg\.replyCount \?\? 0\) > 0/)
+    assert.match(source, /openThreadView\(msg\.conversationId, msg\.id\)/)
+  })
+})


### PR DESCRIPTION
## What you see

You hover a teammate's message, click the reply arrow, type an answer, hit enter. Your reply posts fine.

**But the "1 reply" link never appears under their message on your screen** — so you cannot open the thread you just started. Your teammate sees it immediately. Yours shows up only after a full app reload.

If the root already had replies, your copy of the count stays one behind theirs for every reply you write.

## Why

`applyEvent` bumps the quoted root's count only for arrivals with no local counterpart:

```ts
// Only bump for fresh arrivals (`prior` was absent) so a server-echo of an
// optimistic bubble doesn't double-count.
if (!prior && m.quotedMessageId) { …+1… }
```

`!prior` is never true on the client that *wrote* the reply. Its own server echo always matches the optimistic bubble — by real id once the POST resolves, or by `clientId` when the echo wins the race; the finder right above deliberately tries both.

And the send path never counted it either:

```
$ grep -n replyCount src/stores/messages.ts
257:    replyCount?: number | null      # the type
276:    replyCount: raw.replyCount …    # mapping from the API
508,516:                                # the !prior bump
```

Four references, none in `sendUserMessage`. So the guard's comment was protecting against a double that could not happen, while the single never happened.

Nothing repairs it. `loadConversation` bails on `loaded.has(id)`, so leaving the conversation and coming back does not refetch. The stale count survives the whole session.

## Why it is worse than a wrong number

`Message.tsx` gates the app's **only** `openThreadView` call site on the count:

```tsx
{(msg.replyCount ?? 0) > 0 && (
  <button onClick={() => openThreadView(msg.conversationId, msg.id)}>
```

At zero there is no other entrance. The person who writes a thread's first reply is the one person who cannot open it.

## The fix

Count the reply where the bubble is inserted — next to the thing it is counting — and keep the `!prior` guard, which now genuinely prevents a double instead of suppressing the only count.

`discardFailedMessage` hands the count back. That is also what keeps a retry balanced: `retryFailedMessage` discards and then re-sends, so the net stays +1.

The three sites now agree on one invariant: **a reply moves its root by exactly one, once, on every client.**

## Tests

Twelve in `tests/reply-count.test.ts`. Eight cover the helper — zero to one (the case that opens the door), counting on top of a server value, the refund, the floor at zero, no-op for a non-reply, no-op when the root is not in the loaded page, not mutating the input, and the author's full sequence landing on exactly one.

Four read the source, because the helper is pure and every arithmetic test above passes just as well against a build where the send path never counts. The bug was never in the arithmetic — it was that only one of the three sites did any. Each was verified red by reverting its own site:

```
sendUserMessage no longer counts the reply it just inserted — the author's root
will stay one short and, at zero, hide the only way into the thread

the arrival bump is no longer guarded on `!prior`, so the author would
double-count their own reply

a discarded reply leaves a phantom count on its root, and a retry would count twice
```

The fourth pins that the thread drawer is still gated on the count at all — if that ever changes, this stops being a missing door and becomes merely a wrong number, and it is worth knowing which one is being fixed.

Green: `tsc --noEmit` for renderer and server, `biome lint .`, all three `scripts/guard-*.mjs`, and the unit suite (1344 tests, 0 failures).

## A note on how this was found

A multi-lens pass over the everyday journeys, each finding then put to three independent reviewers instructed to refute it and to default to "refuted" when unsure — including one lens whose whole job was asking "would a normal five-person workspace actually hit this?". This one came back 3/3 upheld, and I then re-read every link of the chain by hand before writing the fix.
