### PR TITLE
fix(agent): compaction must not hoist an answered steer to the newest-input slot

### DIFF
--- a/server/src/__tests__/agents-turn-compaction.test.ts
+++ b/server/src/__tests__/agents-turn-compaction.test.ts
@@ -776,3 +776,103 @@ test('summary: items with no call_id (legacy / bare function_call) do NOT confus
   assert.equal(last.type, 'function_call')
   assert.equal(last.name, 'orphan')
 })
+
+// ── Position preservation: an answered steer must not be re-asked ───────────
+//
+// Mid-turn steers (turn.ts `tryDrainSteer`) push the new user message into
+// `history` as a role:'user' item, and the tool calls that ANSWER it land
+// after it. That ordering is the only in-context evidence the steer was
+// handled: assistant text is deliberately never added as a history item
+// (turn.ts, "would corrupt history shape — see earlier bug"), so there is no
+// assistant message for the model to see its own reply in.
+//
+// Stage 2 used to bucket every non-tool item sitting after the first tool item
+// and re-append that bucket AFTER all surviving pairs. A steer answered in hop
+// 5 therefore reappeared as the LAST item of the hop-20 input — the fresh-input
+// slot — with its answer now ordered before the question, while its text reads
+// as an imperative fresh arrival ("Re-assess your current plan … respond to the
+// new message in its own conversation"). The agent replied to the user twice.
+
+const steerMsg = (text: string): ResponseInputItem => ({
+  type: 'message',
+  role: 'user',
+  content: text,
+}) as unknown as ResponseInputItem
+
+/** History shaped like a real steered turn: seed question, two old tool
+ *  pairs, the steer, the pair that answered the steer, one later pair. */
+const steeredHistory = (): ResponseInputItem[] => [
+  userMsg('original question'),
+  fnCall('call_old1'), fnOutput('call_old1', 'a'),
+  fnCall('call_old2'), fnOutput('call_old2', 'b'),
+  steerMsg('[Mid-turn update — 1 new message received while you were working]\n@ana (in conversation c9):\nalso check the logs\nRe-assess your current plan in light of these and continue.'),
+  fnCall('call_answer'), fnOutput('call_answer', 'posted reply to c9'),
+  fnCall('call_later'), fnOutput('call_later', 'd'),
+]
+
+const indexOfSteer = (history: ResponseInputItem[]): number =>
+  history.findIndex((it) => {
+    const r = it as unknown as { content?: unknown }
+    return typeof r.content === 'string' && r.content.startsWith('[Mid-turn update')
+  })
+
+const indexOfCallId = (history: ResponseInputItem[], callId: string): number =>
+  history.findIndex((it) => (it as unknown as { call_id?: string }).call_id === callId)
+
+test('stage 2 (drop path): an ANSWERED mid-turn steer keeps its position — never hoisted to the newest-input slot', () => {
+  const result = compactHistory(steeredHistory(), ALWAYS_OVER)
+  assert.equal(result.droppedPairCount, 2, 'the two oldest pairs go; the steer and its answer survive')
+
+  const steerAt = indexOfSteer(result.newHistory)
+  assert.ok(steerAt >= 0, 'the steer itself must never be dropped')
+  assert.notEqual(
+    steerAt, result.newHistory.length - 1,
+    'the answered steer was hoisted into the newest-input slot — the model reads it as a fresh message and answers it again',
+  )
+  assert.ok(
+    steerAt < indexOfCallId(result.newHistory, 'call_answer'),
+    'the tool call that answered the steer must still come AFTER it — that ordering is the only evidence it was handled',
+  )
+  assert.ok(
+    steerAt < indexOfCallId(result.newHistory, 'call_later'),
+    'later work must stay after the steer',
+  )
+})
+
+test('stage 2 (summary path): an ANSWERED mid-turn steer keeps its position', async () => {
+  const result = await compactHistoryWithSummary(steeredHistory(), () => true, async () => 'ran two lookups')
+  assert.equal(result.usedLlmSummary, true)
+
+  const steerAt = indexOfSteer(result.newHistory)
+  assert.ok(steerAt >= 0, 'the steer itself must never be dropped')
+  assert.notEqual(
+    steerAt, result.newHistory.length - 1,
+    'the answered steer was hoisted into the newest-input slot on the summarized path too',
+  )
+  assert.ok(
+    steerAt < indexOfCallId(result.newHistory, 'call_answer'),
+    'the tool call that answered the steer must still come AFTER it',
+  )
+})
+
+test('stage 2: surviving tool items keep their original relative order (no regrouping by call_id)', () => {
+  // One hop can emit two function_calls and then both outputs:
+  // fc1, fc2, out1, out2 — that is the exact shape every UNCOMPACTED hop
+  // already sends on the wire. Compaction must hand back the same order it
+  // was given, not a re-grouped fc1,out1,fc2,out2.
+  const history: ResponseInputItem[] = [
+    userMsg('q'),
+    fnCall('call_drop'), fnOutput('call_drop', 'x'),
+    fnCall('call_a'), fnCall('call_b'), fnOutput('call_a', 'a'), fnOutput('call_b', 'b'),
+  ]
+  const result = compactHistory(history, ALWAYS_OVER)
+  const shape = result.newHistory.map((it) => {
+    const r = it as unknown as { type?: string; call_id?: string }
+    return r.call_id ? `${r.type}:${r.call_id}` : `${r.type}`
+  })
+  assert.deepEqual(shape, [
+    'message', 'message',
+    'function_call:call_a', 'function_call:call_b',
+    'function_call_output:call_a', 'function_call_output:call_b',
+  ])
+})

