### PR TITLE
fix(agent): the anti-monologue gate was eating the answer it asked for

### DIFF
--- a/server/src/__integration__/agent-anti-duplicate.test.ts
+++ b/server/src/__integration__/agent-anti-duplicate.test.ts
@@ -264,3 +264,89 @@ test('[integration] worklog blocks a duplicate heavy-tool claim from a peer', as
     scopeKey, agentId: agentA, taskType: 'web-search', subject: 'audio editor competitive analysis',
   })
 })
+
+// ─── announce-then-deliver ─────────────────────────────────────────
+//
+// The operating rules in turn.ts REQUIRE an intent message before any work
+// that keeps the asker waiting: "POST A SHORT INTENT MESSAGE first via
+// `cumora reply` … THEN do the work. THEN reply with the actual result. The
+// intent message must be a SEPARATE `cumora reply` call."
+//
+// In a group of three or more, that intent message is then the room's last
+// message and seconds old — exactly what the anti-monologue gate refuses. So
+// the product mandated a flow its own backstop rejected, and the deliverable
+// that came back was the failure notice rather than the answer.
+
+test('[integration] the gate refuses the result that the mandated intent message asked for', async () => {
+  const { agentA, convoId } = await seedGroupWithTwoAgents()
+
+  const intent = await runCli(['--as', agentA, 'reply', convoId, 'Drafting the email now — ~30s'])
+  assert.equal(intent.ok, true, `the intent message the rules require must post: ${intent.text}`)
+
+  // …30 seconds of work later, the actual answer, exactly as the relay used to
+  // send it: no flag.
+  const answer = await runCli(['--as', agentA, 'reply', convoId, 'Here is the draft: ...'])
+  assert.equal(answer.ok, false, 'this is the state being fixed — the gate refuses the deliverable')
+  assert.match(answer.text, /you already posted in/)
+})
+
+test('[integration] the relay delivers that result, body intact', async () => {
+  const { agentA, convoId } = await seedGroupWithTwoAgents()
+  await runCli(['--as', agentA, 'reply', convoId, 'Drafting the email now — ~30s'])
+
+  // The shape turn.ts's declared relay now sends: flag LAST.
+  const body = 'Here is the draft: subject line, three paragraphs, CTA.'
+  const relayed = await runCli(['--as', agentA, 'reply', convoId, body, '--continue'])
+  assert.equal(relayed.ok, true, `the relay must deliver the answer: ${relayed.text}`)
+
+  const { rows } = await pool.query<{ body: string }>(
+    `SELECT body FROM messages WHERE conversation_id = $1 ORDER BY sequence DESC LIMIT 1`,
+    [convoId],
+  )
+  assert.equal(rows[0].body, body, 'the answer must arrive whole, not empty')
+})
+
+test('[integration] the bypass flag has to come after the body', async () => {
+  // parseArgs reads `--continue <token>` as a VALUE flag, so putting the flag
+  // before the body consumes the body: the gate is bypassed and an EMPTY
+  // message is posted. Pin the ordering, because moving the flag to the front
+  // reads like a harmless tidy-up.
+  const { agentA, convoId } = await seedGroupWithTwoAgents()
+  await runCli(['--as', agentA, 'reply', convoId, 'Drafting the email now — ~30s'])
+
+  const wrongOrder = await runCli(['--as', agentA, 'reply', convoId, '--continue', 'the actual answer'])
+  const { rows } = await pool.query<{ body: string }>(
+    `SELECT body FROM messages WHERE conversation_id = $1 ORDER BY sequence DESC LIMIT 1`,
+    [convoId],
+  )
+  if (wrongOrder.ok) {
+    assert.notEqual(
+      rows[0].body, 'the actual answer',
+      'flag-before-body must not be adopted: parseArgs eats the body as the flag value',
+    )
+  }
+})
+
+test('[integration] a plain second post is still refused', async () => {
+  // The guard rail: this fix must not turn the gate off. Only the relay, which
+  // carries the flag, gets through.
+  const { agentA, convoId } = await seedGroupWithTwoAgents()
+  await runCli(['--as', agentA, 'reply', convoId, 'first'])
+  const second = await runCli(['--as', agentA, 'reply', convoId, 'monologuing on'])
+  assert.equal(second.ok, false, 'the anti-monologue gate must still hold for ordinary replies')
+})
+
+test('[unit] the declared relay carries the bypass, last', async () => {
+  // Every test above passes just as well against a relay that sends no flag —
+  // they exercise cmdReply, not the caller. Read turn.ts, because the defect
+  // was in what the relay sends.
+  const { readFile } = await import('node:fs/promises')
+  const source = await readFile(new URL('../agents/turn.ts', import.meta.url), 'utf8')
+  const relay = source.slice(source.indexOf('Auto-relayed assistant text as reply'))
+  const block = relay.slice(0, relay.indexOf('if (!relay.ok)'))
+
+  assert.match(
+    block, /command: `cumora reply \$\{target\.conversationId\} \$\{escaped\} --continue`/,
+    'the declared relay no longer bypasses the anti-monologue gate — after the intent message the rules require, the agent\'s answer is refused and the room gets a failure notice instead',
+  )
+})

