### PR TITLE
fix(deploy): let a catch-up migration outlive the 10-minute Job deadline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,10 @@ on:
         default: 'off'
         type: choice
         options: ['off', 'archive-detach']
+      migration_deadline_seconds:
+        description: 'Candidate migration Job deadline in seconds (60-2700). Raise only for a large catch-up migration.'
+        required: false
+        default: '600'
       recovery_mode:
         description: 'Baseline mode (normal requires known-good baseline; forward-only never auto-restores)'
         required: false
@@ -49,10 +53,11 @@ jobs:
   deploy:
     name: Roll cumora-server
     runs-on: ubuntu-latest
-    # The candidate rollout, bounded old-image verifier, restore rollout, and
-    # two authenticated smokes fit inside this job budget.  A cancellation
-    # cannot be relied on to run cleanup, so recovery state remains protected.
-    timeout-minutes: 45
+    # The candidate migration (up to the 2700s input ceiling), candidate
+    # rollout, bounded old-image verifier, restore rollout, and two
+    # authenticated smokes fit inside this job budget.  A cancellation cannot
+    # be relied on to run cleanup, so recovery state remains protected.
+    timeout-minutes: 75
     environment:
       name: production
       url: https://api.cumora.ai
@@ -76,13 +81,29 @@ jobs:
         env:
           INPUT_TAG: ${{ inputs.tag }}
           INPUT_INCLUDE_AGENT: ${{ inputs.include_agent || 'Y' }}
+          INPUT_MIGRATION_DEADLINE: ${{ inputs.migration_deadline_seconds || '600' }}
         run: |
           set -euo pipefail
           TAG="$INPUT_TAG"
           INCLUDE_AGENT="$INPUT_INCLUDE_AGENT"
           case "$INCLUDE_AGENT" in Y|N) ;; *) echo "::error::include_agent must be Y or N"; exit 1 ;; esac
+          # Reject anything that is not a plain integer before it can reach
+          # activeDeadlineSeconds, where a NaN would silently become the
+          # script's 600s default and hide the operator's intent.
+          DEADLINE="$INPUT_MIGRATION_DEADLINE"
+          case "$DEADLINE" in ''|*[!0-9]*) echo "::error::migration_deadline_seconds must be an integer, got '$DEADLINE'"; exit 1 ;; esac
+          if [ "$DEADLINE" -lt 60 ] || [ "$DEADLINE" -gt 2700 ]; then
+            echo "::error::migration_deadline_seconds must be between 60 and 2700, got $DEADLINE"
+            exit 1
+          fi
+          # The poller runs at RECOVERY_POLL_MS (3s) and must outlive the Job's
+          # own deadline, or a slow migration reports job_timeout instead of the
+          # real terminal condition Kubernetes recorded.
+          POLL_ATTEMPTS=$(( DEADLINE / 3 + 20 ))
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "include_agent=$INCLUDE_AGENT" >> "$GITHUB_OUTPUT"
+          echo "migration_deadline=$DEADLINE" >> "$GITHUB_OUTPUT"
+          echo "migration_poll_attempts=$POLL_ATTEMPTS" >> "$GITHUB_OUTPUT"
 
       - uses: google-github-actions/auth@v2
         with:
@@ -144,8 +165,8 @@ jobs:
           CANDIDATE_SERVER_IMAGE: ${{ steps.digest.outputs.server }}
           CANDIDATE_AGENT_IMAGE: ${{ steps.digest.outputs.agent }}
           MIGRATION_REPAIR: ${{ inputs.repair_0002 || 'off' }}
-          MIGRATION_DEADLINE_SECONDS: '600'
-          MIGRATION_POLL_ATTEMPTS: '200'
+          MIGRATION_DEADLINE_SECONDS: ${{ steps.tag.outputs.migration_deadline }}
+          MIGRATION_POLL_ATTEMPTS: ${{ steps.tag.outputs.migration_poll_attempts }}
           VERIFIER_POLL_ATTEMPTS: '75'
           RECOVERY_POLL_MS: '3000'
           ROLLOUT_TIMEOUT_SECONDS: '600'

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -46,6 +46,13 @@ To deploy a candidate:
    bundled CLI/runtime, or the agent-computer image. Otherwise use `N`.
    Leave `repair_0002=off` unless you are clearing the migration 0002
    precondition — see below.
+   Leave `migration_deadline_seconds` at `600` for an ordinary deploy, which
+   applies at most one small migration. Raise it (ceiling 2700) only for a
+   catch-up deploy that has many pending migrations or a large backfill: a
+   Job killed by `DeadlineExceeded` reports as `job_failed`, and a deadline
+   sized for the common case is what makes that signal mean "stuck". Every
+   migration is either transactional or built to be safely rerun, so a
+   deadline kill leaves the Deployment untouched and the schema intact.
 4. Approve the protected `production` environment. The approver should not be
    the person who built the feature for high-risk changes.
 5. Verify the workflow summary contains the selected digest, a completed


### PR DESCRIPTION
Deploy run [34529081984](https://github.com/yetone/cumora/actions/runs/34529081984) failed with `deploy-release: job_failed` after 10m14s. The Job's own events say why:

```
Warning  DeadlineExceeded  job-controller  Job was active longer than specified deadline
```

`activeDeadlineSeconds` is `600`, and the poller is `200 × 3s` — also 600s — so both bounds land together and the failure arrives as a bare `job_failed` with the pod already deleted and its logs gone.

600s is the right number for an ordinary deploy, which applies at most one small migration. It is the wrong number for a catch-up deploy that has to apply every pending migration in a single Job, one of which is a `CREATE INDEX CONCURRENTLY` over a production-sized table.

**What changes**

- `migration_deadline_seconds` becomes a workflow input, **defaulting to the same 600**. Ordinary deploys are unaffected.
- It is validated as a plain integer in `[60, 2700]` in the resolve step. Without that check a non-numeric value reaches `Number(...)` in `deploy-release.mjs`, becomes `NaN`, and falls through to that script's own 600s default — silently discarding what the operator asked for.
- Poll attempts are derived as `deadline / 3 + 20`, so the poller outlives the Job's deadline and reports the terminal condition Kubernetes actually recorded rather than `job_timeout`.
- `timeout-minutes` 45 → 75, covering the 2700s ceiling plus the 600s rollout and both smokes.

**Why the default stays at 600:** a deadline sized for the common case is what makes `DeadlineExceeded` mean *stuck* rather than *busy*. Raising it globally would remove that signal from every deploy to serve a one-time backfill.

**On safety of the kill that prompted this:** migration 0002 is `transactional: true`, so the killed pod rolled back rather than leaving a partial detach; 0005 and 0006 are `transactional: false` but use `ensureConcurrentIndex`, which repairs an INVALID index left by an interrupted build. The Deployment was never patched — the migration is the step before it. Production is on its previous image and the schema is intact and rerunnable, which is the behaviour `docs/RELEASE.md` already promises.

The residual Job is terminal (`Failed=True`, `active` unset) and carries no active writer, so `listResidualMigrationJobs` will not block the retry.