--- a/server/src/agents/turn-compaction.ts
+++ b/server/src/agents/turn-compaction.ts
@@ -38,6 +38,44 @@
  *   3. The most recent {@link KEEP_RECENT_PAIRS} pairs are NEVER
  *      dropped either — they're the immediate conversational context
  *      the model needs to continue from.
+ *
+ *   4. Everything that SURVIVES keeps its original relative POSITION.
+ *      Compaction only deletes; it never reorders. This one is not
+ *      cosmetic — it is the fix for the duplicate-reply bug below.
+ *
+ *      Stage 2 used to partition by item TYPE: every non-tool item
+ *      sitting after the first tool item went into a `tailNonTool`
+ *      bucket that both rebuilds re-appended AFTER all surviving
+ *      pairs. The only non-tool items that ever appear mid-history
+ *      are `role:'user'` items we inject ourselves — the mid-turn
+ *      steer render (turn.ts `tryDrainSteer`), the status-required
+ *      nudge, and the completion-rejection nudge. And there is no
+ *      assistant message in `history` for the model to see its own
+ *      reply in: assistant text is deliberately never added as a
+ *      history item (turn.ts: synthesizing one with no item_id /
+ *      part_id / responseId corrupts history shape — see the earlier
+ *      bug noted there). So the ONLY in-context evidence that a
+ *      steer was already handled is that the function_call /
+ *      function_call_output pairs answering it sit AFTER it.
+ *
+ *      The tail-move inverted exactly that: a steer answered in hop 5
+ *      came back as the LAST item of the hop-20 input — the
+ *      fresh-input slot — with its answer now ordered before the
+ *      question, while its own text reads as an imperative fresh
+ *      arrival ("[Mid-turn update — 1 new message received while you
+ *      were working] … Re-assess your current plan … respond to the
+ *      new message in its own conversation"). The agent did the work
+ *      a second time and posted a second reply, and turn.ts persists
+ *      the compacted array for every remaining hop, so it re-asked on
+ *      every hop after that. Same shape for the two nudges: a
+ *      satisfied nudge re-presented last is a live instruction again.
+ *
+ *      Rebuilding in order also stops compaction from re-grouping
+ *      interleaved items. One hop pushes all of its function_calls
+ *      and then all of its outputs (fc1, fc2, out1, out2); that is
+ *      the shape every UNCOMPACTED hop already puts on the wire, so
+ *      handing it back unchanged is strictly closer to known-good
+ *      than the fc1,out1,fc2,out2 the old bucket rebuild produced.
  */
 import type { ResponseInputItem } from 'openai/resources/responses/responses'
 
