### PR TITLE
release: v0.18.1

### DIFF
--- a/agent-cli/package.json
+++ b/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cumora",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Run Cumora agents on your own machine with Claude Code, Codex, Antigravity, and other BYOA engines.",
   "license": "MIT",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cumora",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cumora",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1045.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cumora",
   "private": true,
-  "version": "0.18.0",
+  "version": "0.18.1",
   "type": "module",
   "main": "electron/main.cjs",
   "bin": {


### PR DESCRIPTION
Cuts v0.18.1 over the three fixes merged since v0.18.0.

- **#265** — document edits were lost when a WebSocket send failed. Failed updates are now retained and merged for retry, edits wait for the subscription snapshot before going out, and local state missing from the server is replayed after reconnect.
- **#267** — a failed turn advanced the steer read-cursor from its `finally`, which buried not just the steer but the original question behind it. Both were gone from every future inbox with nothing to retry them. The advance is now gated on `completed`, matching the line the fingerprint contract already draws.
- **#268** — the anti-monologue gate refused the delivery half of the announce-then-deliver flow the rules mandate. A run id now reaches `cumora reply`, so the gate can tell "delivering what I announced this turn" from "woke up and decided to talk again". Capped at two posts per turn per conversation; fail-closed without a run id.

Version only — `package.json`, `agent-cli/package.json`, `package-lock.json`.
