### PR TITLE
fix(agent): a failed turn must not bury the question it failed to answer

### DIFF
--- a/server/src/__integration__/agent-steer.test.ts
+++ b/server/src/__integration__/agent-steer.test.ts
@@ -1019,3 +1019,129 @@ test('[integration] steer queue resets at turn boundaries (no leak across turns)
   const ev = await eventsForAgent(agentId)
   assert.equal(ev.filter((e) => e.kind === 'turn.steered').length, 0)
 })
+
+// ─── a failed turn must not bury its own inbox ─────────────────────
+//
+// The cursor advance above lives in a `finally`, so it used to run whatever
+// the turn's outcome was. A steer arrives DURING the turn, so its
+// (created_at, id) is later than every message the turn was answering, and
+// loadInbox compares ONE cursor per conversation:
+//
+//   AND ROW(mm.created_at, mm.id) > ROW(co.lr_at, co.lr_id)
+//
+// Advancing to the steer therefore buries the original question too. Ask
+// something, add a follow-up while the agent is working, let the turn die:
+// the room gets "Agent run failed … No result was produced" and BOTH messages
+// are gone from every future inbox.
+//
+// It also contradicted the fingerprint contract in the same file: "Failed
+// turns do not update the fingerprint, so they remain retryable instead of
+// disappearing into a silent skip." Retryable work needs its rows to survive.
+
+async function readCursor(agentId: string, conversationId: string): Promise<string | null> {
+  const { rows } = await pool.query<{ last_read_message_id: string | null }>(
+    `SELECT last_read_message_id FROM conversation_reads WHERE user_id = $1 AND conversation_id = $2`,
+    [agentId, conversationId],
+  )
+  return rows[0]?.last_read_message_id ?? null
+}
+
+/** Drive one turn that drains a steer and then dies on the next LLM call.
+ *  `makeLlmStub` throws once its scripted streams run out, which is a faithful
+ *  stand-in for the provider errors and MAX_HOPS exits that fail a real turn
+ *  after work has already happened. */
+async function runTurnThatDrainsASteerThenFails(): Promise<{
+  agentId: string; conversationId: string; originalId: string; steeredId: string
+}> {
+  const { companyId, agentId, humanId, conversationId } = await seedConvo()
+  const originalId = await postHumanMessage({
+    conversationId, companyId, humanId, body: 'original task: list files', sequence: 1,
+  })
+  const steeredId = await postHumanMessage({
+    conversationId, companyId, humanId, body: 'wait, also include hidden files', sequence: 2,
+  })
+
+  // One scripted hop only: the drain happens inside it, then the next call
+  // throws and the turn ends 'failed'.
+  const llm = makeLlmStub([
+    streamWithToolCall({ fcId: 'fc_ls', callId: 'call_ls', name: 'bash', argsJson: JSON.stringify({ command: 'ls' }) }),
+  ])
+  llm.install()
+  makeToolStub({
+    bash: async () => {
+      pushSteer(agentId, {
+        messageId: steeredId, conversationId, authorName: 'alice',
+        body: 'wait, also include hidden files', arrivedAt: Date.now(),
+      })
+      await new Promise((r) => setTimeout(r, DEBOUNCE_MS + 200))
+      return {
+        ok: true, output: { stdout: 'file1\n', stderr: '', exitCode: 0 }, durationMs: DEBOUNCE_MS + 200,
+        display: { name: 'bash', arg: 'ls', status: 'ok', detail: '' },
+      }
+    },
+  }).install()
+
+  await assert.rejects(runAgentTurn(agentId))
+  return { agentId, conversationId, originalId, steeredId }
+}
+
+test('[integration] a failed turn leaves both the steer and the question it interrupted unread', async () => {
+  const { agentId, conversationId, originalId, steeredId } = await runTurnThatDrainsASteerThenFails()
+
+  const { rows: runs } = await pool.query<{ status: string }>(
+    `SELECT status FROM agent_runs WHERE agent_id = $1`, [agentId],
+  )
+  assert.equal(runs[0].status, 'failed', 'the turn did fail — that is the premise, not the bug')
+
+  const cursor = await readCursor(agentId, conversationId)
+  assert.notEqual(
+    cursor, steeredId,
+    'the failed turn advanced the read cursor onto the steer, which buries the original question with it',
+  )
+
+  const { inprocClient } = await import('../agents/runtime/inproc-client.js')
+  const inbox = await inprocClient.loadInbox(agentId)
+  const ids = inbox.map((m) => m.id)
+  assert.ok(ids.includes(steeredId), 'the follow-up must still be waiting to be answered')
+  assert.ok(ids.includes(originalId), 'the question the follow-up interrupted must still be waiting too')
+})
+
+test('[integration] a completed turn still advances the cursor', async () => {
+  // The guard rail. Without the advance a completed turn re-processes its own
+  // steer on the next wake, which is exactly what that code was added for.
+  const { companyId, agentId, humanId, conversationId } = await seedConvo()
+  await postHumanMessage({ conversationId, companyId, humanId, body: 'original task', sequence: 1 })
+  const steeredId = await postHumanMessage({
+    conversationId, companyId, humanId, body: 'follow-up', sequence: 2,
+  })
+
+  const llm = makeLlmStub([
+    streamWithToolCall({ fcId: 'fc_ls', callId: 'call_ls', name: 'bash', argsJson: JSON.stringify({ command: 'ls' }) }),
+    streamSetTurnStatus(),
+  ])
+  llm.install()
+  makeToolStub({
+    bash: async () => {
+      pushSteer(agentId, {
+        messageId: steeredId, conversationId, authorName: 'alice',
+        body: 'follow-up', arrivedAt: Date.now(),
+      })
+      await new Promise((r) => setTimeout(r, DEBOUNCE_MS + 200))
+      return {
+        ok: true, output: { stdout: '', stderr: '', exitCode: 0 }, durationMs: DEBOUNCE_MS + 200,
+        display: { name: 'bash', arg: 'ls', status: 'ok', detail: '' },
+      }
+    },
+  }).install()
+
+  await runAgentTurn(agentId)
+
+  const { rows: runs } = await pool.query<{ status: string }>(
+    `SELECT status FROM agent_runs WHERE agent_id = $1`, [agentId],
+  )
+  assert.equal(runs[0].status, 'completed')
+  assert.equal(
+    await readCursor(agentId, conversationId), steeredId,
+    'a completed turn must still consume the steer it drained',
+  )
+})