@@ -210,13 +248,15 @@ function groupKeyOf(item: ResponseInputItem): string | null {
   return null
 }
 
-/** Partition `history` into [leadingNonTool, pairGroups, tailNonTool].
- *  pairGroups is keyed by call_id and ordered by first appearance. */
+/** Partition `history` into [leadingNonTool, pairGroups]. pairGroups is
+ *  keyed by call_id and ordered by first appearance — it exists purely to
+ *  decide WHICH call_ids get dropped (and to measure them). It is not a
+ *  rebuild order: the rebuild walks the original array (see
+ *  {@link tailWithoutDroppedGroups}) so invariant 4 holds. */
 interface PartitionedHistory {
   leadingNonToolEnd: number
   callIdsInOrder: string[]
   pairItems: Map<string, ResponseInputItem[]>
-  tailNonTool: ResponseInputItem[]
 }
 
 function partitionHistory(history: ResponseInputItem[]): PartitionedHistory {
@@ -226,7 +266,6 @@ function partitionHistory(history: ResponseInputItem[]): PartitionedHistory {
   }
   const callIdsInOrder: string[] = []
   const pairItems = new Map<string, ResponseInputItem[]>()
-  const tailNonTool: ResponseInputItem[] = []
   for (let i = leadingNonToolEnd; i < history.length; i++) {
     const item = history[i]
     const key = groupKeyOf(item)
@@ -236,11 +275,37 @@ function partitionHistory(history: ResponseInputItem[]): PartitionedHistory {
         callIdsInOrder.push(key)
       }
       pairItems.get(key)!.push(item)
-    } else {
-      tailNonTool.push(item)
     }
+    // Non-tool items are NOT collected here. They are rebuilt from their
+    // original index — hoisting them to the tail is the duplicate-reply
+    // bug documented as invariant 4 in the module header.
   }
