### PR TITLE
fix(deploy): resolve the proxy probe's named port so the migration can start

### DIFF
--- a/server/src/__tests__/deployment-recovery.test.ts
+++ b/server/src/__tests__/deployment-recovery.test.ts
@@ -276,3 +276,50 @@ test('verifier script is old-image-local, read-only, bounded, and uses strict pr
     assert.equal(parseSchemaVerifierOutput(output).status, 'unknown')
   }
 })
+
+test("a proxy probe on a named port is resolved to its number, because the Job has no port list", () => {
+  // Production's proxy declares `ports: [{containerPort: 9090, name: pg-health}]`
+  // and probes that name.  The Job strips `ports`, so shipping the name verbatim
+  // leaves kubelet parsing "pg-health" as an integer forever: the sidecar never
+  // reports `started`, the migrate container never launches, and the Job dies of
+  // DeadlineExceeded having run nothing.
+  const deployment = deploymentFixture() as any
+  const proxy = deployment.spec.template.spec.containers[0]
+  proxy.ports = [{ containerPort: 9090, name: 'pg-health', protocol: 'TCP' }]
+  proxy.startupProbe = {
+    httpGet: { path: '/readiness', port: 'pg-health', scheme: 'HTTP' },
+    periodSeconds: 2,
+    failureThreshold: 30,
+  }
+  const baseline = extractDeploymentSnapshot(deployment, { capturedAt: '2026-09-10T00:00:00.000Z' })
+  const job = buildMigrationJob(baseline, {
+    name: 'cumora-migrate-named-port',
+    image: `server@sha256:${DIGEST_CANDIDATE}`,
+    repairMode: 'off',
+  })
+
+  const jobProxy = templateSpec(job).initContainers.find((c: any) => c.name === 'cloud-sql-proxy')
+  assert.equal(jobProxy.startupProbe.httpGet.port, 9090)
+  // The rest of the operator's probe is preserved, not replaced by the default.
+  assert.equal(jobProxy.startupProbe.failureThreshold, 30)
+  assert.equal(jobProxy.startupProbe.httpGet.path, '/readiness')
+  // A Job container still carries no port declarations.
+  assert.equal(jobProxy.ports, undefined)
+})
+
+test('an unresolvable named probe port falls back to a probe that can actually pass', () => {
+  const deployment = deploymentFixture() as any
+  const proxy = deployment.spec.template.spec.containers[0]
+  // Name declared nowhere: keeping it would ship a permanently erroring probe.
+  proxy.startupProbe = { httpGet: { path: '/readiness', port: 'pg-health' }, failureThreshold: 30 }
+  const baseline = extractDeploymentSnapshot(deployment, { capturedAt: '2026-09-10T00:00:00.000Z' })
+  const job = buildMigrationJob(baseline, {
+    name: 'cumora-migrate-unresolvable-port',
+    image: `server@sha256:${DIGEST_CANDIDATE}`,
+    repairMode: 'off',
+  })
+
+  const jobProxy = templateSpec(job).initContainers.find((c: any) => c.name === 'cloud-sql-proxy')
+  assert.equal(jobProxy.startupProbe.httpGet.port, 9090)
+  assert.equal(jobProxy.startupProbe.failureThreshold, 60)
+})

--- a/server/src/deploy/recovery.ts
+++ b/server/src/deploy/recovery.ts
@@ -493,6 +493,33 @@ function cleanContainerForJob(container: JsonObject): JsonObject {
   return result
 }
 