--- a/server/src/agents/turn.ts
+++ b/server/src/agents/turn.ts
@@ -3510,7 +3510,25 @@ Mechanics:
     // agent would re-process them. Per-conversation: take the
     // latest message id we drained (markConversationRead picks the
     // max created_at via GREATEST(...) so out-of-order is fine).
-    if (steeredMessageIds.size > 0) {
+    //
+    // ONLY on a completed turn. This is a `finally`, so it used to run on
+    // 'failed' and 'skipped' too — and there the advance is not an
+    // optimization, it is a deletion. A steer arrived DURING the turn, so its
+    // (created_at, id) is later than every message the turn was answering, and
+    // loadInbox compares one cursor per conversation:
+    //
+    //   AND ROW(mm.created_at, mm.id) > ROW(co.lr_at, co.lr_id)
+    //
+    // so advancing to the steer buries the turn's own unanswered inbox with
+    // it. Ask a question, add a follow-up while the agent works, let the turn
+    // die at MAX_HOPS or on a 429: the room gets a failure notice and BOTH
+    // messages are gone from every future inbox. Nothing retries them.
+    //
+    // That also contradicted the fingerprint contract twenty lines up:
+    // "Failed turns do not update the fingerprint, so they remain retryable
+    // instead of disappearing into a silent skip." Retryable work needs its
+    // inbox rows to still be there.
+    if (steeredMessageIds.size > 0 && finalStatus === 'completed') {
       // Group by conversation so we only do one upsert per convo.
       const byConvo = new Map<string, string>()
       for (const [messageId, conversationId] of steeredMessageIds) {


### PR DESCRIPTION
## What happens

You ask an agent something. While it is working you add a follow-up. The turn dies — `MAX_HOPS`, a provider error, a 429.

The room gets **"Agent run failed before it could finish. No result was produced."**

And then nothing. Not the follow-up, not the original question. Both are gone from every future inbox, the agent never retries either, and the only recovery is for you to notice the silence and re-ask both.

## Why

The steer read-cursor advance sits in `runAgentTurn`'s `finally`, guarded only on whether anything was drained:

```ts
if (steeredMessageIds.size > 0) {
  …
  await runtime.markConversationRead({ agentId, conversationId, upToMessageId })
```

A `finally` runs on `'completed'`, on `'skipped'`, on `'failed'`, and on a thrown error alike.

On anything but `'completed'` that advance is not an optimization — it is a deletion, and it takes more than the steer with it. A steered message arrived **during** the turn, so its `(created_at, id)` is later than every message the turn was answering. `loadInbox` compares **one cursor per conversation**:

```sql
AND ROW(mm.created_at, mm.id) > ROW(co.lr_at, co.lr_id)
```

So moving the cursor onto the steer also moves it past the original question sitting behind it.

```
09:00:00  Q1  "summarize the incident"        ← the turn's inbox
09:01:00  Q2  "and include the timeline"      ← steered mid-turn, drained at hop 3
          …hops 4-12… MAX_HOPS → finalStatus = 'failed'
          finally → markConversationRead(…, upToMessageId = Q2)
          cursor = (09:01:00, Q2)  →  Q1 and Q2 both excluded, forever
```

The correlation is adverse rather than incidental: long multi-hop turns are both the ones users interrupt with a follow-up and the ones that hit `MAX_HOPS`.

## Two mechanisms in one file, disagreeing

Twenty lines above, the fingerprint contract:

> Skip the LLM if this agent already completed exactly this inbox in their previous wake. **Failed turns do not update the fingerprint, so they remain retryable instead of disappearing into a silent skip.**

`lastCompletedInbox.set(...)` is reached only under `if (finalStatus === 'completed')`. So the runtime's stated invariant is that a failure leaves the work re-doable — and the cursor advance was quietly deleting the rows that work is made of.

The comment on the advance reasons only about the other direction:

> failures fall through to console.warn (the message stays in inbox; next wake re-reads it which is fine — markConversationRead is purely an OPTIMIZATION, not a correctness requirement)

That is true of *failing to mark*. Nobody had reasoned about *marking on a turn that produced nothing*, and there the same call is the delete key.

## The fix

Gate the advance on `finalStatus === 'completed'` — the same line the fingerprint already draws. One condition; the two mechanisms now agree.

## Tests

- **a failed turn leaves both the steer and the question it interrupted unread** — drives a real turn that drains a steer and then dies, then asserts the cursor did not move onto the steer and that `loadInbox` still returns *both* messages. Verified red against the ungated advance:

  ```
  the failed turn advanced the read cursor onto the steer, which buries the
  original question with it
  ```

- **a completed turn still advances the cursor** — the guard rail: without the advance a completed turn re-processes its own steer on the next wake, which is exactly what that code exists for. Green either way, on purpose.

Green: `tsc --noEmit` (server + renderer), `biome lint .`, all three `scripts/guard-*.mjs`, the unit suite (1390 tests, 0 failures), and the full `agent-steer` suite — 13/13, run twice cleanly. (An earlier run showed three unrelated steer tests failing; that was contention from my own overlapping test processes, not this change. `main` and this branch both pass the suite when it has the database to itself.)

## Related

[#266](https://github.com/yetone/cumora/pull/266) fixes the notice this failure posts — that it claims "No result was produced" even where a result was. This one fixes what the failure does to the questions. They are independent and can land in either order.