-  return { leadingNonToolEnd, callIdsInOrder, pairItems, tailNonTool }
+  return { leadingNonToolEnd, callIdsInOrder, pairItems }
+}
+
+/** Rebuild everything after the leading seed messages IN ORIGINAL ORDER,
+ *  skipping only the items whose call_id group was dropped. Non-tool
+ *  items (steer renders, protocol nudges) and un-pair-able items (a
+ *  malformed function_call with no call_id — `groupKeyOf` returns null,
+ *  so it is never drop-eligible) simply keep their slot.
+ *
+ *  Invariant 1 still holds by construction: membership is decided per
+ *  call_id group, so a function_call_output is kept iff its matching
+ *  function_call is kept. Nothing can be split, so upstream never sees
+ *  "No tool call found for function call output with call_id X". */
+function tailWithoutDroppedGroups(
+  history: ResponseInputItem[],
+  leadingNonToolEnd: number,
+  droppedCallIds: Set<string>,
+): ResponseInputItem[] {
+  const kept: ResponseInputItem[] = []
+  for (let i = leadingNonToolEnd; i < history.length; i++) {
+    const item = history[i]
+    const key = groupKeyOf(item)
+    if (key !== null && droppedCallIds.has(key)) continue
+    kept.push(item)
+  }
+  return kept
 }
 
 /** Build a defensive deep-ish copy of every item so callers' arrays are
@@ -296,30 +361,30 @@ function compactHistoryInternal(
     return { newHistory, truncatedOutputBytes, truncatedOutputCount, droppedPairCount: 0, droppedItemBytes: 0, usedLlmSummary: false }
   }
 
-  const { leadingNonToolEnd, callIdsInOrder, pairItems, tailNonTool } = partitionHistory(newHistory)
+  const { leadingNonToolEnd, callIdsInOrder, pairItems } = partitionHistory(newHistory)
+  // Pin the stage-1 array: every iteration rebuilds from THIS one, so the
+  // surviving items are always read at their original indices (invariant 4).
+  // `newHistory` is reassigned below and must not become the rebuild source.
+  const stage1History = newHistory
   const dropEligible = callIdsInOrder.slice(0, Math.max(0, callIdsInOrder.length - KEEP_RECENT_PAIRS))
+  const droppedCallIds = new Set<string>()
   let droppedPairCount = 0
   let droppedItemBytes = 0
   for (let idx = 0; idx < dropEligible.length; idx++) {
     const cid = dropEligible[idx]
     const items = pairItems.get(cid) ?? []
     for (const it of items) droppedItemBytes += JSON.stringify(it).length
-    pairItems.delete(cid)
+    droppedCallIds.add(cid)
     droppedPairCount += 1
-    const surviving: ResponseInputItem[] = []
-    for (let j = idx + 1; j < callIdsInOrder.length; j++) {
-      surviving.push(...(pairItems.get(callIdsInOrder[j]) ?? []))
-    }
     const marker: ResponseInputItem = {
       type: 'message',
       role: 'user',
       content: `[auto-compaction] ${droppedPairCount} earlier tool ${droppedPairCount === 1 ? 'call/output pair was' : 'call/output pairs were'} dropped from history to fit the context budget (~${droppedItemBytes} bytes). Continue from where you left off.`,
     } as unknown as ResponseInputItem
     newHistory = [
-      ...newHistory.slice(0, leadingNonToolEnd),
+      ...stage1History.slice(0, leadingNonToolEnd),
       marker,
-      ...surviving,
-      ...tailNonTool,
+      ...tailWithoutDroppedGroups(stage1History, leadingNonToolEnd, droppedCallIds),
     ]
     estimateTokensCount = estimateHistoryTokens(newHistory)
     if (!stillOverThreshold(estimateTokensCount)) break
@@ -335,7 +400,7 @@ async function summarizeAndSplice(
   stage1Counters: { truncatedOutputBytes: number; truncatedOutputCount: number },
   summarize: (itemsToDrop: ResponseInputItem[]) => Promise<string>,
 ): Promise<CompactionResult | null> {
-  const { leadingNonToolEnd, callIdsInOrder, pairItems, tailNonTool } = partitionHistory(stage1History)
+  const { leadingNonToolEnd, callIdsInOrder, pairItems } = partitionHistory(stage1History)
   const dropEligible = callIdsInOrder.slice(0, Math.max(0, callIdsInOrder.length - KEEP_RECENT_PAIRS))
   if (dropEligible.length === 0) return null
 
@@ -354,16 +419,10 @@ async function summarizeAndSplice(
     content: `[auto-compaction · ${dropEligible.length} earlier tool call/output ${dropEligible.length === 1 ? 'pair' : 'pairs'} summarized below — continue from where you left off]\n\n${cleaned}`,
   } as unknown as ResponseInputItem
 
-  const survivingTailPairs: ResponseInputItem[] = []
-  for (const cid of callIdsInOrder) {
-    if (dropEligible.includes(cid)) continue
-    survivingTailPairs.push(...(pairItems.get(cid) ?? []))
-  }
   const newHistory = [
     ...stage1History.slice(0, leadingNonToolEnd),
     summaryMarker,
-    ...survivingTailPairs,
-    ...tailNonTool,
+    ...tailWithoutDroppedGroups(stage1History, leadingNonToolEnd, new Set(dropEligible)),
   ]
   return {
     newHistory,


### PR DESCRIPTION
## The bug

Stage-2 compaction partitioned history by item **type**: every non-tool item sitting after the first tool item went into a `tailNonTool` bucket that both rebuild paths re-appended *after* all surviving pairs.

```js
const newHistory = [
  ...stage1History.slice(0, leadingNonToolEnd),
  summaryMarker,
  ...survivingTailPairs,
  ...tailNonTool,        // <- everything non-tool, moved to the end
]
```

So compaction reordered, not just deleted. That matters more than it looks, because of two things that are true together:

- The only non-tool items that ever appear mid-history are `role:'user'` items the runtime injects itself — the mid-turn steer render, the status-required nudge, and the completion-rejection nudge.
- There is **no assistant message in `history`** for the model to see its own reply in. Assistant text is deliberately never added as a history item (synthesizing one with no `item_id` / `part_id` / `responseId` corrupts history shape — the comment in `turn.ts` says so and names the earlier bug).

Put together: the *only* in-context evidence that a steer was already handled is that the `function_call` / `function_call_output` pairs answering it sit **after** it. The tail-move inverted exactly that.

## Reproduced

Against the real module, on the history shape `turn.ts` builds:

```
before: [0] user  book the team sync for 4pm and send the agenda
        c1 c2 c3 pairs  (create 4pm, draft agenda, reply "booked 4pm")
        [7] user  [Mid-turn update — new message from Alice] actually make it 5pm
        c4 c5 pairs     (move to 5pm, reply "moved to 5pm")

after:  [0] user  book the team sync for 4pm …
        [1] user  [auto-compaction · 3 earlier pairs summarized]
        [2..5]    c4 c5          ← the answer, now BEFORE the question
        [6] user  [Mid-turn update] actually make it 5pm     ← LAST ITEM
```

The steer's own text is written as an imperative fresh arrival — *"Re-assess your current plan in light of these and continue"* — so sitting in the newest-input slot it reads as a live instruction. The agent moves the event a second time and posts a second reply. `turn.ts` assigns the compacted array back to `history`, so it re-asks on **every remaining hop**, not once.

Anything side-effecting the steer asked for — send an email, post to a channel, move a calendar event — gets done twice. The same shape applies to the status-required and completion-rejection nudges: a satisfied nudge re-presented last is a live instruction again.

**How often:** it needs a mid-turn steer, at least one more hop of work after it, and stage-2 compaction firing (past 75% of the context window, with stage-1 truncation not enough on its own). Steering is a headline feature and long tool-heavy turns are exactly the ones that cross 75%, so this is a recurring bug on busy agents rather than a corner case. It cannot happen when compaction stops at stage 1.

## The fix

Rebuild in original order. `partitionHistory` no longer collects a tail bucket — it exists only to decide *which* `call_id` groups get dropped. Both rebuild sites now walk the original array and skip the dropped groups:

```ts
function tailWithoutDroppedGroups(history, leadingNonToolEnd, droppedCallIds) {
  const kept = []
  for (let i = leadingNonToolEnd; i < history.length; i++) {
    const item = history[i]
    const key = groupKeyOf(item)
    if (key !== null && droppedCallIds.has(key)) continue
    kept.push(item)
  }
  return kept
}
```

Surviving items keep their positions and their relative order. Documented as **invariant 4** in the module header: compaction only deletes, never reorders.

This also stops compaction re-grouping interleaved items. One hop pushes `fc1, fc2, out1, out2`; that is the shape every *uncompacted* hop already puts on the wire, so handing it back unchanged is strictly closer to known-good than the `fc1,out1,fc2,out2` the bucket rebuild produced. The existing invariants still hold — a `function_call` still immediately precedes its own `function_call_output`, and the leading seed messages are untouched.

## Tests

Three added, **no existing test changed** — 100 lines added, 0 removed:

- `stage 2 (drop path): an ANSWERED mid-turn steer keeps its position — never hoisted to the newest-input slot`
- `stage 2 (summary path): an ANSWERED mid-turn steer keeps its position`
- `stage 2: surviving tool items keep their original relative order (no regrouping by call_id)`

```
against main:   not ok 41, not ok 42, not ok 43        # pass 40  # fail 3
with the fix:                                          # pass 43  # fail 0
```

The 40 that were already there stay green, including the one that pins how a malformed no-`call_id` item is handled — that item's original position happens to be after the surviving pairs, so order-preserving and tail-moving agree there.

Also green: `tsc --noEmit`, `biome lint .`, all three `scripts/guard-*.mjs`, and the unit suite (1399 tests, 0 failures).