+/**
+ * A probe copied out of the Deployment may target a *named* port, but the Job's
+ * containers carry no `ports` list (cleanContainerForJob strips it), so the name
+ * has nothing to resolve against.  kubelet then falls back to parsing the name
+ * as a number, the probe errors permanently ("strconv.Atoi: parsing ..."), the
+ * native sidecar never reports `started`, and the migrate container is never
+ * launched at all — the Job silently burns its whole activeDeadlineSeconds and
+ * dies as DeadlineExceeded with no logs.  Resolve the name to its number here,
+ * while the source container's port list is still in hand, and return null when
+ * it cannot be resolved so the caller uses its own numeric probe rather than one
+ * that can never pass.
+ */
+function resolveProbePorts(probe: unknown, ports: unknown): JsonValue | null {
+  if (!isRecord(probe) || !isJsonValue(probe)) return null
+  const resolved = cloneJson(probe) as JsonObject
+  for (const key of ['httpGet', 'tcpSocket']) {
+    const target = resolved[key]
+    if (!isRecord(target) || typeof target.port !== 'string') continue
+    const declared = Array.isArray(ports)
+      ? ports.find((entry) => isRecord(entry) && entry.name === target.port && typeof entry.containerPort === 'number')
+      : undefined
+    if (!isRecord(declared)) return null
+    target.port = declared.containerPort
+  }
+  return resolved
+}
+
 function podSpecForJob(template: JsonObject): { pod: JsonObject; server: JsonObject; proxy: JsonObject; proxyStartupProbe: JsonValue } {
   const spec = asJsonObject(getObjectPath(template, ['spec'], 'pod template'), 'pod template spec')
   const allInit = Array.isArray(spec.initContainers) ? spec.initContainers : []
@@ -504,13 +531,11 @@ function podSpecForJob(template: JsonObject): { pod: JsonObject; server: JsonObj
   delete pod.containers
   delete pod.initContainers
   delete pod.ephemeralContainers
-  const proxyStartupProbe = isJsonValue(proxySource.startupProbe)
-    ? cloneJson(proxySource.startupProbe)
-    : {
-        httpGet: { path: '/readiness', port: 9090 },
-        periodSeconds: 1,
-        failureThreshold: 60,
-      }
+  const proxyStartupProbe = resolveProbePorts(proxySource.startupProbe, proxySource.ports) ?? {
+    httpGet: { path: '/readiness', port: 9090 },
+    periodSeconds: 1,
+    failureThreshold: 60,
+  }
   return { pod, server: cleanContainerForJob(server), proxy: cleanContainerForJob(proxySource), proxyStartupProbe }
 }
 


### PR DESCRIPTION
## What breaks

The production deploy has not been able to run its schema migration. Run `34529081984` failed with `deploy-release: job_failed` after the Job hit `DeadlineExceeded` at 600s, which reads as "the catch-up migration is too big". It is not — the migration never started at all.

The Deployment's `cloud-sql-proxy` declares:

```yaml
ports: [{containerPort: 9090, name: pg-health}]
startupProbe: {httpGet: {path: /readiness, port: pg-health}}
```

`buildMigrationJob` copies that probe onto the Job's sidecar, but `cleanContainerForJob` strips `ports`. The name then has nothing to resolve against, and kubelet says so:

```
Warning  Unhealthy  pod/cumora-migrate-...  Startup probe errored and resulted in
unknown state: strconv.Atoi: parsing "pg-health": invalid syntax
```

A native sidecar whose startup probe never passes never reports `started`, so the `migrate` container is never launched. Observed live in `cumora-migrate-e11b024-34531956583`: proxy `ready=false started=false`, proxy logs `"The proxy has started successfully and is ready for new connections!"`, migrate container `PodInitializing` nine minutes in. The Job then burns its whole deadline and its pod is reaped, so there are no logs to reveal that nothing ran.

## The fix

Resolve a named `httpGet`/`tcpSocket` port against the source container's port list at the point where the probe is copied, while that list is still in hand. When the name cannot be resolved, return `null` so the caller keeps its existing numeric default — shipping a probe that can never pass is strictly worse than using our own.

The Job's containers still declare no `ports`; only the probe target changes.

## Tests

The fixture's proxy had neither `ports` nor a `startupProbe`, so the suite only ever exercised the numeric fallback path — which is exactly why this never showed up before production. Two cases added, both verified to fail on `main`:

```
not ok 4 - a proxy probe on a named port is resolved to its number, ...
not ok 5 - an unresolvable named probe port falls back to a probe that can actually pass
```