### PR TITLE
release: v0.18.0

### DIFF
--- a/agent-cli/package.json
+++ b/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cumora",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Run Cumora agents on your own machine with Claude Code, Codex, Antigravity, and other BYOA engines.",
   "license": "MIT",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cumora",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cumora",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1045.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cumora",
   "private": true,
-  "version": "0.17.0",
+  "version": "0.18.0",
   "type": "module",
   "main": "electron/main.cjs",
   "bin": {


### PR DESCRIPTION
Everything merged to `main` since `v0.17.0`. Minor bump: three user-visible features land (per-agent Claude provider profiles, the ZCode BYOA engine, one-of-us routing election), plus two schema migrations and a document data-loss fix.

## Features

- **Per-agent Claude provider profiles** (#233) — an agent can carry its own Claude provider config instead of inheriting one global profile. Migration `0008-agent-provider-profile`.
- **ZCode as a BYOA engine** (#247) — a new engine adapter bridging `zcode-acp-server` over ACP. Lands in the compatibility tier (`SANDBOXED_ENGINE_IDS` is unchanged), so it needs `CUMORA_BYOA_ALLOW_UNSANDBOXED=1` to run.
- **One agent is elected for unaddressed human group messages** (#123) — in a room with N agents, an unaddressed human message wakes one primary instead of all N. Behind `ROUTING_ONE_OF_US`, **default off**. Migration `0009-agent-routing-claims`.

## Fixes

- **Document compaction no longer deletes persisted edits** (#262) — compaction snapshotted the live in-memory room but trimmed `document_updates` by `MAX(id)`. Those two cover different sets, so an update persisted by another instance could be deleted without ever entering the snapshot: permanent loss on the next cold load. Snapshots are now built from the persisted log under a document-level advisory lock, and only the exact merged rows are deleted.
- **The anti-monologue gate no longer eats the relayed answer** (#263) — when the agent's own message was the room's last and under ten minutes old, the runtime's declared relay was refused and the room got "Agent run failed... No result was produced." in place of the work. The relay now carries `--continue`. The verbatim-duplicate check is unaffected — it is deliberately not gated on the bypass.
- **The person who writes a reply can open the thread they started** (#261) — the author's own root message never got its `replyCount` bumped, and `replyCount > 0` gates the only `openThreadView` call site, so the author had no entrance to their own thread.
- **Selected is not watched** (#260) — a conversation that is selected but off-screen (window blurred, tab hidden, mobile list view) no longer marks arriving messages read.
- **FUSE: dirty workspace writes are preserved** (#251), and **a path truncate is durable, an absurd size an error** (#259).
- **R2: email attachments are gated before bucket reads** (#252).
- **WS: document authorization fanout is bounded** (#256).
- **Ops: startup probes align with the schema boot budget** (#253).
- **Deploy: schema-compatible recovery is guarded** (#257).
- **Agent: a demoted runtime boundary is enforced** (#258).

## Schema

`MIN_SUPPORTED_SCHEMA_VERSION` / `MAX_SUPPORTED_SCHEMA_VERSION` move **7 → 9** (migrations 0008 and 0009).

There is **no overlap** with the v0.17.0 image's supported range (7–7). Once the candidate migration Job takes production to 9, the previous image can no longer boot, so the deploy workflow's automatic recovery will classify a failed candidate as *newer schema* and **refuse to auto-restore** — by design. If the candidate rollout fails, the path forward is a forward-compatible image, not a rollback. Both migrations are additive (one new column set, one new table) and neither rewrites existing rows.

Migration `0009` creates a brand-new table plus its index, so it does not contend with production traffic for locks — the multi-table-DDL deadlock that bit v0.13.1/v0.14.0 does not apply here.

## Verification

Ran on the merged tree (`main` + this bump), same gates as CI:

- `npm run lint` (Biome) — pass
- `npm run typecheck` — pass
- `npm run server:typecheck` — pass
- `npm run guard:big-brain`, `guard:llm-tracked`, `guard:engine-registry` — pass
- `npm test` — pass (the one local failure is `agents-observability-turns.test.ts`, which needs a real Postgres; CI provides one)
- Migration checksum test (`schema-migrations.test.ts`) — pass


https://claude.ai/code/session_01Tw4EygpE4o73TMLzyPFWEv