--- a/server/src/__integration__/agent-turn.test.ts
+++ b/server/src/__integration__/agent-turn.test.ts
@@ -521,7 +521,10 @@ test('[integration] declared assistant-text relay posts the exact draft to the d
   const tools = makeToolStub({
     bash: async (parsed) => {
       const cmd = String(parsed.command ?? '')
-      const matched = cmd.match(/^cumora\s+reply\s+(\S+)\s+'([\s\S]*)'$/)
+      // The declared relay carries `--continue` so the anti-monologue gate
+      // cannot refuse the turn's deliverable after the intent message the
+      // operating rules require. Requiring it here keeps that shape pinned.
+      const matched = cmd.match(/^cumora\s+reply\s+(\S+)\s+'([\s\S]*)'\s+--continue$/)
       if (!matched) throw new Error(`unexpected bash invocation: ${cmd}`)
       const [, convoId, body] = matched
       const messageId = `m-${randomUUID()}`

--- a/server/src/agents/turn.ts
+++ b/server/src/agents/turn.ts
@@ -3231,9 +3231,31 @@ Mechanics:
         },
         stage: 'auto_relay',
       })
+      // `--continue` bypasses cmdReply's anti-monologue gate, and the relay is
+      // the one caller that must have it.
+      //
+      // The operating rules above REQUIRE an intent message before any work
+      // that keeps the asker waiting ("Drafting the email now"), posted as a
+      // SEPARATE `cumora reply`. In a group of three or more that intent
+      // message is then the room's last message and less than ten minutes old,
+      // which is exactly what the gate refuses — so the relay of the actual
+      // answer failed, `finalStatus` went to 'failed', and the room got
+      // "Agent run failed before it could finish. No result was produced."
+      // in place of the work the agent had just done.
+      //
+      // The gate exists to stop the agent DECIDING to speak again: "each
+      // wake-up is a fresh 'should I respond?' decision with no global
+      // stop-signal" (see cmdReply). The relay is not a decision. It is the
+      // runtime delivering text the model already composed and explicitly
+      // declared as this turn's reply, at most once per turn — the deliberate
+      // commitment `--continue` was documented for.
+      //
+      // The flag goes LAST on purpose. parseArgs reads `--continue <token>` as
+      // a value flag, so placing it before the body would consume the body and
+      // post an empty message.
       const relay = await executePodTool({
         agentId, name: 'bash',
-        argsJson: JSON.stringify({ command: `cumora reply ${target.conversationId} ${escaped}` }),
+        argsJson: JSON.stringify({ command: `cumora reply ${target.conversationId} ${escaped} --continue` }),
         ns: namespace,
       })
       if (!relay.ok) {


### PR DESCRIPTION
## What a user sees

> I asked Nova in our #product room to draft the launch email. It replied **"Drafting the email now — ~30s"** and then went silent. The draft never arrived. Sometimes the room shows a red line instead: **"Agent run failed before it could finish. No result was produced."**
>
> The exact same request in a DM with Nova works fine.

## The product mandates a flow its own backstop rejects

`turn.ts` puts this in every turn's operating rules:

> **ANNOUNCE BEFORE LONG OR VISIBLE-EFFECT WORK** … POST A SHORT INTENT MESSAGE first via `cumora reply` … THEN do the work. THEN reply with the actual result. The intent message must be a **SEPARATE** `cumora reply` call, NOT chained with `&&`.

`cmdReply`'s anti-monologue gate then refuses exactly that second call:

```ts
const monologueBypass = Boolean(parsed.flags.continue || parsed.flags.also)
if (!monologueBypass && cv[0].actor_is_agent && cv[0].member_count > 2) {
  // …if my own message is last and younger than 10 minutes…
  return err(`you already posted in ${convoId} ${ageSec}s ago and nobody has replied yet …`)
```

Its exemptions are DMs, a ten-minute valve, and `--continue`. The announce-then-deliver flow is not among them — so in any room of three or more, following the rules costs the agent its answer.

## Where it turns destructive

The declared relay, because no model judgment is involved:

```ts
command: `cumora reply ${target.conversationId} ${escaped}`   // no flag
```

`relay.ok` is false → `finalStatus = 'failed'` → `postTurnFailureNotices` posts

> Agent run failed before it could finish (…). **No result was produced.**

into the room, in place of the work the agent had just done. The user asked, the agent said "on it", did the work, and the room got a red notice.

## The fix

Give the relay the bypass — `--continue`, appended last.

The gate exists to stop the agent **deciding** to speak again. Its own comment says why: *"each wake-up is a fresh 'should I respond?' decision with no global stop-signal."* The relay is not a decision. It is the runtime delivering text the model already composed and **explicitly declared** as this turn's reply (`assistant_text: "reply"` + `reply_conversation_id`), at most once per turn. That is precisely the deliberate commitment `--continue` is documented for:

> Bypass via `--continue` / `--also`: rare cases where the agent genuinely has to add to its own previous message … The flag forces the agent to commit deliberately rather than absent-mindedly continuing to monologue.

**The flag has to go last.** `parseArgs` reads `--continue <token>` as a *value* flag, so putting it before the body would consume the body and post an empty message. That is not hypothetical — it is what the parser does, and there is a test for it, because moving the flag to the front reads like a harmless tidy-up.

`flags.continue` is referenced in exactly one place in `cli.ts` (the gate), so the flag has no other effect.

## Scope, stated plainly

This fixes the deterministic path — the one where the answer is destroyed *and* replaced with a failure notice, with no model in the loop.

The model-driven path (the model calls `cumora reply` twice itself) still hits the gate and, per `personas.ts`, is told not to retry — so the answer is lost quietly rather than loudly. Reconciling that properly means either exempting a same-turn announce (which needs a run id the CLI does not currently have — messages carry no `run_id` and `executePodTool` does not plumb one) or relaxing the prompt rule. Both are your call, so I have left them alone rather than pick one on your behalf.

## Tests

Four drive the real `cmdReply` against Postgres, in `agent-anti-duplicate.test.ts` — the file that already owns this contract:

- **the gate refuses the result that the mandated intent message asked for** — the state being fixed, pinned so the interaction cannot silently return
- **the relay delivers that result, body intact** — asserts the stored body, not just `ok`
- **the bypass flag has to come after the body** — the `parseArgs` trap
- **a plain second post is still refused** — the guard rail: this must not turn the gate off

The fifth reads `turn.ts`, because the four above pass just as well against a relay that sends no flag. Verified red by removing the flag:

```
the declared relay no longer bypasses the anti-monologue gate — after the
intent message the rules require, the agent's answer is refused and the room
gets a failure notice instead
```

`agent-turn.test.ts`'s existing relay stub matched the command with a `$`-anchored regex. It now **requires** the flag rather than merely tolerating it, so that test becomes a second guard.

Green locally: `tsc --noEmit` (server + renderer), `biome lint .`, all three `scripts/guard-*.mjs`, the unit suite (1332 tests, 0 failures), the full `agent-anti-duplicate` suite (14/14), and all four declared-relay tests in `agent-turn`. The rest of `agent-turn` needs a real model endpoint — it is 17-of-24 red on clean `main` in my environment, so I am leaning on CI for that file rather than claiming a local result I do not have.
